### PR TITLE
feat: add DysonX Signal Candidate Pipeline V1

### DIFF
--- a/docs/DYSONX_SIGNAL_CANDIDATE_V1.md
+++ b/docs/DYSONX_SIGNAL_CANDIDATE_V1.md
@@ -1,0 +1,85 @@
+# DysonX Signal Candidate Pipeline V1
+
+Status: pre-LLM candidate pipeline foundation
+
+This document describes the first deterministic Signal Candidate pipeline:
+
+`Raw Item -> Normalizer -> Signal Candidate -> Audit Report`
+
+This is intentionally pre-LLM. It does not call LLM APIs, fetch source content, run RSS/web/GitHub collectors, publish pages, post to social platforms, implement Knowledge Graph, or implement Prediction Engine.
+
+## Purpose
+
+The V1 Signal Candidate pipeline turns already-available raw item fixtures into structured Signal Candidates. It exists to prove object boundaries and audit behavior before LLM analysis is introduced.
+
+## RawItem V1
+
+Required fields:
+
+- `source_id`
+- `source_name`
+- `title`
+- `url`
+- `published_at`
+- `language`
+- `collected_at`
+- `raw_content`
+- `metadata`
+
+Raw Items are evidence inputs. They are not Signals and must not be published directly.
+
+## SignalCandidate V1
+
+Required fields:
+
+- `candidate_id`
+- `title`
+- `source_id`
+- `source_name`
+- `url`
+- `candidate_type`
+- `entities`
+- `tags`
+- `status`
+- `confidence`
+- `created_at`
+
+Signal Candidates are proposed Signals. They are not published Signals, tracker entries, Knowledge Graph nodes, or social posts.
+
+## Deterministic Normalization
+
+V1 uses a deterministic rule-based normalizer only:
+
+- Titles containing `openai` and `release` map to `model_release`.
+- Titles containing `anthropic` and `announce` map to `company_announcement`.
+- Titles containing `ai act`, `regulation`, or `regulatory` map to `regulation`.
+- Titles containing `deepmind`, `research`, or `paper` map to `research_update`.
+- Otherwise, valid items map to `general_signal`.
+
+These rules are scaffolding only. They do not replace future LLM analysis.
+
+## Audit Report
+
+The pipeline writes a JSON audit report with:
+
+- `total_raw_items`
+- `candidates_created`
+- `candidate_types`
+- `rejected_items`
+- `processing_warnings`
+- `llm_used`
+- `network_requests_performed`
+- `publishing_performed`
+
+## Non-Goals
+
+Signal Candidate Pipeline V1 must not:
+
+- Call LLM APIs.
+- Add RSS, web, GitHub, social, paper, or government collectors.
+- Fetch article or webpage content.
+- Publish pages.
+- Post to social platforms.
+- Implement Knowledge Graph.
+- Implement Prediction Engine.
+- Add dashboard, billing, API platform, enterprise, or multi-tenant features.

--- a/scripts/dysonx_raw_item.py
+++ b/scripts/dysonx_raw_item.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""DysonX RawItem and SignalCandidate V1 data structures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RawItemV1:
+    source_id: str
+    source_name: str
+    title: str
+    url: str
+    published_at: str
+    language: str
+    collected_at: str
+    raw_content: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SignalCandidateV1:
+    candidate_id: str
+    title: str
+    source_id: str
+    source_name: str
+    url: str
+    candidate_type: str
+    entities: tuple[str, ...]
+    tags: tuple[str, ...]
+    status: str
+    confidence: float
+    created_at: str

--- a/scripts/dysonx_signal_candidate_pipeline.py
+++ b/scripts/dysonx_signal_candidate_pipeline.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""DysonX Signal Candidate Pipeline V1.
+
+Loads RawItem fixtures, applies deterministic pre-LLM normalization rules, and
+writes a candidate audit report. It does not perform network requests, call LLM
+APIs, publish pages, or implement graph/prediction features.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any
+
+from dysonx_raw_item import RawItemV1, SignalCandidateV1
+
+
+REQUIRED_RAW_ITEM_FIELDS = (
+    "source_id",
+    "source_name",
+    "title",
+    "url",
+    "published_at",
+    "language",
+    "collected_at",
+    "raw_content",
+    "metadata",
+)
+
+
+def load_raw_item_records(path: str | pathlib.Path) -> list[dict[str, Any]]:
+    fixture_path = pathlib.Path(path)
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("Raw item fixture must contain a list of records")
+    if not all(isinstance(record, dict) for record in data):
+        raise ValueError("Every raw item fixture record must be an object")
+    return data
+
+
+def validate_raw_item_record(record: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field_name in REQUIRED_RAW_ITEM_FIELDS:
+        if field_name not in record:
+            errors.append(f"{field_name} is required")
+
+    for field_name in ("source_id", "source_name", "title", "url", "language", "collected_at"):
+        if record.get(field_name) in (None, ""):
+            errors.append(f"{field_name} must be present")
+
+    if "metadata" in record and not isinstance(record.get("metadata"), dict):
+        errors.append("metadata must be an object")
+
+    return errors
+
+
+def raw_item_from_record(record: dict[str, Any]) -> RawItemV1:
+    return RawItemV1(
+        source_id=str(record["source_id"]),
+        source_name=str(record["source_name"]),
+        title=str(record["title"]),
+        url=str(record["url"]),
+        published_at=str(record.get("published_at") or ""),
+        language=str(record["language"]),
+        collected_at=str(record["collected_at"]),
+        raw_content=str(record.get("raw_content") or ""),
+        metadata=dict(record.get("metadata") or {}),
+    )
+
+
+def classify_candidate_type(raw_item: RawItemV1) -> str:
+    text = f"{raw_item.title} {raw_item.raw_content}".lower()
+    if "openai" in text and ("release" in text or "launch" in text):
+        return "model_release"
+    if "anthropic" in text and ("announce" in text or "announcement" in text):
+        return "company_announcement"
+    if "ai act" in text or "regulation" in text or "regulatory" in text:
+        return "regulation"
+    if "deepmind" in text or "research" in text or "paper" in text:
+        return "research_update"
+    return "general_signal"
+
+
+def extract_entities(raw_item: RawItemV1) -> tuple[str, ...]:
+    text = f"{raw_item.title} {raw_item.raw_content}".lower()
+    entities = []
+    for entity in ("OpenAI", "Anthropic", "Google DeepMind", "EU"):
+        if entity.lower() in text:
+            entities.append(entity)
+    return tuple(entities)
+
+
+def tags_for_candidate_type(candidate_type: str) -> tuple[str, ...]:
+    tags = {
+        "model_release": ("model", "release"),
+        "company_announcement": ("company", "announcement"),
+        "regulation": ("policy", "regulation"),
+        "research_update": ("research", "technical"),
+        "general_signal": ("signal",),
+    }
+    return tags[candidate_type]
+
+
+def candidate_id_for_raw_item(raw_item: RawItemV1) -> str:
+    digest = hashlib.sha256(f"{raw_item.source_id}|{raw_item.url}|{raw_item.title}".encode("utf-8")).hexdigest()
+    return f"candidate_{digest[:16]}"
+
+
+def create_signal_candidate(raw_item: RawItemV1, created_at: str) -> SignalCandidateV1:
+    candidate_type = classify_candidate_type(raw_item)
+    return SignalCandidateV1(
+        candidate_id=candidate_id_for_raw_item(raw_item),
+        title=raw_item.title,
+        source_id=raw_item.source_id,
+        source_name=raw_item.source_name,
+        url=raw_item.url,
+        candidate_type=candidate_type,
+        entities=extract_entities(raw_item),
+        tags=tags_for_candidate_type(candidate_type),
+        status="candidate",
+        confidence=0.55,
+        created_at=created_at,
+    )
+
+
+def run_pipeline(records: list[dict[str, Any]], created_at: str | None = None) -> dict[str, Any]:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    candidates: list[SignalCandidateV1] = []
+    rejected_items: list[dict[str, Any]] = []
+    processing_warnings: list[str] = []
+
+    for index, record in enumerate(records):
+        errors = validate_raw_item_record(record)
+        if errors:
+            rejected_items.append(
+                {
+                    "index": index,
+                    "title": record.get("title", ""),
+                    "errors": errors,
+                }
+            )
+            continue
+
+        raw_item = raw_item_from_record(record)
+        candidate = create_signal_candidate(raw_item, created_at=timestamp)
+        if candidate.candidate_type == "general_signal":
+            processing_warnings.append(f"Raw item {index} used fallback candidate type")
+        candidates.append(candidate)
+
+    candidate_type_counts: dict[str, int] = {}
+    for candidate in candidates:
+        candidate_type_counts[candidate.candidate_type] = candidate_type_counts.get(candidate.candidate_type, 0) + 1
+
+    return {
+        "generated_at": timestamp,
+        "total_raw_items": len(records),
+        "candidates_created": len(candidates),
+        "candidate_types": candidate_type_counts,
+        "candidates": [
+            {
+                **asdict(candidate),
+                "entities": list(candidate.entities),
+                "tags": list(candidate.tags),
+            }
+            for candidate in candidates
+        ],
+        "rejected_items": rejected_items,
+        "processing_warnings": processing_warnings,
+        "llm_used": False,
+        "network_requests_performed": False,
+        "publishing_performed": False,
+    }
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Signal Candidate Pipeline V1.")
+    parser.add_argument("--fixture", required=True, help="Path to raw item fixture JSON.")
+    parser.add_argument("--output", required=True, help="Path to write signal candidate audit report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    records = load_raw_item_records(args.fixture)
+    report = run_pipeline(records)
+    write_report(report, args.output)
+    print(
+        "[signal-candidate-pipeline] wrote report: "
+        f"{args.output} candidates={report['candidates_created']} rejected={len(report['rejected_items'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/raw_items_v1.json
+++ b/tests/fixtures/raw_items_v1.json
@@ -1,0 +1,65 @@
+[
+  {
+    "source_id": "source_openai_blog",
+    "source_name": "OpenAI Blog",
+    "title": "OpenAI releases GPT-6 for advanced reasoning",
+    "url": "https://openai.com/blog/gpt-6",
+    "published_at": "2026-06-15T12:00:00Z",
+    "language": "English",
+    "collected_at": "2026-06-17T10:00:00Z",
+    "raw_content": "OpenAI releases GPT-6 with stronger reasoning and tool-use capabilities.",
+    "metadata": {
+      "source_type": "Official Company Blog"
+    }
+  },
+  {
+    "source_id": "source_anthropic_blog",
+    "source_name": "Anthropic Blog",
+    "title": "Anthropic announces Claude agent reliability update",
+    "url": "https://anthropic.com/news/claude-agent-update",
+    "published_at": "2026-06-14T09:00:00Z",
+    "language": "English",
+    "collected_at": "2026-06-17T10:00:00Z",
+    "raw_content": "Anthropic announces improvements to Claude agent reliability for enterprise workflows.",
+    "metadata": {
+      "source_type": "Official Company Blog"
+    }
+  },
+  {
+    "source_id": "source_deepmind",
+    "source_name": "Google DeepMind",
+    "title": "Google DeepMind publishes world model research update",
+    "url": "https://deepmind.google/discover/blog/world-model-update",
+    "published_at": "2026-06-13T08:00:00Z",
+    "language": "English",
+    "collected_at": "2026-06-17T10:00:00Z",
+    "raw_content": "Google DeepMind shares a research update on world models and multimodal planning.",
+    "metadata": {
+      "source_type": "Research Lab"
+    }
+  },
+  {
+    "source_id": "source_eu_policy",
+    "source_name": "EU AI Office",
+    "title": "EU passes AI Act update for foundation model reporting",
+    "url": "https://digital-strategy.ec.europa.eu/ai-act-update",
+    "published_at": "2026-06-12T07:00:00Z",
+    "language": "English",
+    "collected_at": "2026-06-17T10:00:00Z",
+    "raw_content": "EU regulators pass an AI Act update affecting foundation model transparency reporting.",
+    "metadata": {
+      "source_type": "Regulatory"
+    }
+  },
+  {
+    "source_id": "source_invalid",
+    "source_name": "Invalid Fixture",
+    "title": "",
+    "url": "",
+    "published_at": "2026-06-11T07:00:00Z",
+    "language": "English",
+    "collected_at": "2026-06-17T10:00:00Z",
+    "raw_content": "This record is intentionally invalid.",
+    "metadata": {}
+  }
+]

--- a/tests/test_dysonx_signal_candidate_pipeline.py
+++ b/tests/test_dysonx_signal_candidate_pipeline.py
@@ -1,0 +1,90 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from dataclasses import fields
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_signal_candidate_pipeline as pipeline
+from dysonx_raw_item import RawItemV1, SignalCandidateV1
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+FIXED_TIME = "2026-06-17T10:00:00+00:00"
+
+
+class DysonXSignalCandidatePipelineTests(unittest.TestCase):
+    def test_raw_item_and_signal_candidate_remain_separate(self):
+        raw_fields = {field.name for field in fields(RawItemV1)}
+        candidate_fields = {field.name for field in fields(SignalCandidateV1)}
+
+        self.assertIn("raw_content", raw_fields)
+        self.assertIn("metadata", raw_fields)
+        self.assertNotIn("candidate_id", raw_fields)
+        self.assertNotIn("candidate_type", raw_fields)
+
+        self.assertIn("candidate_id", candidate_fields)
+        self.assertIn("candidate_type", candidate_fields)
+        self.assertNotIn("raw_content", candidate_fields)
+
+    def test_candidate_generation_is_deterministic(self):
+        records = pipeline.load_raw_item_records(FIXTURE_PATH)
+        first = pipeline.run_pipeline(records, created_at=FIXED_TIME)
+        second = pipeline.run_pipeline(records, created_at=FIXED_TIME)
+
+        self.assertEqual(first["candidates"], second["candidates"])
+        self.assertEqual(
+            first["candidate_types"],
+            {
+                "company_announcement": 1,
+                "model_release": 1,
+                "regulation": 1,
+                "research_update": 1,
+            },
+        )
+
+    def test_invalid_raw_items_do_not_crash_processing(self):
+        records = pipeline.load_raw_item_records(FIXTURE_PATH)
+        report = pipeline.run_pipeline(records, created_at=FIXED_TIME)
+
+        self.assertEqual(report["total_raw_items"], 5)
+        self.assertEqual(report["candidates_created"], 4)
+        self.assertEqual(len(report["rejected_items"]), 1)
+        self.assertIn("title must be present", report["rejected_items"][0]["errors"])
+
+    def test_audit_report_is_generated(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "candidate_report.json"
+            exit_code = pipeline.main(["--fixture", str(FIXTURE_PATH), "--output", str(output)])
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(report["candidates_created"], 4)
+            self.assertFalse(report["llm_used"])
+            self.assertFalse(report["publishing_performed"])
+
+    def test_no_llm_calls_occur(self):
+        module_source = pathlib.Path(pipeline.__file__).read_text(encoding="utf-8")
+
+        self.assertNotIn("import openai", module_source.lower())
+        self.assertNotIn("from openai", module_source.lower())
+        self.assertNotIn("import anthropic", module_source.lower())
+        self.assertNotIn("from anthropic", module_source.lower())
+        self.assertNotIn("chat.completions", module_source)
+        self.assertNotIn("responses.create", module_source)
+
+    def test_no_network_requests_occur(self):
+        with mock.patch("socket.socket") as socket_mock:
+            records = pipeline.load_raw_item_records(FIXTURE_PATH)
+            report = pipeline.run_pipeline(records, created_at=FIXED_TIME)
+
+        socket_mock.assert_not_called()
+        self.assertFalse(report["network_requests_performed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Create the DysonX Signal Candidate Pipeline V1 vertical slice:

`Raw Item -> deterministic normalizer -> Signal Candidate -> audit report`

This is pre-LLM and fixture-only.

## Scope

Included:

- Add `docs/DYSONX_SIGNAL_CANDIDATE_V1.md`
- Add `scripts/dysonx_raw_item.py` with `RawItemV1` and `SignalCandidateV1` structures
- Add `scripts/dysonx_signal_candidate_pipeline.py` CLI
- Add `tests/fixtures/raw_items_v1.json` examples
- Add deterministic rule-based candidate type normalization
- Generate SignalCandidate objects from fixture RawItems
- Produce audit report with totals, candidate types, rejected items, and warnings
- Add tests for separation, determinism, invalid item handling, audit report generation, no LLM calls, and no network requests

Not included:

- LLM API calls
- RSS/web/GitHub collectors
- Webpage/article fetching
- Page publishing
- Social posting
- Knowledge Graph implementation
- Prediction Engine
- Dashboard, billing, API platform, enterprise, or multi-tenant features
- Merge or deployment

## Required Reading Confirmation

- [x] I read `/docs/DYSONX_PRODUCT_CONSTITUTION.md`
- [x] I read `/docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- [x] I read `/docs/DYSONX_ENGINEERING_GOVERNANCE.md`
- [x] I read `/docs/DYSONX_PROJECT_CONTEXT.md`
- [x] I read `/docs/DYSONX_OWNER_INTENT.md`
- [x] I read `AGENTS.md`

## Constitution Compliance

- [x] This PR does not turn DysonX into a generic news site
- [x] This PR preserves English-default / Chinese-switchable architecture
- [x] This PR preserves Signal-first design
- [x] This PR does not hardcode monitored production sources
- [x] This PR does not add collectors or source fetching
- [x] This PR remains pre-LLM and does not call LLM APIs
- [x] This PR does not bypass the publishing quality gate
- [x] This PR does not publish pages or social posts
- [x] This PR does not create thin SEO content or content-farm behavior
- [x] This PR preserves long-term intelligence value

## Architecture Impact

Affected layers:

- Raw Data
- Normalization
- Observability / Audit
- Governance

This PR creates deterministic pre-LLM candidate scaffolding only. It keeps RawItem and SignalCandidate separate and writes an audit report. It performs no network I/O, LLM analysis, publishing, graph work, prediction work, or deployment.

## Data and Migration Impact

- [x] No live database schema change
- [x] No migration included
- [x] Fixture data only
- [x] No production secrets changed

## Tests Run

```bash
python3 scripts/constitution_guard.py
python3 scripts/architecture_guard.py
python3 scripts/release_guard.py
python3 -m py_compile scripts/*.py
python3 -m unittest discover -s tests
python3 scripts/dysonx_signal_candidate_pipeline.py --fixture tests/fixtures/raw_items_v1.json --output tmp/dysonx_signal_candidates_report.json
git diff --check HEAD~1 HEAD
```

Results:

- `python3 scripts/constitution_guard.py`: PASS
- `python3 scripts/architecture_guard.py`: PASS
- `python3 scripts/release_guard.py`: PASS
- `python3 -m py_compile scripts/*.py`: PASS
- `python3 -m unittest discover -s tests`: PASS, 37 tests
- Signal candidate pipeline CLI: PASS
- `git diff --check HEAD~1 HEAD`: PASS

## Sample Candidate Report Summary

- Total raw items: 5
- Candidates created: 4
- Rejected items: 1
- Candidate types:
  - `model_release`: 1
  - `company_announcement`: 1
  - `research_update`: 1
  - `regulation`: 1
- Rejected item errors: missing title and URL
- LLM used: `false`
- Network requests performed: `false`
- Publishing performed: `false`

## Deployment Impact

- [x] No deployment performed
- [x] No production code changed
- [x] No production secrets changed

## Rollback Plan

Revert commit `6ae274e` or close this draft PR.

## Known Limitations

- Rules are deterministic scaffolding only and do not replace future LLM analysis.
- No raw item collector exists in this PR.
- No Signal publishing or quality gate promotion occurs in this PR.

## Final Agent Statement

I confirm that this PR follows DysonX Product Constitution, System Architecture, and Engineering Governance.

I did not merge or deploy this change.
