### PR TITLE
fix: avoid governance guard false positives

### DIFF
--- a/scripts/architecture_guard.py
+++ b/scripts/architecture_guard.py
@@ -13,6 +13,22 @@ import sys
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 ARCH_DOC = ROOT / "docs/DYSONX_SYSTEM_ARCHITECTURE.md"
 
+GOVERNANCE_FILES = {
+    "AGENTS.md",
+    "docs/DYSONX_PRODUCT_CONSTITUTION.md",
+    "docs/DYSONX_SYSTEM_ARCHITECTURE.md",
+    "docs/DYSONX_ENGINEERING_GOVERNANCE.md",
+    "docs/DYSONX_PROJECT_CONTEXT.md",
+    "docs/DYSONX_OWNER_INTENT.md",
+    ".github/pull_request_template.md",
+}
+
+GUARD_FILES = {
+    "scripts/architecture_guard.py",
+}
+
+SCAN_SUFFIXES = {".md", ".py", ".js", ".ts", ".tsx", ".jsx", ".html", ".json", ".yml", ".yaml"}
+
 REQUIRED_LAYERS = [
     "Source Configuration Layer",
     "Collection Layer",
@@ -54,6 +70,17 @@ def read(path: pathlib.Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
+def drift_scan_files() -> list[pathlib.Path]:
+    return [
+        path for path in ROOT.rglob("*")
+        if path.is_file()
+        and ".git" not in path.parts
+        and path.relative_to(ROOT).as_posix() not in GOVERNANCE_FILES
+        and path.relative_to(ROOT).as_posix() not in GUARD_FILES
+        and path.suffix.lower() in SCAN_SUFFIXES
+    ]
+
+
 def main() -> None:
     if not ARCH_DOC.exists():
         fail("missing docs/DYSONX_SYSTEM_ARCHITECTURE.md")
@@ -69,9 +96,11 @@ def main() -> None:
         if term.lower() not in lower:
             fail(f"missing canonical flow term: {term}")
 
-    for phrase in FORBIDDEN_ARCHITECTURE_HINTS:
-        if phrase in lower and "forbidden" not in lower[max(0, lower.find(phrase)-120):lower.find(phrase)+120]:
-            fail(f"forbidden architecture hint appears without prohibition: {phrase}")
+    for path in drift_scan_files():
+        text = read(path).lower()
+        for phrase in FORBIDDEN_ARCHITECTURE_HINTS:
+            if phrase in text:
+                fail(f"forbidden architecture hint found in {path.relative_to(ROOT)}: {phrase}")
 
     print("[architecture-guard] PASS")
 

--- a/scripts/constitution_guard.py
+++ b/scripts/constitution_guard.py
@@ -21,6 +21,20 @@ REQUIRED_FILES = [
     ".github/pull_request_template.md",
 ]
 
+GOVERNANCE_FILES = {
+    "AGENTS.md",
+    "docs/DYSONX_PRODUCT_CONSTITUTION.md",
+    "docs/DYSONX_SYSTEM_ARCHITECTURE.md",
+    "docs/DYSONX_ENGINEERING_GOVERNANCE.md",
+    "docs/DYSONX_PROJECT_CONTEXT.md",
+    "docs/DYSONX_OWNER_INTENT.md",
+    ".github/pull_request_template.md",
+}
+
+GUARD_FILES = {
+    "scripts/constitution_guard.py",
+}
+
 FORBIDDEN_PRIMARY_FRAMING = [
     "dysonx is an ai news aggregator",
     "dysonx is a news aggregator",
@@ -71,6 +85,8 @@ def check_forbidden_framing() -> None:
         p for p in ROOT.rglob("*")
         if p.is_file()
         and ".git" not in p.parts
+        and p.relative_to(ROOT).as_posix() not in GOVERNANCE_FILES
+        and p.relative_to(ROOT).as_posix() not in GUARD_FILES
         and p.suffix.lower() in {".md", ".py", ".js", ".ts", ".tsx", ".jsx", ".html", ".json", ".yml", ".yaml"}
     ]
     for path in text_files:
@@ -87,6 +103,10 @@ def check_signal_not_article_primary() -> None:
     ]
     for path in ROOT.rglob("*"):
         if not path.is_file() or ".git" in path.parts:
+            continue
+        if path.relative_to(ROOT).as_posix() in GOVERNANCE_FILES:
+            continue
+        if path.relative_to(ROOT).as_posix() in GUARD_FILES:
             continue
         if path.suffix.lower() not in {".md", ".py", ".js", ".ts", ".tsx", ".jsx"}:
             continue


### PR DESCRIPTION
## Purpose

Fix false positives in PR #15 guard scripts where forbidden wording inside governance documents was treated as product/runtime drift.

## Scope

Included:

- Update `scripts/constitution_guard.py` to keep required governance checks but exclude governance docs and the guard script phrase list from forbidden-framing drift scans.
- Update `scripts/architecture_guard.py` to keep required architecture document checks but scan non-governance product/runtime files for forbidden architecture hints.

Not included:

- Signal Engine implementation
- Product/runtime behavior changes
- Deployment changes
- Secret changes

## Required Reading Confirmation

- [x] I read `/docs/DYSONX_PRODUCT_CONSTITUTION.md`
- [x] I read `/docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- [x] I read `/docs/DYSONX_ENGINEERING_GOVERNANCE.md`
- [x] I read `/docs/DYSONX_PROJECT_CONTEXT.md`
- [x] I read `/docs/DYSONX_OWNER_INTENT.md`
- [x] I read `AGENTS.md`

## Constitution Compliance

- [x] This PR does not turn DysonX into a generic news site
- [x] This PR preserves English-default / Chinese-switchable architecture
- [x] This PR preserves Signal-first design
- [x] This PR does not hardcode monitored sources
- [x] This PR keeps LLM analysis as the first major interpretation step after collection
- [x] This PR strengthens governance value
- [x] This PR does not bypass the publishing quality gate
- [x] This PR does not create thin SEO content or content-farm behavior
- [x] This PR preserves source attribution requirements
- [x] This PR preserves long-term intelligence value

## Architecture Impact

Affected layers:

- Governance

The guards now distinguish governance documents that describe forbidden behavior from product/runtime files that implement forbidden behavior. The checks are not disabled: required file/concept/layer checks remain, and drift scans still inspect non-governance source/product files.

## Data and Migration Impact

- [x] No database schema change
- [x] No migration included

## Tests Run

```bash
python3 scripts/constitution_guard.py
python3 scripts/architecture_guard.py
python3 scripts/release_guard.py
git diff --check
```

Results:

- `python3 scripts/constitution_guard.py`: PASS
- `python3 scripts/architecture_guard.py`: PASS
- `python3 scripts/release_guard.py`: PASS
- `git diff --check`: PASS

## Deployment Impact

- [x] No deployment performed
- [x] No production code changed
- [x] No production secrets changed

## Rollback Plan

Close this draft PR or revert commit `2cfbd84`.

## Known Limitations

- The guards remain lightweight phrase-based checks and do not replace human review.

## Final Agent Statement

I confirm that this PR follows DysonX Product Constitution, System Architecture, and Engineering Governance.

I did not merge or deploy this change.
