### PR TITLE
feat: add DysonX Notion source schema foundation

### DIFF
--- a/docs/DYSONX_NOTION_SOURCE_SCHEMA.md
+++ b/docs/DYSONX_NOTION_SOURCE_SCHEMA.md
@@ -1,0 +1,206 @@
+# DysonX Notion Source Schema
+
+Status: V1 source schema foundation only
+
+This document defines the Notion source database fields required for DysonX Signal Engine V1. It does not connect to the Notion API, fetch live Notion data, add collectors, call LLM APIs, publish pages, or implement Knowledge Graph features.
+
+## Purpose
+
+Notion is the source of truth for monitored source configuration. V1 code may later sync these records into local schema objects, but the API connection and sync workflow are out of scope for this schema foundation.
+
+## Database
+
+Recommended Notion database name:
+
+`DysonX Sources`
+
+## Required Fields
+
+The V1 Notion source database must define these properties:
+
+- `Name`
+- `Source Type`
+- `URL`
+- `Platform`
+- `Priority`
+- `Authority Score`
+- `Language`
+- `Region`
+- `Topic Tags`
+- `Related Entities`
+- `Enabled`
+- `Fetch Frequency`
+- `Last Fetched At`
+- `Last Success At`
+- `Last Error`
+- `Notes`
+
+## Field Definitions
+
+### Name
+
+- Notion type: `title`
+- Required: yes
+- Purpose: Human-readable source name.
+
+### Source Type
+
+- Notion type: `select`
+- Required: yes
+- Purpose: Identifies the kind of source so future collection logic can choose the correct collector.
+- V1 allowed values:
+  - `Official Company Blog`
+  - `Research Lab`
+  - `Paper`
+  - `GitHub Repository`
+  - `Government`
+  - `Regulatory`
+  - `Product Changelog`
+  - `Key Person`
+  - `Conference`
+  - `High Authority Media`
+  - `Manual`
+
+### URL
+
+- Notion type: `url`
+- Required: yes
+- Purpose: Canonical source URL or entry point.
+
+### Platform
+
+- Notion type: `select`
+- Required: yes
+- Purpose: Identifies where the source lives.
+- V1 allowed values:
+  - `Website`
+  - `RSS`
+  - `GitHub`
+  - `Paper Repository`
+  - `Government Site`
+  - `Social`
+  - `Manual`
+
+### Priority
+
+- Notion type: `select`
+- Required: yes
+- Purpose: Collection priority for future sync and collection scheduling.
+- V1 allowed values:
+  - `Critical`
+  - `High`
+  - `Medium`
+  - `Low`
+
+### Authority Score
+
+- Notion type: `number`
+- Required: yes
+- Purpose: Source authority score used by later Signal analysis and quality gates.
+- Valid range: `0` to `100`, inclusive.
+
+### Language
+
+- Notion type: `select`
+- Required: yes
+- Purpose: Default language for source material.
+- V1 allowed values:
+  - `English`
+  - `Chinese`
+  - `Multilingual`
+  - `Other`
+
+### Region
+
+- Notion type: `select`
+- Required: yes
+- Purpose: Geographic or policy region for the source.
+- V1 allowed values:
+  - `Global`
+  - `US`
+  - `China`
+  - `EU`
+  - `UK`
+  - `Japan`
+  - `Other`
+
+### Topic Tags
+
+- Notion type: `multi_select`
+- Required: no
+- Purpose: Lightweight source categorization before LLM interpretation.
+- These tags do not replace LLM analysis.
+
+### Related Entities
+
+- Notion type: `multi_select`
+- Required: no
+- Purpose: Optional source-level entity hints.
+- Entity hints are not a Knowledge Graph implementation.
+
+### Enabled
+
+- Notion type: `checkbox`
+- Required: yes
+- Purpose: Determines whether the source is eligible for future collection.
+- A source must not be considered collection-eligible unless `Enabled` is true.
+
+### Fetch Frequency
+
+- Notion type: `number`
+- Required: yes
+- Purpose: Future collection cadence in minutes.
+- Valid range: `15` to `10080`, inclusive.
+
+### Last Fetched At
+
+- Notion type: `date`
+- Required: no
+- Purpose: Future sync state written after collection attempts.
+
+### Last Success At
+
+- Notion type: `date`
+- Required: no
+- Purpose: Future sync state written after successful collection.
+
+### Last Error
+
+- Notion type: `rich_text`
+- Required: no
+- Purpose: Future sync state for the latest collection or validation error.
+
+### Notes
+
+- Notion type: `rich_text`
+- Required: no
+- Purpose: Human review notes for source management.
+
+## Collection Eligibility
+
+A source is eligible for future collection only when:
+
+- `Enabled` is true.
+- `Name` is present.
+- `Source Type` is present and valid.
+- `URL` is present.
+- `Platform` is present and valid.
+- `Priority` is present and valid.
+- `Authority Score` is present and within range.
+- `Language` is present and valid.
+- `Region` is present and valid.
+- `Fetch Frequency` is present and within range.
+
+Eligibility does not fetch anything. It only validates that the source record is ready for future collector work.
+
+## V1 Non-Goals
+
+This schema foundation must not:
+
+- Connect to Notion API.
+- Fetch real Notion data.
+- Add collectors.
+- Call LLM APIs.
+- Publish pages.
+- Implement Knowledge Graph tables or relationships.
+- Implement Prediction Engine, billing, subscriptions, dashboards, API platform, enterprise, or multi-tenant features.

--- a/scripts/dysonx_notion_source_schema.py
+++ b/scripts/dysonx_notion_source_schema.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""DysonX V1 Notion source schema mapping and validation.
+
+This module is schema-only. It does not import Notion clients, call network
+APIs, fetch source records, collect content, call LLM APIs, or publish pages.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+NotionPropertyType = Literal["title", "select", "url", "number", "multi_select", "checkbox", "date", "rich_text"]
+
+
+ALLOWED_SOURCE_TYPES: frozenset[str] = frozenset(
+    {
+        "Official Company Blog",
+        "Research Lab",
+        "Paper",
+        "GitHub Repository",
+        "Government",
+        "Regulatory",
+        "Product Changelog",
+        "Key Person",
+        "Conference",
+        "High Authority Media",
+        "Manual",
+    }
+)
+
+ALLOWED_PLATFORMS: frozenset[str] = frozenset(
+    {
+        "Website",
+        "RSS",
+        "GitHub",
+        "Paper Repository",
+        "Government Site",
+        "Social",
+        "Manual",
+    }
+)
+
+ALLOWED_PRIORITIES: frozenset[str] = frozenset({"Critical", "High", "Medium", "Low"})
+ALLOWED_LANGUAGES: frozenset[str] = frozenset({"English", "Chinese", "Multilingual", "Other"})
+ALLOWED_REGIONS: frozenset[str] = frozenset({"Global", "US", "China", "EU", "UK", "Japan", "Other"})
+
+AUTHORITY_SCORE_MIN = 0
+AUTHORITY_SCORE_MAX = 100
+FETCH_FREQUENCY_MIN_MINUTES = 15
+FETCH_FREQUENCY_MAX_MINUTES = 10080
+
+
+@dataclass(frozen=True)
+class NotionSourceField:
+    name: str
+    property_type: NotionPropertyType
+    required: bool
+    description: str
+
+
+NOTION_SOURCE_FIELDS: tuple[NotionSourceField, ...] = (
+    NotionSourceField("Name", "title", True, "Human-readable source name."),
+    NotionSourceField("Source Type", "select", True, "Kind of source for future collector selection."),
+    NotionSourceField("URL", "url", True, "Canonical source URL or entry point."),
+    NotionSourceField("Platform", "select", True, "Platform where the source lives."),
+    NotionSourceField("Priority", "select", True, "Future collection priority."),
+    NotionSourceField("Authority Score", "number", True, "Source authority score from 0 to 100."),
+    NotionSourceField("Language", "select", True, "Default language for source material."),
+    NotionSourceField("Region", "select", True, "Geographic or policy region."),
+    NotionSourceField("Topic Tags", "multi_select", False, "Lightweight categorization hints."),
+    NotionSourceField("Related Entities", "multi_select", False, "Optional entity hints, not Knowledge Graph records."),
+    NotionSourceField("Enabled", "checkbox", True, "Collection eligibility flag."),
+    NotionSourceField("Fetch Frequency", "number", True, "Future collection cadence in minutes."),
+    NotionSourceField("Last Fetched At", "date", False, "Future collection attempt timestamp."),
+    NotionSourceField("Last Success At", "date", False, "Future successful collection timestamp."),
+    NotionSourceField("Last Error", "rich_text", False, "Future validation or collection error details."),
+    NotionSourceField("Notes", "rich_text", False, "Human review notes."),
+)
+
+
+def notion_source_field_names() -> tuple[str, ...]:
+    return tuple(field.name for field in NOTION_SOURCE_FIELDS)
+
+
+def required_notion_source_field_names() -> frozenset[str]:
+    return frozenset(field.name for field in NOTION_SOURCE_FIELDS if field.required)
+
+
+def notion_source_schema_by_name() -> dict[str, NotionSourceField]:
+    return {field.name: field for field in NOTION_SOURCE_FIELDS}
+
+
+def validate_notion_source_record(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    for field_name in required_notion_source_field_names():
+        value = record.get(field_name)
+        if value is None or value == "":
+            errors.append(f"{field_name} is required")
+
+    source_type = record.get("Source Type")
+    if source_type is not None and source_type != "" and source_type not in ALLOWED_SOURCE_TYPES:
+        errors.append("Source Type is invalid")
+
+    platform = record.get("Platform")
+    if platform is not None and platform != "" and platform not in ALLOWED_PLATFORMS:
+        errors.append("Platform is invalid")
+
+    priority = record.get("Priority")
+    if priority is not None and priority != "" and priority not in ALLOWED_PRIORITIES:
+        errors.append("Priority is invalid")
+
+    language = record.get("Language")
+    if language is not None and language != "" and language not in ALLOWED_LANGUAGES:
+        errors.append("Language is invalid")
+
+    region = record.get("Region")
+    if region is not None and region != "" and region not in ALLOWED_REGIONS:
+        errors.append("Region is invalid")
+
+    authority_score = record.get("Authority Score")
+    if authority_score is not None and authority_score != "":
+        if not isinstance(authority_score, (int, float)):
+            errors.append("Authority Score must be numeric")
+        elif not AUTHORITY_SCORE_MIN <= authority_score <= AUTHORITY_SCORE_MAX:
+            errors.append("Authority Score must be between 0 and 100")
+
+    fetch_frequency = record.get("Fetch Frequency")
+    if fetch_frequency is not None and fetch_frequency != "":
+        if not isinstance(fetch_frequency, (int, float)):
+            errors.append("Fetch Frequency must be numeric")
+        elif not FETCH_FREQUENCY_MIN_MINUTES <= fetch_frequency <= FETCH_FREQUENCY_MAX_MINUTES:
+            errors.append("Fetch Frequency must be between 15 and 10080 minutes")
+
+    enabled = record.get("Enabled")
+    if enabled is not None and not isinstance(enabled, bool):
+        errors.append("Enabled must be a boolean")
+
+    return errors
+
+
+def is_collection_eligible(record: dict[str, Any]) -> bool:
+    if record.get("Enabled") is not True:
+        return False
+    return not validate_notion_source_record(record)

--- a/tests/test_dysonx_notion_source_schema.py
+++ b/tests/test_dysonx_notion_source_schema.py
@@ -1,0 +1,99 @@
+import pathlib
+import sys
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_notion_source_schema as schema
+
+
+def valid_record(**overrides):
+    record = {
+        "Name": "OpenAI Blog",
+        "Source Type": "Official Company Blog",
+        "URL": "https://openai.com/blog",
+        "Platform": "Website",
+        "Priority": "Critical",
+        "Authority Score": 95,
+        "Language": "English",
+        "Region": "Global",
+        "Topic Tags": ["foundation models"],
+        "Related Entities": ["OpenAI"],
+        "Enabled": True,
+        "Fetch Frequency": 60,
+        "Last Fetched At": None,
+        "Last Success At": None,
+        "Last Error": "",
+        "Notes": "",
+    }
+    record.update(overrides)
+    return record
+
+
+class DysonXNotionSourceSchemaTests(unittest.TestCase):
+    def test_required_fields_are_defined(self):
+        expected_fields = {
+            "Name",
+            "Source Type",
+            "URL",
+            "Platform",
+            "Priority",
+            "Authority Score",
+            "Language",
+            "Region",
+            "Topic Tags",
+            "Related Entities",
+            "Enabled",
+            "Fetch Frequency",
+            "Last Fetched At",
+            "Last Success At",
+            "Last Error",
+            "Notes",
+        }
+
+        self.assertEqual(set(schema.notion_source_field_names()), expected_fields)
+        self.assertTrue({"Name", "Source Type", "URL", "Enabled"}.issubset(schema.required_notion_source_field_names()))
+
+    def test_enabled_is_required_before_collection_eligibility(self):
+        self.assertTrue(schema.is_collection_eligible(valid_record()))
+        self.assertFalse(schema.is_collection_eligible(valid_record(Enabled=False)))
+        self.assertFalse(schema.is_collection_eligible(valid_record(Enabled=None)))
+
+    def test_source_type_and_url_are_required(self):
+        source_type_errors = schema.validate_notion_source_record(valid_record(**{"Source Type": ""}))
+        url_errors = schema.validate_notion_source_record(valid_record(URL=""))
+
+        self.assertIn("Source Type is required", source_type_errors)
+        self.assertIn("URL is required", url_errors)
+        self.assertIn("Source Type is invalid", schema.validate_notion_source_record(valid_record(**{"Source Type": "Forum"})))
+
+    def test_authority_score_and_priority_have_valid_ranges(self):
+        self.assertEqual(schema.validate_notion_source_record(valid_record(**{"Authority Score": 0, "Priority": "Low"})), [])
+        self.assertEqual(schema.validate_notion_source_record(valid_record(**{"Authority Score": 100, "Priority": "Critical"})), [])
+        self.assertIn(
+            "Authority Score must be between 0 and 100",
+            schema.validate_notion_source_record(valid_record(**{"Authority Score": 101})),
+        )
+        self.assertIn("Priority is invalid", schema.validate_notion_source_record(valid_record(Priority="Urgent")))
+
+    def test_fetch_frequency_has_valid_range(self):
+        self.assertEqual(schema.validate_notion_source_record(valid_record(**{"Fetch Frequency": 15})), [])
+        self.assertEqual(schema.validate_notion_source_record(valid_record(**{"Fetch Frequency": 10080})), [])
+        self.assertIn(
+            "Fetch Frequency must be between 15 and 10080 minutes",
+            schema.validate_notion_source_record(valid_record(**{"Fetch Frequency": 5})),
+        )
+
+    def test_module_does_not_call_notion_api(self):
+        module_source = pathlib.Path(schema.__file__).read_text(encoding="utf-8")
+
+        self.assertNotIn("requests", module_source)
+        self.assertNotIn("urllib", module_source)
+        self.assertNotIn("notion_client", module_source)
+        self.assertNotIn("Client(", module_source)
+        self.assertNotIn("api.notion.com", module_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Create the DysonX Signal Engine V1 Notion source schema foundation.

## Scope

Included:

- Add `docs/DYSONX_NOTION_SOURCE_SCHEMA.md`
- Add lightweight schema mapping and validation in `scripts/dysonx_notion_source_schema.py`
- Add tests for required fields, eligibility, value ranges, and no Notion API calls

Not included:

- Notion API connection
- Real Notion data fetch
- Collectors
- LLM API calls
- Page publishing
- Knowledge Graph implementation
- Prediction Engine
- Billing, subscriptions, dashboards, API platform, enterprise, or multi-tenant features

## Required Reading Confirmation

- [x] I read `/docs/DYSONX_PRODUCT_CONSTITUTION.md`
- [x] I read `/docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- [x] I read `/docs/DYSONX_ENGINEERING_GOVERNANCE.md`
- [x] I read `/docs/DYSONX_PROJECT_CONTEXT.md`
- [x] I read `/docs/DYSONX_OWNER_INTENT.md`
- [x] I read `AGENTS.md`

## Constitution Compliance

- [x] This PR does not turn DysonX into a generic news site
- [x] This PR preserves English-default / Chinese-switchable architecture
- [x] This PR preserves Signal-first design
- [x] This PR does not hardcode monitored sources
- [x] This PR keeps Notion as the future source of truth for monitored sources
- [x] This PR does not connect to Notion or fetch real source data
- [x] This PR does not bypass LLM analysis or the publishing quality gate
- [x] This PR does not create thin SEO content or content-farm behavior
- [x] This PR preserves long-term intelligence value

## Architecture Impact

Affected layers:

- Source Configuration
- Governance

This is Notion source schema foundation only. It defines the expected V1 source properties and validation rules without implementing Notion sync, collection, analysis, publishing, graph, prediction, or enterprise features.

## Data and Migration Impact

- [x] No live database schema change
- [x] No migration included
- [x] No Notion API connection
- [x] Documentation and lightweight Python validation only

## Tests Run

```bash
python3 scripts/constitution_guard.py
python3 scripts/architecture_guard.py
python3 scripts/release_guard.py
python3 -m py_compile scripts/*.py
python3 -m unittest discover -s tests
git diff --check HEAD~1 HEAD
```

Results:

- `python3 scripts/constitution_guard.py`: PASS
- `python3 scripts/architecture_guard.py`: PASS
- `python3 scripts/release_guard.py`: PASS
- `python3 -m py_compile scripts/*.py`: PASS
- `python3 -m unittest discover -s tests`: PASS, 11 tests
- `git diff --check HEAD~1 HEAD`: PASS

## Deployment Impact

- [x] No deployment performed
- [x] No production code changed
- [x] No production secrets changed

## Rollback Plan

Revert commit `4f7617c` or close this draft PR.

## Known Limitations

- This PR does not create or connect a real Notion database.
- This PR does not fetch sources or determine source content.
- Collection eligibility is validation-only and does not run collectors.

## Reviewer Notes

Please verify that this remains schema/mapping-only and that no Notion client, network call, collector, LLM call, publishing path, Knowledge Graph, Prediction Engine, billing, dashboard, API platform, enterprise, or multi-tenant scope has entered the branch.

## Final Agent Statement

I confirm that this PR follows DysonX Product Constitution, System Architecture, and Engineering Governance.

I did not merge or deploy this change.
