### PR TITLE
feat: add DysonX V1 schema foundation

### DIFF
--- a/docs/DYSONX_SIGNAL_ENGINE_V1_SCHEMA.md
+++ b/docs/DYSONX_SIGNAL_ENGINE_V1_SCHEMA.md
@@ -1,0 +1,282 @@
+# DysonX Signal Engine V1 Schema
+
+Status: V1 schema foundation only
+
+This document defines the first implementation boundary for the DysonX Signal Engine V1. It is not a database migration, Notion integration, collector implementation, LLM integration, publishing system, or deployment change.
+
+## Scope
+
+V1 schema foundation includes only these entities:
+
+- Source
+- RawItem
+- LLMAnalysisJob
+- SignalCandidate
+- Signal
+- QualityReview
+- PublishJob
+- SocialDraft
+
+V1 schema foundation explicitly excludes:
+
+- Knowledge Graph tables
+- Entity relationship tables
+- Prediction Engine tables
+- Subscription, billing, dashboard, enterprise, API marketplace, and multi-tenant tables
+- Notion API connection
+- Collector execution
+- LLM API calls
+- Page publishing
+- Social platform posting
+
+## Layer Separation
+
+The schema keeps the first Signal Engine path explicit:
+
+`Source -> RawItem -> LLMAnalysisJob -> SignalCandidate -> QualityReview -> Signal -> PublishJob -> SocialDraft`
+
+The boundaries are intentional:
+
+- `RawItem` is collected evidence, not a published Signal.
+- `LLMAnalysisJob` records model interpretation output, not editorial approval.
+- `SignalCandidate` is a proposed Signal, not a published Signal.
+- `Signal` is the approved Signal object.
+- `SocialDraft` is review-only text and does not represent platform posting.
+
+## Entity Definitions
+
+### Source
+
+Represents a monitored source configured outside runtime code. In V1, this mirrors the minimum shape needed for a future Notion-managed source sync.
+
+Required fields:
+
+- `id`
+- `notion_page_id`
+- `name`
+- `source_type`
+- `url`
+- `authority_score`
+- `enabled`
+
+Optional fields:
+
+- `platform`
+- `feed_url`
+- `language`
+- `region`
+- `priority`
+- `notes`
+
+### RawItem
+
+Represents raw collected evidence from a Source.
+
+Required fields:
+
+- `id`
+- `source_id`
+- `original_url`
+- `raw_title`
+- `fetched_at`
+- `content_hash`
+- `fetch_status`
+
+Optional fields:
+
+- `canonical_url`
+- `raw_content`
+- `raw_excerpt`
+- `raw_author`
+- `raw_published_at`
+- `detected_language`
+- `error`
+
+### LLMAnalysisJob
+
+Represents a versioned LLM analysis attempt for a RawItem.
+
+Required fields:
+
+- `id`
+- `raw_item_id`
+- `provider`
+- `model_name`
+- `prompt_version`
+- `status`
+- `started_at`
+
+Optional fields:
+
+- `completed_at`
+- `output_json`
+- `validation_errors_json`
+- `confidence_score`
+- `error`
+
+### SignalCandidate
+
+Represents a structured Signal proposal created from an LLMAnalysisJob.
+
+Required fields:
+
+- `id`
+- `raw_item_id`
+- `llm_analysis_job_id`
+- `suggested_title_en`
+- `summary_en`
+- `source_authority_score`
+- `confidence_score`
+- `agi_impact_score`
+- `suggested_publish_status`
+- `review_status`
+
+Optional fields:
+
+- `suggested_title_zh`
+- `suggested_slug`
+- `summary_zh`
+- `market_impact_score`
+- `technical_impact_score`
+- `affected_capabilities`
+- `related_entities`
+- `dysonx_take_en`
+- `dysonx_take_zh`
+- `watch_next_en`
+- `watch_next_zh`
+- `duplicate_group_id`
+- `reviewer_notes`
+
+### Signal
+
+Represents an approved Signal. It is separate from both raw evidence and SignalCandidate review state.
+
+Required fields:
+
+- `id`
+- `signal_candidate_id`
+- `signal_id`
+- `title_en`
+- `slug`
+- `summary_en`
+- `original_source_url`
+- `source_id`
+- `source_type`
+- `source_authority_score`
+- `confidence_score`
+- `agi_impact_score`
+- `publish_status`
+
+Optional fields:
+
+- `title_zh`
+- `summary_zh`
+- `market_impact_score`
+- `technical_impact_score`
+- `affected_capabilities`
+- `related_entities`
+- `dysonx_take_en`
+- `dysonx_take_zh`
+- `watch_next_en`
+- `watch_next_zh`
+- `duplicate_group_id`
+- `published_at`
+
+### QualityReview
+
+Represents the quality gate result for a SignalCandidate or Signal.
+
+Required fields:
+
+- `id`
+- `signal_candidate_id`
+- `status`
+- `has_source_attribution`
+- `has_llm_summary`
+- `has_authority_score`
+- `has_confidence_score`
+- `has_agi_impact_score`
+- `duplicate_checked`
+- `has_english_version`
+- `has_social_draft`
+- `unsupported_claims_flag`
+- `copied_text_flag`
+
+Optional fields:
+
+- `signal_id`
+- `has_entity_candidates`
+- `has_seo_metadata`
+- `decision_value_score`
+- `reviewer_notes`
+- `reviewed_at`
+
+### PublishJob
+
+Represents a publish workflow attempt for an approved Signal.
+
+Required fields:
+
+- `id`
+- `signal_id`
+- `target`
+- `status`
+- `started_at`
+
+Optional fields:
+
+- `completed_at`
+- `output_path`
+- `error`
+
+### SocialDraft
+
+Represents a generated draft for later human review. It is not a posted social update.
+
+Required fields:
+
+- `id`
+- `signal_id`
+- `platform`
+- `language`
+- `draft_text`
+- `status`
+
+Optional fields:
+
+- `generated_by_llm_job_id`
+- `reviewer_notes`
+- `created_at`
+- `updated_at`
+
+V1 status values should include `draft`, `approved`, and `rejected`. V1 must not include `posted` because platform posting is out of scope.
+
+## V1 Non-Goals
+
+The following tables or models must not be introduced in this V1 schema foundation:
+
+- Entity
+- EntityRelationship
+- Topic
+- Tracker
+- Prediction
+- Report
+- Account
+- Organization
+- Tenant
+- Subscription
+- Invoice
+- ApiKey
+- Dashboard
+
+Entity names may appear only as candidate strings inside `SignalCandidate.related_entities` or `Signal.related_entities`. That is not a Knowledge Graph implementation.
+
+## Validation Expectations
+
+Tests should verify:
+
+- RawItem is separate from Signal.
+- LLMAnalysisJob is separate from SignalCandidate.
+- SignalCandidate is separate from Signal.
+- SocialDraft remains draft-only.
+- No Knowledge Graph, prediction, billing, subscription, API platform, dashboard, enterprise, or multi-tenant schema classes are implemented in V1.

--- a/scripts/dysonx_schema.py
+++ b/scripts/dysonx_schema.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Lightweight DysonX Signal Engine V1 schema definitions.
+
+This module defines schema-level data objects only. It does not connect to
+Notion, collect sources, call LLM APIs, publish pages, or post to social media.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, ClassVar, Literal
+
+
+SchemaEntity = Literal[
+    "Source",
+    "RawItem",
+    "LLMAnalysisJob",
+    "SignalCandidate",
+    "Signal",
+    "QualityReview",
+    "PublishJob",
+    "SocialDraft",
+]
+
+
+V1_SCHEMA_ENTITIES: tuple[SchemaEntity, ...] = (
+    "Source",
+    "RawItem",
+    "LLMAnalysisJob",
+    "SignalCandidate",
+    "Signal",
+    "QualityReview",
+    "PublishJob",
+    "SocialDraft",
+)
+
+
+OUT_OF_SCOPE_SCHEMA_ENTITIES: frozenset[str] = frozenset(
+    {
+        "Entity",
+        "EntityRelationship",
+        "Topic",
+        "Tracker",
+        "Prediction",
+        "Report",
+        "Account",
+        "Organization",
+        "Tenant",
+        "Subscription",
+        "Invoice",
+        "ApiKey",
+        "Dashboard",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Source:
+    id: str
+    notion_page_id: str
+    name: str
+    source_type: str
+    url: str
+    authority_score: float
+    enabled: bool
+    platform: str | None = None
+    feed_url: str | None = None
+    language: str = "English"
+    region: str | None = None
+    priority: str = "Medium"
+    notes: str | None = None
+
+
+@dataclass(frozen=True)
+class RawItem:
+    id: str
+    source_id: str
+    original_url: str
+    raw_title: str
+    fetched_at: datetime
+    content_hash: str
+    fetch_status: str
+    canonical_url: str | None = None
+    raw_content: str | None = None
+    raw_excerpt: str | None = None
+    raw_author: str | None = None
+    raw_published_at: datetime | None = None
+    detected_language: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class LLMAnalysisJob:
+    id: str
+    raw_item_id: str
+    provider: str
+    model_name: str
+    prompt_version: str
+    status: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    output_json: dict[str, Any] = field(default_factory=dict)
+    validation_errors_json: list[str] = field(default_factory=list)
+    confidence_score: float | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SignalCandidate:
+    id: str
+    raw_item_id: str
+    llm_analysis_job_id: str
+    suggested_title_en: str
+    summary_en: str
+    source_authority_score: float
+    confidence_score: float
+    agi_impact_score: float
+    suggested_publish_status: str
+    review_status: str
+    suggested_title_zh: str | None = None
+    suggested_slug: str | None = None
+    summary_zh: str | None = None
+    market_impact_score: float | None = None
+    technical_impact_score: float | None = None
+    affected_capabilities: tuple[str, ...] = ()
+    related_entities: tuple[str, ...] = ()
+    dysonx_take_en: str | None = None
+    dysonx_take_zh: str | None = None
+    watch_next_en: str | None = None
+    watch_next_zh: str | None = None
+    duplicate_group_id: str | None = None
+    reviewer_notes: str | None = None
+
+
+@dataclass(frozen=True)
+class Signal:
+    id: str
+    signal_candidate_id: str
+    signal_id: str
+    title_en: str
+    slug: str
+    summary_en: str
+    original_source_url: str
+    source_id: str
+    source_type: str
+    source_authority_score: float
+    confidence_score: float
+    agi_impact_score: float
+    publish_status: str
+    title_zh: str | None = None
+    summary_zh: str | None = None
+    market_impact_score: float | None = None
+    technical_impact_score: float | None = None
+    affected_capabilities: tuple[str, ...] = ()
+    related_entities: tuple[str, ...] = ()
+    dysonx_take_en: str | None = None
+    dysonx_take_zh: str | None = None
+    watch_next_en: str | None = None
+    watch_next_zh: str | None = None
+    duplicate_group_id: str | None = None
+    published_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class QualityReview:
+    id: str
+    signal_candidate_id: str
+    status: str
+    has_source_attribution: bool
+    has_llm_summary: bool
+    has_authority_score: bool
+    has_confidence_score: bool
+    has_agi_impact_score: bool
+    duplicate_checked: bool
+    has_english_version: bool
+    has_social_draft: bool
+    unsupported_claims_flag: bool
+    copied_text_flag: bool
+    signal_id: str | None = None
+    has_entity_candidates: bool = False
+    has_seo_metadata: bool = False
+    decision_value_score: float | None = None
+    reviewer_notes: str | None = None
+    reviewed_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PublishJob:
+    id: str
+    signal_id: str
+    target: str
+    status: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    output_path: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SocialDraft:
+    DRAFT_ONLY_STATUSES: ClassVar[frozenset[str]] = frozenset({"draft", "approved", "rejected"})
+
+    id: str
+    signal_id: str
+    platform: str
+    language: str
+    draft_text: str
+    status: str
+    generated_by_llm_job_id: str | None = None
+    reviewer_notes: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in self.DRAFT_ONLY_STATUSES:
+            allowed = ", ".join(sorted(self.DRAFT_ONLY_STATUSES))
+            raise ValueError(f"SocialDraft status must be draft-only: {allowed}")
+
+
+def v1_schema_entity_names() -> tuple[str, ...]:
+    return tuple(V1_SCHEMA_ENTITIES)
+
+
+def out_of_scope_schema_entity_names() -> frozenset[str]:
+    return OUT_OF_SCOPE_SCHEMA_ENTITIES

--- a/tests/test_dysonx_schema.py
+++ b/tests/test_dysonx_schema.py
@@ -1,0 +1,99 @@
+import pathlib
+import sys
+import unittest
+from dataclasses import fields
+from datetime import datetime, timezone
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_schema
+
+
+class DysonXSchemaTests(unittest.TestCase):
+    def test_raw_item_is_separate_from_signal(self):
+        raw_item_fields = {field.name for field in fields(dysonx_schema.RawItem)}
+        signal_fields = {field.name for field in fields(dysonx_schema.Signal)}
+
+        self.assertIn("raw_title", raw_item_fields)
+        self.assertIn("content_hash", raw_item_fields)
+        self.assertNotIn("publish_status", raw_item_fields)
+        self.assertNotIn("signal_id", raw_item_fields)
+
+        self.assertIn("signal_candidate_id", signal_fields)
+        self.assertIn("publish_status", signal_fields)
+        self.assertNotIn("raw_content", signal_fields)
+
+    def test_llm_analysis_job_is_separate_from_signal_candidate(self):
+        llm_fields = {field.name for field in fields(dysonx_schema.LLMAnalysisJob)}
+        candidate_fields = {field.name for field in fields(dysonx_schema.SignalCandidate)}
+
+        self.assertIn("provider", llm_fields)
+        self.assertIn("model_name", llm_fields)
+        self.assertIn("prompt_version", llm_fields)
+        self.assertIn("output_json", llm_fields)
+        self.assertNotIn("suggested_title_en", llm_fields)
+
+        self.assertIn("llm_analysis_job_id", candidate_fields)
+        self.assertIn("suggested_title_en", candidate_fields)
+        self.assertNotIn("model_name", candidate_fields)
+
+    def test_signal_candidate_is_separate_from_published_signal(self):
+        candidate_fields = {field.name for field in fields(dysonx_schema.SignalCandidate)}
+        signal_fields = {field.name for field in fields(dysonx_schema.Signal)}
+
+        self.assertIn("suggested_publish_status", candidate_fields)
+        self.assertIn("review_status", candidate_fields)
+        self.assertNotIn("published_at", candidate_fields)
+
+        self.assertIn("signal_candidate_id", signal_fields)
+        self.assertIn("publish_status", signal_fields)
+        self.assertIn("published_at", signal_fields)
+        self.assertNotIn("review_status", signal_fields)
+
+    def test_social_draft_is_draft_only(self):
+        draft = dysonx_schema.SocialDraft(
+            id="social_draft_1",
+            signal_id="signal_1",
+            platform="x",
+            language="English",
+            draft_text="Draft text",
+            status="draft",
+            created_at=datetime.now(timezone.utc),
+        )
+
+        self.assertEqual(draft.status, "draft")
+        self.assertNotIn("posted", dysonx_schema.SocialDraft.DRAFT_ONLY_STATUSES)
+
+        with self.assertRaises(ValueError):
+            dysonx_schema.SocialDraft(
+                id="social_draft_2",
+                signal_id="signal_1",
+                platform="x",
+                language="English",
+                draft_text="Posted text",
+                status="posted",
+            )
+
+    def test_no_knowledge_graph_tables_are_implemented_in_v1(self):
+        implemented = set(dysonx_schema.v1_schema_entity_names())
+        out_of_scope = dysonx_schema.out_of_scope_schema_entity_names()
+
+        self.assertEqual(
+            implemented,
+            {
+                "Source",
+                "RawItem",
+                "LLMAnalysisJob",
+                "SignalCandidate",
+                "Signal",
+                "QualityReview",
+                "PublishJob",
+                "SocialDraft",
+            },
+        )
+        self.assertTrue(implemented.isdisjoint(out_of_scope))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Create the first implementation PR for DysonX Signal Engine V1 schema foundation.

## Scope

Included:

- Add `docs/DYSONX_SIGNAL_ENGINE_V1_SCHEMA.md`
- Add lightweight code-level schema definitions in `scripts/dysonx_schema.py`
- Add unit tests for V1 schema separation and scope boundaries

V1 entities defined only:

- Source
- RawItem
- LLMAnalysisJob
- SignalCandidate
- Signal
- QualityReview
- PublishJob
- SocialDraft

Not included:

- Notion connection
- Collectors
- LLM API calls
- Page publishing
- Knowledge Graph implementation
- Prediction Engine
- Billing, subscriptions, dashboards, API platform, enterprise, or multi-tenant features

## Required Reading Confirmation

- [x] I read `/docs/DYSONX_PRODUCT_CONSTITUTION.md`
- [x] I read `/docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- [x] I read `/docs/DYSONX_ENGINEERING_GOVERNANCE.md`
- [x] I read `/docs/DYSONX_PROJECT_CONTEXT.md`
- [x] I read `/docs/DYSONX_OWNER_INTENT.md`
- [x] I read `AGENTS.md`

## Constitution Compliance

- [x] This PR does not turn DysonX into a generic news site
- [x] This PR preserves English-default / Chinese-switchable architecture
- [x] This PR preserves Signal-first design
- [x] This PR does not hardcode monitored sources
- [x] This PR keeps LLM analysis as the first major interpretation step after collection
- [x] This PR strengthens schema and governance value
- [x] This PR does not bypass the publishing quality gate
- [x] This PR does not create thin SEO content or content-farm behavior
- [x] This PR preserves source attribution requirements
- [x] This PR preserves long-term intelligence value

## Architecture Impact

Affected layers:

- Source Configuration
- Raw Data
- LLM Intelligence
- Publishing
- Social Distribution
- Observability / Audit
- Governance

This is schema foundation only. It intentionally does not implement Knowledge Graph tables, collectors, Notion sync, LLM calls, publishing, or social posting.

## Data and Migration Impact

- [x] No live database schema change
- [x] No migration included
- [x] Documentation and lightweight Python schema definitions only

## Tests Run

```bash
python3 scripts/constitution_guard.py
python3 scripts/architecture_guard.py
python3 scripts/release_guard.py
python3 -m py_compile scripts/*.py
python3 -m unittest discover -s tests
git diff --check HEAD~1 HEAD
```

Results:

- `python3 scripts/constitution_guard.py`: PASS
- `python3 scripts/architecture_guard.py`: PASS
- `python3 scripts/release_guard.py`: PASS
- `python3 -m py_compile scripts/*.py`: PASS
- `python3 -m unittest discover -s tests`: PASS, 5 tests
- `git diff --check HEAD~1 HEAD`: PASS

## Deployment Impact

- [x] No deployment performed
- [x] No production code changed
- [x] No production secrets changed

## Rollback Plan

Revert commit `8057c98` or close this draft PR.

## Known Limitations

- No persistence layer or migration is implemented yet.
- No Notion sync, collector, LLM call, publishing, or social posting exists in this PR.
- Schema definitions are lightweight dataclasses intended to anchor V1 boundaries before implementation.

## Reviewer Notes

Please verify that V1 remains limited to schema foundation and that no Knowledge Graph, Prediction Engine, billing, subscription, dashboard, API platform, enterprise, or multi-tenant scope has entered this PR.

## Final Agent Statement

I confirm that this PR follows DysonX Product Constitution, System Architecture, and Engineering Governance.

I did not merge or deploy this change.
