### PR TITLE
feat: add DysonX LLM Intelligence Layer V1

### DIFF
--- a/docs/DYSONX_LLM_INTELLIGENCE_LAYER_V1.md
+++ b/docs/DYSONX_LLM_INTELLIGENCE_LAYER_V1.md
@@ -1,0 +1,89 @@
+# DysonX LLM Intelligence Layer V1
+
+This document defines the first DysonX Intelligence Signal generation layer.
+
+V1 transforms `SignalCandidate` objects into structured `IntelligenceSignal`
+records through an LLM provider abstraction. This is intelligence extraction,
+not article generation.
+
+## Scope
+
+Allowed in V1:
+
+- Read existing `SignalCandidate` records.
+- Analyze candidates through a provider abstraction.
+- Use `FakeLLMProvider` for deterministic local tests.
+- Produce structured `IntelligenceSignal` records.
+- Produce an audit report with processing counts and distributions.
+
+Not included in V1:
+
+- Real OpenAI, Anthropic, Gemini, or local model calls.
+- Provider credentials or environment variables.
+- Website publishing.
+- Social posting.
+- Knowledge Graph writes.
+- Prediction Engine behavior.
+- Dashboard, billing, subscription, enterprise, API platform, or multi-tenant features.
+
+## Target Flow
+
+```text
+SignalCandidate
+-> LLM Analysis abstraction
+-> IntelligenceSignal
+-> Audit Report
+```
+
+V1 uses a fake provider behind the same interface that future providers can
+implement. This preserves the LLM-first architecture without introducing real
+network calls in this foundation PR.
+
+## IntelligenceSignal V1 Fields
+
+- `signal_id`
+- `title`
+- `source_id`
+- `source_name`
+- `signal_type`
+- `importance`
+- `confidence`
+- `summary`
+- `key_points`
+- `affected_entities`
+- `impact_horizon`
+- `tags`
+- `created_at`
+
+## Provider Abstraction
+
+The LLM provider interface accepts one `SignalCandidate` and returns structured
+analysis fields used to create an `IntelligenceSignal`.
+
+Future provider families are intentionally provider-neutral:
+
+- OpenAI
+- Anthropic
+- Gemini
+- Local models
+
+V1 implements only `FakeLLMProvider`. It is deterministic, has no credentials,
+and performs no network requests.
+
+## Audit Report
+
+The audit report records:
+
+- Candidates processed
+- Signals generated
+- Confidence distribution
+- Importance distribution
+- Processing warnings
+- Provider mode
+- Whether real LLM APIs, network requests, or publishing occurred
+
+## Governance Notes
+
+This layer supports the DysonX constitution by making LLM analysis the first
+major interpretation layer after pre-LLM candidate preparation. It does not
+generate articles, publish pages, or optimize for content volume.

--- a/scripts/dysonx_intelligence_signal.py
+++ b/scripts/dysonx_intelligence_signal.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""DysonX IntelligenceSignal V1 data structure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class IntelligenceSignalV1:
+    signal_id: str
+    title: str
+    source_id: str
+    source_name: str
+    signal_type: str
+    importance: str
+    confidence: float
+    summary: str
+    key_points: tuple[str, ...]
+    affected_entities: tuple[str, ...]
+    impact_horizon: str
+    tags: tuple[str, ...]
+    created_at: str

--- a/scripts/dysonx_llm_intelligence_layer.py
+++ b/scripts/dysonx_llm_intelligence_layer.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""DysonX LLM Intelligence Layer V1.
+
+Transforms SignalCandidate records into structured IntelligenceSignal records
+through a provider abstraction. V1 ships only a deterministic fake provider: it
+does not call real LLM APIs, perform network requests, publish pages, or create
+social posts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from dysonx_intelligence_signal import IntelligenceSignalV1
+from dysonx_raw_item import SignalCandidateV1
+import dysonx_signal_candidate_pipeline as candidate_pipeline
+
+
+SUPPORTED_FUTURE_PROVIDER_FAMILIES = ("openai", "anthropic", "gemini", "local")
+
+
+class LLMProvider(Protocol):
+    provider_name: str
+
+    def analyze_candidate(self, candidate: SignalCandidateV1) -> dict[str, Any]:
+        """Return structured intelligence fields for one SignalCandidate."""
+
+
+class FakeLLMProvider:
+    """Deterministic provider for V1 tests and audit reports."""
+
+    provider_name = "fake"
+
+    def analyze_candidate(self, candidate: SignalCandidateV1) -> dict[str, Any]:
+        importance = importance_for_candidate_type(candidate.candidate_type)
+        impact_horizon = impact_horizon_for_candidate_type(candidate.candidate_type)
+        confidence = min(0.95, round(candidate.confidence + 0.2, 2))
+        entity_text = ", ".join(candidate.entities) if candidate.entities else "the tracked AI ecosystem"
+
+        return {
+            "title": f"Intelligence Signal: {candidate.title}",
+            "signal_type": candidate.candidate_type,
+            "importance": importance,
+            "confidence": confidence,
+            "summary": (
+                f"{candidate.title} is a {candidate.candidate_type.replace('_', ' ')} "
+                f"signal involving {entity_text}."
+            ),
+            "key_points": (
+                f"Source candidate type: {candidate.candidate_type}",
+                f"Original source: {candidate.source_name}",
+                "Provider output is deterministic fake analysis for V1.",
+            ),
+            "affected_entities": candidate.entities,
+            "impact_horizon": impact_horizon,
+            "tags": candidate.tags,
+        }
+
+
+def importance_for_candidate_type(candidate_type: str) -> str:
+    importance = {
+        "model_release": "high",
+        "company_announcement": "medium",
+        "research_update": "medium",
+        "regulation": "high",
+        "general_signal": "low",
+    }
+    return importance.get(candidate_type, "low")
+
+
+def impact_horizon_for_candidate_type(candidate_type: str) -> str:
+    horizons = {
+        "model_release": "near_term",
+        "company_announcement": "near_term",
+        "research_update": "mid_term",
+        "regulation": "mid_term",
+        "general_signal": "unknown",
+    }
+    return horizons.get(candidate_type, "unknown")
+
+
+def signal_id_for_candidate(candidate: SignalCandidateV1) -> str:
+    digest = hashlib.sha256(f"{candidate.candidate_id}|{candidate.url}|{candidate.title}".encode("utf-8")).hexdigest()
+    return f"signal_{digest[:16]}"
+
+
+def candidate_from_record(record: dict[str, Any]) -> SignalCandidateV1:
+    required_fields = (
+        "candidate_id",
+        "title",
+        "source_id",
+        "source_name",
+        "url",
+        "candidate_type",
+        "entities",
+        "tags",
+        "status",
+        "confidence",
+        "created_at",
+    )
+    missing = [field for field in required_fields if field not in record]
+    if missing:
+        raise ValueError(f"SignalCandidate record missing fields: {', '.join(missing)}")
+
+    return SignalCandidateV1(
+        candidate_id=str(record["candidate_id"]),
+        title=str(record["title"]),
+        source_id=str(record["source_id"]),
+        source_name=str(record["source_name"]),
+        url=str(record["url"]),
+        candidate_type=str(record["candidate_type"]),
+        entities=tuple(str(entity) for entity in record.get("entities", ())),
+        tags=tuple(str(tag) for tag in record.get("tags", ())),
+        status=str(record["status"]),
+        confidence=float(record["confidence"]),
+        created_at=str(record["created_at"]),
+    )
+
+
+def create_intelligence_signal(
+    candidate: SignalCandidateV1,
+    provider: LLMProvider,
+    created_at: str,
+) -> IntelligenceSignalV1:
+    analysis = provider.analyze_candidate(candidate)
+    return IntelligenceSignalV1(
+        signal_id=signal_id_for_candidate(candidate),
+        title=str(analysis["title"]),
+        source_id=candidate.source_id,
+        source_name=candidate.source_name,
+        signal_type=str(analysis["signal_type"]),
+        importance=str(analysis["importance"]),
+        confidence=float(analysis["confidence"]),
+        summary=str(analysis["summary"]),
+        key_points=tuple(str(point) for point in analysis["key_points"]),
+        affected_entities=tuple(str(entity) for entity in analysis["affected_entities"]),
+        impact_horizon=str(analysis["impact_horizon"]),
+        tags=tuple(str(tag) for tag in analysis["tags"]),
+        created_at=created_at,
+    )
+
+
+def run_intelligence_layer(
+    candidates: list[SignalCandidateV1],
+    provider: LLMProvider | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    llm_provider = provider or FakeLLMProvider()
+    signals = [create_intelligence_signal(candidate, llm_provider, timestamp) for candidate in candidates]
+
+    confidence_distribution = {"low": 0, "medium": 0, "high": 0}
+    importance_distribution: dict[str, int] = {}
+    warnings: list[str] = []
+
+    for signal in signals:
+        if signal.confidence < 0.5:
+            confidence_distribution["low"] += 1
+        elif signal.confidence < 0.75:
+            confidence_distribution["medium"] += 1
+        else:
+            confidence_distribution["high"] += 1
+        importance_distribution[signal.importance] = importance_distribution.get(signal.importance, 0) + 1
+        if not signal.affected_entities:
+            warnings.append(f"{signal.signal_id} has no affected entities")
+
+    return {
+        "generated_at": timestamp,
+        "provider": llm_provider.provider_name,
+        "provider_mode": "fake_only",
+        "future_provider_families": list(SUPPORTED_FUTURE_PROVIDER_FAMILIES),
+        "candidates_processed": len(candidates),
+        "signals_generated": len(signals),
+        "confidence_distribution": confidence_distribution,
+        "importance_distribution": importance_distribution,
+        "signals": [
+            {
+                **asdict(signal),
+                "key_points": list(signal.key_points),
+                "affected_entities": list(signal.affected_entities),
+                "tags": list(signal.tags),
+            }
+            for signal in signals
+        ],
+        "warnings": warnings,
+        "real_llm_api_used": False,
+        "network_requests_performed": False,
+        "publishing_performed": False,
+    }
+
+
+def load_candidates_from_candidate_report(path: str | pathlib.Path) -> list[SignalCandidateV1]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    records = data.get("candidates")
+    if not isinstance(records, list):
+        raise ValueError("Candidate report must contain a candidates list")
+    return [candidate_from_record(record) for record in records]
+
+
+def load_candidates_from_raw_fixture(path: str | pathlib.Path) -> list[SignalCandidateV1]:
+    records = candidate_pipeline.load_raw_item_records(path)
+    candidate_report = candidate_pipeline.run_pipeline(records)
+    return [candidate_from_record(record) for record in candidate_report["candidates"]]
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX LLM Intelligence Layer V1 with FakeLLMProvider.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--candidate-report", help="Path to an existing SignalCandidate audit report JSON.")
+    source.add_argument("--raw-fixture", help="Path to a RawItem fixture JSON to convert through the candidate layer first.")
+    parser.add_argument("--output", required=True, help="Path to write intelligence signal audit report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.candidate_report:
+        candidates = load_candidates_from_candidate_report(args.candidate_report)
+    else:
+        candidates = load_candidates_from_raw_fixture(args.raw_fixture)
+
+    report = run_intelligence_layer(candidates, provider=FakeLLMProvider())
+    write_report(report, args.output)
+    print(
+        "[llm-intelligence-layer] wrote report: "
+        f"{args.output} signals={report['signals_generated']} provider={report['provider']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_llm_intelligence_layer.py
+++ b/tests/test_dysonx_llm_intelligence_layer.py
@@ -1,0 +1,99 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from dataclasses import fields
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_llm_intelligence_layer as layer
+import dysonx_signal_candidate_pipeline as candidate_pipeline
+from dysonx_intelligence_signal import IntelligenceSignalV1
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+FIXED_TIME = "2026-06-17T10:00:00+00:00"
+
+
+class DysonXLLMIntelligenceLayerTests(unittest.TestCase):
+    def candidate_records(self):
+        raw_records = candidate_pipeline.load_raw_item_records(FIXTURE_PATH)
+        return candidate_pipeline.run_pipeline(raw_records, created_at=FIXED_TIME)["candidates"]
+
+    def candidates(self):
+        return [layer.candidate_from_record(record) for record in self.candidate_records()]
+
+    def test_intelligence_signal_schema_is_signal_not_article(self):
+        signal_fields = {field.name for field in fields(IntelligenceSignalV1)}
+
+        self.assertIn("signal_id", signal_fields)
+        self.assertIn("summary", signal_fields)
+        self.assertIn("affected_entities", signal_fields)
+        self.assertIn("impact_horizon", signal_fields)
+        self.assertNotIn("article_body", signal_fields)
+        self.assertNotIn("published_at", signal_fields)
+
+    def test_llm_abstraction_and_fake_provider_work(self):
+        provider = layer.FakeLLMProvider()
+        candidate = self.candidates()[0]
+        analysis = provider.analyze_candidate(candidate)
+
+        self.assertEqual(provider.provider_name, "fake")
+        self.assertIn("summary", analysis)
+        self.assertIn("importance", analysis)
+        self.assertGreaterEqual(analysis["confidence"], candidate.confidence)
+
+    def test_intelligence_signal_generation_works(self):
+        candidates = self.candidates()
+        report = layer.run_intelligence_layer(candidates, provider=layer.FakeLLMProvider(), created_at=FIXED_TIME)
+
+        self.assertEqual(report["candidates_processed"], 4)
+        self.assertEqual(report["signals_generated"], 4)
+        self.assertEqual(report["provider"], "fake")
+        self.assertEqual(report["importance_distribution"], {"high": 2, "medium": 2})
+        self.assertFalse(report["publishing_performed"])
+        self.assertFalse(report["real_llm_api_used"])
+
+    def test_generation_is_deterministic_with_fake_provider(self):
+        candidates = self.candidates()
+        first = layer.run_intelligence_layer(candidates, provider=layer.FakeLLMProvider(), created_at=FIXED_TIME)
+        second = layer.run_intelligence_layer(candidates, provider=layer.FakeLLMProvider(), created_at=FIXED_TIME)
+
+        self.assertEqual(first["signals"], second["signals"])
+        self.assertEqual(first["confidence_distribution"], second["confidence_distribution"])
+
+    def test_no_provider_specific_dependency_exists(self):
+        module_source = pathlib.Path(layer.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("from anthropic", module_source)
+        self.assertNotIn("google.generativeai", module_source)
+        self.assertIn("fakellmprovider", module_source)
+
+    def test_no_network_requests_or_publishing_occur(self):
+        with mock.patch("socket.socket") as socket_mock:
+            report = layer.run_intelligence_layer(self.candidates(), provider=layer.FakeLLMProvider(), created_at=FIXED_TIME)
+
+        socket_mock.assert_not_called()
+        self.assertFalse(report["network_requests_performed"])
+        self.assertFalse(report["publishing_performed"])
+
+    def test_cli_writes_audit_report_from_raw_fixture(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "intelligence_report.json"
+            exit_code = layer.main(["--raw-fixture", str(FIXTURE_PATH), "--output", str(output)])
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(report["signals_generated"], 4)
+            self.assertEqual(report["provider_mode"], "fake_only")
+            self.assertFalse(report["publishing_performed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add the first DysonX LLM Intelligence Layer V1 foundation that transforms SignalCandidate objects into structured IntelligenceSignal records through a provider abstraction. V1 uses only FakeLLMProvider and performs no real LLM API calls.

## Scope

- Add docs/DYSONX_LLM_INTELLIGENCE_LAYER_V1.md
- Add scripts/dysonx_intelligence_signal.py
- Add scripts/dysonx_llm_intelligence_layer.py
- Add tests/test_dysonx_llm_intelligence_layer.py
- Convert SignalCandidate records into IntelligenceSignal audit reports
- Keep provider abstraction neutral for future OpenAI, Anthropic, Gemini, and local model support

## Constitution Compliance

- Read AGENTS.md and all DysonX governance documents first.
- Preserves Signal-first design.
- Adds intelligence extraction, not article generation.
- Does not hardcode monitored production source lists.
- Keeps LLM interpretation as the first major post-candidate intelligence layer.
- Does not implement Knowledge Graph, Prediction Engine, dashboard, billing, or enterprise features.

## Architecture Impact

This PR adds a separable LLM Intelligence Layer with a fake provider only. It does not connect to external providers, perform network requests, publish pages, or create social posts.

## Tests Run

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_llm_intelligence_layer.py --raw-fixture tests/fixtures/raw_items_v1.json --output tmp/dysonx_intelligence_signals_report.json
- git diff --check

## Sample Report

- candidates_processed: 4
- signals_generated: 4
- provider: fake
- provider_mode: fake_only
- importance_distribution: high=2, medium=2
- confidence_distribution: high=4, medium=0, low=0
- real_llm_api_used: false
- network_requests_performed: false
- publishing_performed: false

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Rollback Notes

Revert this PR to remove the V1 fake-provider intelligence layer and its tests.

## Known Limitations

- FakeLLMProvider is deterministic and does not call real providers.
- No provider credentials or environment handling are introduced.
- No publishing, social posting, Knowledge Graph writes, or Prediction Engine behavior are included.