### PR TITLE
feat: add DysonX LLM Job & Audit Foundation V1

### DIFF
--- a/docs/DYSONX_LLM_JOB_AUDIT_V1.md
+++ b/docs/DYSONX_LLM_JOB_AUDIT_V1.md
@@ -1,0 +1,128 @@
+# DysonX LLM Job & Audit Foundation V1
+
+This document defines the provider-neutral LLM execution and audit foundation
+for DysonX V1.
+
+This is not real provider integration. V1 remains fake-provider only and
+performs no network requests.
+
+## Target Flow
+
+```text
+Signal Candidate
+-> LLM Job
+-> Prompt Template
+-> Model Run
+-> Output Validation
+-> Intelligence Signal
+-> Audit Report
+```
+
+## Scope
+
+Allowed in V1:
+
+- Create provider-neutral LLM job records.
+- Use versioned prompt templates from a central registry.
+- Execute deterministic fake-provider model runs.
+- Validate structured model output before creating Intelligence Signals.
+- Preserve audit records tying jobs, runs, validations, and output together.
+- Generate an audit report with counts and distributions.
+
+Not included in V1:
+
+- OpenAI API calls.
+- Anthropic API calls.
+- Gemini API calls.
+- Local model runtime calls.
+- Provider credentials or secrets.
+- Publishing.
+- Social posting.
+- Knowledge Graph writes.
+- Prediction Engine behavior.
+- Dashboard, billing, enterprise, or multi-tenant features.
+
+## V1 Structures
+
+### LLMJobV1
+
+- `job_id`
+- `candidate_id`
+- `provider`
+- `model`
+- `prompt_template_version`
+- `status`
+- `created_at`
+
+### PromptTemplateV1
+
+- `template_id`
+- `template_version`
+- `purpose`
+- `template_text`
+
+### ModelRunV1
+
+- `run_id`
+- `job_id`
+- `provider`
+- `model`
+- `latency_ms`
+- `token_counts`
+- `status`
+
+### OutputValidationV1
+
+- `validation_id`
+- `run_id`
+- `passed`
+- `warnings`
+- `validation_rules`
+
+### AuditRecordV1
+
+- `audit_id`
+- `job_id`
+- `run_id`
+- `validation_id`
+- `created_at`
+
+## Prompt Registry
+
+Prompts are registered by `template_id` and `template_version`.
+
+Prompt text must live in the prompt registry, not scattered through provider
+execution code. Future real provider integrations should reference a registered
+template version and record it in the LLM job.
+
+## Output Validation
+
+V1 validation checks:
+
+- Required fields are present.
+- Confidence is in the `0..1` range.
+- Importance is one of `low`, `medium`, or `high`.
+- Summary is present and non-empty.
+
+Malformed output must be captured as validation failure rather than silently
+converted into an Intelligence Signal.
+
+## Audit Report
+
+The V1 audit report includes:
+
+- Jobs created
+- Runs completed
+- Validations passed
+- Validations failed
+- Provider distribution
+- Prompt versions used
+- Job, run, validation, audit record, and signal details
+- Confirmation that no real LLM API, network request, or publishing occurred
+
+## Governance Notes
+
+This PR strengthens governance and observability before real model integration.
+It keeps the LLM layer provider-neutral, fake-only, and auditable.
+
+No publishing or public distribution path is introduced.

--- a/scripts/dysonx_llm_audit.py
+++ b/scripts/dysonx_llm_audit.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""DysonX LLM Job & Audit Foundation V1.
+
+Runs SignalCandidate records through a provider-neutral fake model execution
+chain, validates structured output, creates IntelligenceSignal records, and
+writes an audit report. V1 performs no real provider calls, network requests,
+publishing, social posting, graph writes, or prediction work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+from dataclasses import asdict
+from datetime import datetime, timezone
+from time import perf_counter
+from typing import Any
+
+from dysonx_intelligence_signal import IntelligenceSignalV1
+from dysonx_llm_intelligence_layer import (
+    FakeLLMProvider,
+    candidate_from_record,
+    signal_id_for_candidate,
+)
+from dysonx_llm_job import AuditRecordV1, LLMJobV1, ModelRunV1, OutputValidationV1
+from dysonx_output_validation import VALIDATION_RULES, validate_intelligence_output
+from dysonx_prompt_registry import PromptTemplateV1, get_prompt_template
+import dysonx_signal_candidate_pipeline as candidate_pipeline
+
+
+FAKE_PROVIDER_NAME = "fake"
+FAKE_MODEL_NAME = "fake-dysonx-intelligence-v1"
+DEFAULT_PROMPT_TEMPLATE_ID = "intelligence_signal_extraction"
+DEFAULT_PROMPT_TEMPLATE_VERSION = "v1"
+
+
+def stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:16]}"
+
+
+def create_llm_job(candidate_id: str, prompt_template: PromptTemplateV1, created_at: str) -> LLMJobV1:
+    return LLMJobV1(
+        job_id=stable_id("llm_job", candidate_id, prompt_template.template_version),
+        candidate_id=candidate_id,
+        provider=FAKE_PROVIDER_NAME,
+        model=FAKE_MODEL_NAME,
+        prompt_template_version=prompt_template.template_version,
+        status="created",
+        created_at=created_at,
+    )
+
+
+def estimate_token_counts(prompt_template: PromptTemplateV1, output: dict[str, Any]) -> dict[str, int]:
+    prompt_tokens = len(prompt_template.template_text.split())
+    completion_tokens = len(json.dumps(output, sort_keys=True).split())
+    return {
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+    }
+
+
+def execute_fake_model_run(
+    job: LLMJobV1,
+    candidate_record: dict[str, Any],
+    prompt_template: PromptTemplateV1,
+    provider: FakeLLMProvider | None = None,
+) -> tuple[ModelRunV1, dict[str, Any]]:
+    candidate = candidate_from_record(candidate_record)
+    fake_provider = provider or FakeLLMProvider()
+    start = perf_counter()
+    output = fake_provider.analyze_candidate(candidate)
+    latency_ms = max(0, int((perf_counter() - start) * 1000))
+    run = ModelRunV1(
+        run_id=stable_id("model_run", job.job_id, candidate.candidate_id),
+        job_id=job.job_id,
+        provider=fake_provider.provider_name,
+        model=job.model,
+        latency_ms=latency_ms,
+        token_counts=estimate_token_counts(prompt_template, output),
+        status="completed",
+    )
+    return run, output
+
+
+def validate_model_output(run_id: str, output: dict[str, Any]) -> OutputValidationV1:
+    passed, warnings = validate_intelligence_output(output)
+    return OutputValidationV1(
+        validation_id=stable_id("validation", run_id),
+        run_id=run_id,
+        passed=passed,
+        warnings=warnings,
+        validation_rules=VALIDATION_RULES,
+    )
+
+
+def create_audit_record(job_id: str, run_id: str, validation_id: str, created_at: str) -> AuditRecordV1:
+    return AuditRecordV1(
+        audit_id=stable_id("audit", job_id, run_id, validation_id),
+        job_id=job_id,
+        run_id=run_id,
+        validation_id=validation_id,
+        created_at=created_at,
+    )
+
+
+def create_signal_from_valid_output(
+    candidate_record: dict[str, Any],
+    output: dict[str, Any],
+    created_at: str,
+) -> IntelligenceSignalV1:
+    candidate = candidate_from_record(candidate_record)
+    return IntelligenceSignalV1(
+        signal_id=signal_id_for_candidate(candidate),
+        title=str(output["title"]),
+        source_id=candidate.source_id,
+        source_name=candidate.source_name,
+        signal_type=str(output["signal_type"]),
+        importance=str(output["importance"]),
+        confidence=float(output["confidence"]),
+        summary=str(output["summary"]),
+        key_points=tuple(str(point) for point in output["key_points"]),
+        affected_entities=tuple(str(entity) for entity in output["affected_entities"]),
+        impact_horizon=str(output["impact_horizon"]),
+        tags=tuple(str(tag) for tag in output["tags"]),
+        created_at=created_at,
+    )
+
+
+def serialize_dataclass(value: Any) -> dict[str, Any]:
+    data = asdict(value)
+    for key, item in list(data.items()):
+        if isinstance(item, tuple):
+            data[key] = list(item)
+    return data
+
+
+def run_llm_audit(
+    candidate_records: list[dict[str, Any]],
+    created_at: str | None = None,
+    prompt_template_id: str = DEFAULT_PROMPT_TEMPLATE_ID,
+    prompt_template_version: str = DEFAULT_PROMPT_TEMPLATE_VERSION,
+) -> dict[str, Any]:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    prompt_template = get_prompt_template(prompt_template_id, prompt_template_version)
+
+    jobs: list[LLMJobV1] = []
+    runs: list[ModelRunV1] = []
+    validations: list[OutputValidationV1] = []
+    audit_records: list[AuditRecordV1] = []
+    signals: list[IntelligenceSignalV1] = []
+
+    for candidate_record in candidate_records:
+        candidate_id = str(candidate_record["candidate_id"])
+        job = create_llm_job(candidate_id, prompt_template, timestamp)
+        run, output = execute_fake_model_run(job, candidate_record, prompt_template)
+        validation = validate_model_output(run.run_id, output)
+        audit_record = create_audit_record(job.job_id, run.run_id, validation.validation_id, timestamp)
+
+        jobs.append(job)
+        runs.append(run)
+        validations.append(validation)
+        audit_records.append(audit_record)
+        if validation.passed:
+            signals.append(create_signal_from_valid_output(candidate_record, output, timestamp))
+
+    provider_distribution: dict[str, int] = {}
+    prompt_versions_used: dict[str, int] = {}
+    for job in jobs:
+        provider_distribution[job.provider] = provider_distribution.get(job.provider, 0) + 1
+        prompt_versions_used[job.prompt_template_version] = prompt_versions_used.get(job.prompt_template_version, 0) + 1
+
+    return {
+        "generated_at": timestamp,
+        "jobs_created": len(jobs),
+        "runs_completed": sum(1 for run in runs if run.status == "completed"),
+        "validations_passed": sum(1 for validation in validations if validation.passed),
+        "validations_failed": sum(1 for validation in validations if not validation.passed),
+        "signals_generated": len(signals),
+        "provider_distribution": provider_distribution,
+        "prompt_versions_used": prompt_versions_used,
+        "prompt_template": serialize_dataclass(prompt_template),
+        "jobs": [serialize_dataclass(job) for job in jobs],
+        "runs": [serialize_dataclass(run) for run in runs],
+        "validations": [serialize_dataclass(validation) for validation in validations],
+        "audit_records": [serialize_dataclass(record) for record in audit_records],
+        "signals": [serialize_dataclass(signal) for signal in signals],
+        "real_llm_api_used": False,
+        "network_requests_performed": False,
+        "publishing_performed": False,
+    }
+
+
+def load_candidate_records_from_raw_fixture(path: str | pathlib.Path) -> list[dict[str, Any]]:
+    records = candidate_pipeline.load_raw_item_records(path)
+    candidate_report = candidate_pipeline.run_pipeline(records)
+    return list(candidate_report["candidates"])
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX LLM Job & Audit Foundation V1.")
+    parser.add_argument("--raw-fixture", required=True, help="Path to RawItem fixture JSON.")
+    parser.add_argument("--output", required=True, help="Path to write LLM audit report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    candidate_records = load_candidate_records_from_raw_fixture(args.raw_fixture)
+    report = run_llm_audit(candidate_records)
+    write_report(report, args.output)
+    print(
+        "[llm-audit] wrote report: "
+        f"{args.output} jobs={report['jobs_created']} "
+        f"validations_passed={report['validations_passed']} signals={report['signals_generated']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_llm_job.py
+++ b/scripts/dysonx_llm_job.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""DysonX provider-neutral LLM job structures V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class LLMJobV1:
+    job_id: str
+    candidate_id: str
+    provider: str
+    model: str
+    prompt_template_version: str
+    status: str
+    created_at: str
+
+
+@dataclass(frozen=True)
+class ModelRunV1:
+    run_id: str
+    job_id: str
+    provider: str
+    model: str
+    latency_ms: int
+    token_counts: dict[str, int] = field(default_factory=dict)
+    status: str = "completed"
+
+
+@dataclass(frozen=True)
+class OutputValidationV1:
+    validation_id: str
+    run_id: str
+    passed: bool
+    warnings: tuple[str, ...]
+    validation_rules: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class AuditRecordV1:
+    audit_id: str
+    job_id: str
+    run_id: str
+    validation_id: str
+    created_at: str

--- a/scripts/dysonx_output_validation.py
+++ b/scripts/dysonx_output_validation.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""DysonX LLM output validation V1."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+REQUIRED_INTELLIGENCE_FIELDS: tuple[str, ...] = (
+    "title",
+    "signal_type",
+    "importance",
+    "confidence",
+    "summary",
+    "key_points",
+    "affected_entities",
+    "impact_horizon",
+    "tags",
+)
+
+VALID_IMPORTANCE_VALUES: frozenset[str] = frozenset({"low", "medium", "high"})
+
+VALIDATION_RULES: tuple[str, ...] = (
+    "required fields present",
+    "confidence within range",
+    "importance value valid",
+    "summary not empty",
+)
+
+
+def validate_intelligence_output(output: dict[str, Any]) -> tuple[bool, tuple[str, ...]]:
+    warnings: list[str] = []
+
+    for field_name in REQUIRED_INTELLIGENCE_FIELDS:
+        if field_name not in output:
+            warnings.append(f"{field_name} is required")
+
+    confidence = output.get("confidence")
+    if not isinstance(confidence, int | float) or confidence < 0 or confidence > 1:
+        warnings.append("confidence must be a number from 0 to 1")
+
+    importance = output.get("importance")
+    if importance not in VALID_IMPORTANCE_VALUES:
+        allowed = ", ".join(sorted(VALID_IMPORTANCE_VALUES))
+        warnings.append(f"importance must be one of: {allowed}")
+
+    summary = output.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        warnings.append("summary must be present")
+
+    return len(warnings) == 0, tuple(warnings)

--- a/scripts/dysonx_prompt_registry.py
+++ b/scripts/dysonx_prompt_registry.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""DysonX versioned prompt registry V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromptTemplateV1:
+    template_id: str
+    template_version: str
+    purpose: str
+    template_text: str
+
+
+_PROMPT_TEMPLATES: dict[tuple[str, str], PromptTemplateV1] = {
+    (
+        "intelligence_signal_extraction",
+        "v1",
+    ): PromptTemplateV1(
+        template_id="intelligence_signal_extraction",
+        template_version="v1",
+        purpose="Transform one SignalCandidate into structured IntelligenceSignal fields.",
+        template_text=(
+            "Analyze the SignalCandidate as DysonX intelligence extraction. "
+            "Return structured fields: title, signal_type, importance, confidence, "
+            "summary, key_points, affected_entities, impact_horizon, and tags. "
+            "Do not write an article. Do not publish."
+        ),
+    )
+}
+
+
+def get_prompt_template(template_id: str, template_version: str) -> PromptTemplateV1:
+    key = (template_id, template_version)
+    if key not in _PROMPT_TEMPLATES:
+        raise KeyError(f"Unknown prompt template: {template_id}@{template_version}")
+    return _PROMPT_TEMPLATES[key]
+
+
+def list_prompt_templates() -> tuple[PromptTemplateV1, ...]:
+    return tuple(_PROMPT_TEMPLATES.values())

--- a/tests/test_dysonx_llm_audit.py
+++ b/tests/test_dysonx_llm_audit.py
@@ -1,0 +1,127 @@
+import pathlib
+import sys
+import tempfile
+import unittest
+import json
+from dataclasses import fields
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_llm_audit as audit
+from dysonx_llm_job import AuditRecordV1, LLMJobV1, ModelRunV1, OutputValidationV1
+from dysonx_output_validation import validate_intelligence_output
+from dysonx_prompt_registry import get_prompt_template, list_prompt_templates
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+FIXED_TIME = "2026-06-17T10:00:00+00:00"
+
+
+class DysonXLLMJobAuditTests(unittest.TestCase):
+    def candidate_records(self):
+        return audit.load_candidate_records_from_raw_fixture(FIXTURE_PATH)
+
+    def test_provider_neutral_job_structures_exist(self):
+        job_fields = {field.name for field in fields(LLMJobV1)}
+        run_fields = {field.name for field in fields(ModelRunV1)}
+        validation_fields = {field.name for field in fields(OutputValidationV1)}
+        audit_fields = {field.name for field in fields(AuditRecordV1)}
+
+        self.assertEqual(
+            job_fields,
+            {"job_id", "candidate_id", "provider", "model", "prompt_template_version", "status", "created_at"},
+        )
+        self.assertIn("provider", run_fields)
+        self.assertIn("model", run_fields)
+        self.assertIn("validation_rules", validation_fields)
+        self.assertIn("validation_id", audit_fields)
+
+    def test_prompt_versioning_works(self):
+        template = get_prompt_template("intelligence_signal_extraction", "v1")
+
+        self.assertEqual(template.template_version, "v1")
+        self.assertIn(template, list_prompt_templates())
+        self.assertIn("Do not write an article", template.template_text)
+
+    def test_audit_chain_remains_intact(self):
+        report = audit.run_llm_audit(self.candidate_records(), created_at=FIXED_TIME)
+
+        self.assertEqual(report["jobs_created"], 4)
+        self.assertEqual(report["runs_completed"], 4)
+        self.assertEqual(report["validations_passed"], 4)
+        self.assertEqual(report["validations_failed"], 0)
+        self.assertEqual(report["signals_generated"], 4)
+
+        job_ids = {job["job_id"] for job in report["jobs"]}
+        run_ids = {run["run_id"] for run in report["runs"]}
+        validation_ids = {validation["validation_id"] for validation in report["validations"]}
+
+        for record in report["audit_records"]:
+            self.assertIn(record["job_id"], job_ids)
+            self.assertIn(record["run_id"], run_ids)
+            self.assertIn(record["validation_id"], validation_ids)
+
+    def test_validation_failures_are_captured(self):
+        passed, warnings = validate_intelligence_output(
+            {
+                "title": "Bad output",
+                "signal_type": "model_release",
+                "importance": "urgent",
+                "confidence": 1.5,
+                "summary": "",
+            }
+        )
+
+        self.assertFalse(passed)
+        self.assertIn("importance must be one of: high, low, medium", warnings)
+        self.assertIn("confidence must be a number from 0 to 1", warnings)
+        self.assertIn("summary must be present", warnings)
+
+    def test_intelligence_signal_generation_still_works(self):
+        report = audit.run_llm_audit(self.candidate_records(), created_at=FIXED_TIME)
+        first_signal = report["signals"][0]
+
+        self.assertTrue(first_signal["signal_id"].startswith("signal_"))
+        self.assertIn("summary", first_signal)
+        self.assertIn("affected_entities", first_signal)
+        self.assertEqual(report["provider_distribution"], {"fake": 4})
+        self.assertEqual(report["prompt_versions_used"], {"v1": 4})
+
+    def test_no_provider_specific_dependency_exists(self):
+        module_source = pathlib.Path(audit.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("from anthropic", module_source)
+        self.assertNotIn("google.generativeai", module_source)
+        self.assertNotIn("import requests", module_source)
+        self.assertNotIn("from requests", module_source)
+        self.assertNotIn("import urllib", module_source)
+        self.assertNotIn("from urllib", module_source)
+
+    def test_no_network_requests_occur(self):
+        with mock.patch("socket.socket") as socket_mock:
+            report = audit.run_llm_audit(self.candidate_records(), created_at=FIXED_TIME)
+
+        socket_mock.assert_not_called()
+        self.assertFalse(report["network_requests_performed"])
+        self.assertFalse(report["real_llm_api_used"])
+        self.assertFalse(report["publishing_performed"])
+
+    def test_cli_writes_audit_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "llm_audit_report.json"
+            exit_code = audit.main(["--raw-fixture", str(FIXTURE_PATH), "--output", str(output)])
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(report["jobs_created"], 4)
+            self.assertEqual(report["validations_passed"], 4)
+            self.assertEqual(report["signals_generated"], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Introduce a provider-neutral LLM execution and audit foundation before any real model integration. This strengthens governance, observability, prompt versioning, and output validation while remaining fake-provider only.

## Scope

- Add docs/DYSONX_LLM_JOB_AUDIT_V1.md
- Add LLMJobV1, PromptTemplateV1, ModelRunV1, OutputValidationV1, and AuditRecordV1 structures
- Add a central versioned prompt registry
- Add output validation rules for required fields, confidence range, importance values, and non-empty summary
- Add deterministic fake-provider execution path
- Add LLM audit CLI and report generation
- Add tests for provider neutrality, prompt versioning, audit chain integrity, validation failures, signal generation, and no network requests

## Files Changed

- docs/DYSONX_LLM_JOB_AUDIT_V1.md
- scripts/dysonx_llm_job.py
- scripts/dysonx_prompt_registry.py
- scripts/dysonx_output_validation.py
- scripts/dysonx_llm_audit.py
- tests/test_dysonx_llm_audit.py

## Governance Compliance

- AGENTS.md and canonical DYSONX governance documents were read before implementation.
- Reviewed PR #22, #23, #24, and #25 before implementation.
- Preserves Signal-first design and strengthens the LLM Intelligence plus Observability/Audit layers.
- Adds no publishing, social posting, collectors, real provider calls, Knowledge Graph, Prediction Engine, dashboard, billing, enterprise, or multi-tenant features.
- Keeps provider execution fake-only and provider-neutral.

## Architecture Impact

Adds the V1 audit chain: Signal Candidate -> LLM Job -> Prompt Template -> Model Run -> Output Validation -> Intelligence Signal -> Audit Report. No runtime publishing path or real model path is introduced.

## Validation Results

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_llm_audit.py --raw-fixture tests/fixtures/raw_items_v1.json --output tmp/dysonx_llm_audit_report.json
- git diff --check

All passed.

## Sample Audit Report

- jobs_created: 4
- runs_completed: 4
- validations_passed: 4
- validations_failed: 0
- signals_generated: 4
- provider_distribution: fake=4
- prompt_versions_used: v1=4
- real_llm_api_used: false
- network_requests_performed: false
- publishing_performed: false

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Known Limitations

- Fake provider only.
- No provider credentials or real SDK integrations.
- No persistence layer yet; audit records are emitted in report JSON only.
- No QualityReview or publishing workflow changes.