### PR TITLE
feat: add DysonX Signal Ranking Engine V1

### DIFF
--- a/docs/DYSONX_SIGNAL_RANKING_ENGINE_V1.md
+++ b/docs/DYSONX_SIGNAL_RANKING_ENGINE_V1.md
@@ -1,0 +1,107 @@
+# DysonX Signal Scoring & Ranking Engine V1
+
+This document defines the V1 ranking layer for DysonX Intelligence Signals.
+
+The purpose is decision priority, not content volume. This layer supports the
+DysonX principle:
+
+```text
+Decision > Content
+```
+
+## Target Flow
+
+```text
+Intelligence Signal
+-> Scoring
+-> Ranking
+-> Top Signals
+-> Audit Report
+```
+
+## Scope
+
+Allowed in V1:
+
+- Read existing fake-provider IntelligenceSignal audit reports.
+- Score each IntelligenceSignal deterministically.
+- Rank signals by decision-priority composite score.
+- Return top signals.
+- Produce an audit report with scoring reasons and scope flags.
+
+Not included in V1:
+
+- Real LLM provider calls.
+- Publishing.
+- Social posting.
+- Knowledge Graph writes.
+- Prediction Engine behavior.
+- Dashboard, billing, enterprise, or multi-tenant features.
+
+## SignalScoreV1
+
+- `signal_id`
+- `importance_score`
+- `confidence_score`
+- `authority_score`
+- `freshness_score`
+- `impact_score`
+- `composite_score`
+- `scoring_version`
+- `scoring_reasons`
+- `created_at`
+
+## RankingResultV1
+
+- `ranking_id`
+- `ranked_signals`
+- `top_n`
+- `scoring_version`
+- `created_at`
+- `audit_summary`
+
+## Deterministic Scoring
+
+V1 scoring is deterministic and does not call LLM APIs.
+
+Weighted composite score:
+
+- `importance_score`: 30%
+- `authority_score`: 25%
+- `impact_score`: 20%
+- `confidence_score`: 15%
+- `freshness_score`: 10%
+
+Importance, authority, impact, confidence, and freshness each normalize to a
+`0..1` range. Missing or invalid fields receive conservative scores and are
+captured in scoring reasons instead of crashing the ranking run.
+
+## Stable Ranking
+
+Signals are sorted by:
+
+1. Composite score descending
+2. Importance score descending
+3. Confidence score descending
+4. Signal ID ascending
+
+This keeps equal-score ranking stable and auditable.
+
+## Audit Report
+
+The ranking audit report includes:
+
+- Signals seen
+- Signals ranked
+- Top N requested
+- Top N returned
+- Scoring version
+- Ranked signal entries with component scores
+- Scoring reasons
+- Confirmation that no LLM API, publishing, or social posting occurred
+
+## Governance Notes
+
+This layer is downstream of LLM Intelligence and LLM Job Audit. It does not
+bypass LLM interpretation; it ranks already-structured Intelligence Signals for
+decision priority.

--- a/scripts/dysonx_signal_ranking.py
+++ b/scripts/dysonx_signal_ranking.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""DysonX Signal Ranking Engine V1.
+
+Ranks IntelligenceSignal records for decision priority. V1 uses deterministic
+scoring only. It does not call LLM APIs, publish, post to social platforms,
+write graph data, or implement prediction features.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from typing import Any
+
+from dysonx_signal_scoring import SCORING_VERSION, SignalScoreV1, parse_timestamp, score_signal, serialize_score
+
+
+@dataclass(frozen=True)
+class RankingResultV1:
+    ranking_id: str
+    ranked_signals: tuple[dict[str, Any], ...]
+    top_n: int
+    scoring_version: str
+    created_at: str
+    audit_summary: dict[str, Any]
+
+
+def load_intelligence_report(path: str | pathlib.Path) -> dict[str, Any]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Intelligence report must be a JSON object")
+    if not isinstance(data.get("signals"), list):
+        raise ValueError("Intelligence report must contain a signals list")
+    return data
+
+
+def reference_time_for_signals(signals: list[dict[str, Any]]) -> datetime | None:
+    timestamps = [parse_timestamp(signal.get("created_at")) for signal in signals]
+    valid_timestamps = [timestamp for timestamp in timestamps if timestamp is not None]
+    if not valid_timestamps:
+        return None
+    return max(valid_timestamps)
+
+
+def sort_ranked_signals(ranked_signals: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        ranked_signals,
+        key=lambda item: (
+            -float(item["score"]["composite_score"]),
+            -float(item["score"]["importance_score"]),
+            -float(item["score"]["confidence_score"]),
+            str(item["signal"].get("signal_id", "")),
+        ),
+    )
+
+
+def ranking_id_for(created_at: str, scores: list[SignalScoreV1]) -> str:
+    seed = "|".join([created_at, *[score.signal_id for score in scores]])
+    digest = hashlib.sha256(seed.encode("utf-8")).hexdigest()
+    return f"ranking_{digest[:16]}"
+
+
+def rank_signals(signals: list[dict[str, Any]], top_n: int, created_at: str | None = None) -> RankingResultV1:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    reference_time = reference_time_for_signals(signals)
+    scored = [score_signal(signal, reference_time=reference_time, created_at=timestamp) for signal in signals]
+    ranked = sort_ranked_signals(
+        [
+            {
+                "rank": 0,
+                "signal": signal,
+                "score": serialize_score(score),
+            }
+            for signal, score in zip(signals, scored, strict=True)
+        ]
+    )
+
+    limited = ranked[: max(0, top_n)]
+    for index, item in enumerate(limited, start=1):
+        item["rank"] = index
+
+    audit_summary = {
+        "signals_seen": len(signals),
+        "signals_ranked": len(ranked),
+        "top_n": top_n,
+        "returned": len(limited),
+        "scoring_version": SCORING_VERSION,
+        "llm_used": False,
+        "publishing_performed": False,
+        "social_posting_performed": False,
+        "invalid_or_missing_fields_handled": any(
+            any("missing or invalid" in reason for reason in score.scoring_reasons) for score in scored
+        ),
+    }
+
+    return RankingResultV1(
+        ranking_id=ranking_id_for(timestamp, scored),
+        ranked_signals=tuple(limited),
+        top_n=top_n,
+        scoring_version=SCORING_VERSION,
+        created_at=timestamp,
+        audit_summary=audit_summary,
+    )
+
+
+def ranking_result_to_report(result: RankingResultV1) -> dict[str, Any]:
+    return {
+        **asdict(result),
+        "ranked_signals": list(result.ranked_signals),
+        "real_llm_api_used": False,
+        "network_requests_performed": False,
+        "publishing_performed": False,
+        "social_posting_performed": False,
+    }
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Signal Ranking Engine V1.")
+    parser.add_argument("--intelligence-report", required=True, help="Path to LLM audit/intelligence report JSON.")
+    parser.add_argument("--output", required=True, help="Path to write signal ranking audit report JSON.")
+    parser.add_argument("--top-n", type=int, default=10, help="Number of ranked signals to return.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    intelligence_report = load_intelligence_report(args.intelligence_report)
+    result = rank_signals(intelligence_report["signals"], top_n=args.top_n)
+    report = ranking_result_to_report(result)
+    write_report(report, args.output)
+    print(
+        "[signal-ranking] wrote report: "
+        f"{args.output} ranked={report['audit_summary']['returned']} top_n={args.top_n}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_signal_scoring.py
+++ b/scripts/dysonx_signal_scoring.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""DysonX Signal Scoring Engine V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from typing import Any
+
+
+SCORING_VERSION = "dysonx-signal-score-v1"
+
+SCORING_WEIGHTS: dict[str, float] = {
+    "importance_score": 0.30,
+    "authority_score": 0.25,
+    "impact_score": 0.20,
+    "confidence_score": 0.15,
+    "freshness_score": 0.10,
+}
+
+IMPORTANCE_VALUES: dict[str, float] = {
+    "high": 1.0,
+    "medium": 0.65,
+    "low": 0.3,
+}
+
+SIGNAL_TYPE_IMPACT_VALUES: dict[str, float] = {
+    "model_release": 0.9,
+    "regulation": 0.9,
+    "research_update": 0.75,
+    "company_announcement": 0.65,
+    "general_signal": 0.4,
+}
+
+HIGH_AUTHORITY_SOURCES = (
+    "openai",
+    "anthropic",
+    "deepmind",
+    "ai office",
+    "government",
+    "research",
+)
+
+
+@dataclass(frozen=True)
+class SignalScoreV1:
+    signal_id: str
+    importance_score: float
+    confidence_score: float
+    authority_score: float
+    freshness_score: float
+    impact_score: float
+    composite_score: float
+    scoring_version: str
+    scoring_reasons: tuple[str, ...]
+    created_at: str
+
+
+def clamp_score(value: float) -> float:
+    return round(max(0.0, min(1.0, value)), 4)
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def score_importance(signal: dict[str, Any]) -> tuple[float, str]:
+    importance = str(signal.get("importance", "")).lower()
+    if importance in IMPORTANCE_VALUES:
+        return IMPORTANCE_VALUES[importance], f"importance={importance}"
+    return 0.0, "importance missing or invalid"
+
+
+def score_confidence(signal: dict[str, Any]) -> tuple[float, str]:
+    confidence = signal.get("confidence")
+    if isinstance(confidence, int | float):
+        score = clamp_score(float(confidence))
+        return score, f"confidence={score:.2f}"
+    return 0.0, "confidence missing or invalid"
+
+
+def score_authority(signal: dict[str, Any]) -> tuple[float, str]:
+    source_text = f"{signal.get('source_id', '')} {signal.get('source_name', '')}".lower()
+    if any(source in source_text for source in HIGH_AUTHORITY_SOURCES):
+        return 0.9, "high-authority first-source pattern"
+    if source_text.strip():
+        return 0.55, "known source without high-authority pattern"
+    return 0.0, "source missing"
+
+
+def score_impact(signal: dict[str, Any]) -> tuple[float, str]:
+    signal_type = str(signal.get("signal_type", "")).lower()
+    base = SIGNAL_TYPE_IMPACT_VALUES.get(signal_type, 0.35)
+    entities = signal.get("affected_entities")
+    entity_bonus = 0.05 if isinstance(entities, list | tuple) and len(entities) > 0 else 0.0
+    score = clamp_score(base + entity_bonus)
+    return score, f"impact={signal_type or 'unknown'}"
+
+
+def score_freshness(signal: dict[str, Any], reference_time: datetime | None) -> tuple[float, str]:
+    created_at = parse_timestamp(signal.get("created_at"))
+    if created_at is None or reference_time is None:
+        return 0.5, "freshness timestamp missing or invalid"
+
+    age_days = max(0.0, (reference_time - created_at).total_seconds() / 86400)
+    if age_days <= 1:
+        return 1.0, "freshness<=1d"
+    if age_days <= 7:
+        return 0.75, "freshness<=7d"
+    if age_days <= 30:
+        return 0.5, "freshness<=30d"
+    return 0.2, "freshness>30d"
+
+
+def calculate_composite_score(
+    importance_score: float,
+    authority_score: float,
+    impact_score: float,
+    confidence_score: float,
+    freshness_score: float,
+) -> float:
+    composite = (
+        importance_score * SCORING_WEIGHTS["importance_score"]
+        + authority_score * SCORING_WEIGHTS["authority_score"]
+        + impact_score * SCORING_WEIGHTS["impact_score"]
+        + confidence_score * SCORING_WEIGHTS["confidence_score"]
+        + freshness_score * SCORING_WEIGHTS["freshness_score"]
+    )
+    return round(composite, 4)
+
+
+def score_signal(signal: dict[str, Any], reference_time: datetime | None = None, created_at: str | None = None) -> SignalScoreV1:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    signal_id = str(signal.get("signal_id") or "unknown_signal")
+
+    importance_score, importance_reason = score_importance(signal)
+    confidence_score, confidence_reason = score_confidence(signal)
+    authority_score, authority_reason = score_authority(signal)
+    freshness_score, freshness_reason = score_freshness(signal, reference_time)
+    impact_score, impact_reason = score_impact(signal)
+    composite_score = calculate_composite_score(
+        importance_score=importance_score,
+        authority_score=authority_score,
+        impact_score=impact_score,
+        confidence_score=confidence_score,
+        freshness_score=freshness_score,
+    )
+
+    return SignalScoreV1(
+        signal_id=signal_id,
+        importance_score=importance_score,
+        confidence_score=confidence_score,
+        authority_score=authority_score,
+        freshness_score=freshness_score,
+        impact_score=impact_score,
+        composite_score=composite_score,
+        scoring_version=SCORING_VERSION,
+        scoring_reasons=(
+            importance_reason,
+            authority_reason,
+            impact_reason,
+            confidence_reason,
+            freshness_reason,
+        ),
+        created_at=timestamp,
+    )
+
+
+def serialize_score(score: SignalScoreV1) -> dict[str, Any]:
+    data = asdict(score)
+    data["scoring_reasons"] = list(score.scoring_reasons)
+    return data

--- a/tests/test_dysonx_signal_ranking.py
+++ b/tests/test_dysonx_signal_ranking.py
@@ -1,0 +1,118 @@
+import copy
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_llm_audit as llm_audit
+import dysonx_signal_ranking as ranking
+import dysonx_signal_scoring as scoring
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+FIXED_TIME = "2026-06-17T10:00:00+00:00"
+
+
+class DysonXSignalRankingTests(unittest.TestCase):
+    def intelligence_signals(self):
+        candidate_records = llm_audit.load_candidate_records_from_raw_fixture(FIXTURE_PATH)
+        return llm_audit.run_llm_audit(candidate_records, created_at=FIXED_TIME)["signals"]
+
+    def test_scoring_is_deterministic(self):
+        signal = self.intelligence_signals()[0]
+        reference_time = scoring.parse_timestamp(FIXED_TIME)
+
+        first = scoring.score_signal(signal, reference_time=reference_time, created_at=FIXED_TIME)
+        second = scoring.score_signal(signal, reference_time=reference_time, created_at=FIXED_TIME)
+
+        self.assertEqual(first, second)
+
+    def test_composite_score_is_calculated_correctly(self):
+        score = scoring.calculate_composite_score(
+            importance_score=1.0,
+            authority_score=0.9,
+            impact_score=0.95,
+            confidence_score=0.75,
+            freshness_score=1.0,
+        )
+
+        self.assertEqual(score, 0.9275)
+
+    def test_ranking_order_is_stable(self):
+        signals = self.intelligence_signals()
+        first = ranking.rank_signals(signals, top_n=10, created_at=FIXED_TIME)
+        second = ranking.rank_signals(signals, top_n=10, created_at=FIXED_TIME)
+
+        first_ids = [item["signal"]["signal_id"] for item in first.ranked_signals]
+        second_ids = [item["signal"]["signal_id"] for item in second.ranked_signals]
+
+        self.assertEqual(first_ids, second_ids)
+        self.assertEqual(first.ranked_signals[0]["rank"], 1)
+
+    def test_low_confidence_signals_rank_lower(self):
+        signals = self.intelligence_signals()
+        low_confidence = copy.deepcopy(signals[0])
+        low_confidence["signal_id"] = "signal_low_confidence"
+        low_confidence["confidence"] = 0.05
+        comparison = [signals[0], low_confidence]
+
+        result = ranking.rank_signals(comparison, top_n=2, created_at=FIXED_TIME)
+        ranked_ids = [item["signal"]["signal_id"] for item in result.ranked_signals]
+
+        self.assertEqual(ranked_ids[-1], "signal_low_confidence")
+
+    def test_missing_invalid_scoring_fields_are_handled_safely(self):
+        invalid_signal = {
+            "signal_id": "signal_invalid",
+            "importance": "urgent",
+            "confidence": "unknown",
+            "signal_type": "",
+            "source_id": "",
+            "source_name": "",
+            "created_at": "not-a-date",
+        }
+
+        result = ranking.rank_signals([invalid_signal], top_n=1, created_at=FIXED_TIME)
+        ranked = result.ranked_signals[0]
+
+        self.assertEqual(ranked["score"]["composite_score"], 0.12)
+        self.assertTrue(result.audit_summary["invalid_or_missing_fields_handled"])
+        self.assertIn("importance missing or invalid", ranked["score"]["scoring_reasons"])
+
+    def test_no_llm_publishing_or_social_posting_occurs(self):
+        signals = self.intelligence_signals()
+        result = ranking.rank_signals(signals, top_n=10, created_at=FIXED_TIME)
+        report = ranking.ranking_result_to_report(result)
+        module_source = pathlib.Path(ranking.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertFalse(report["real_llm_api_used"])
+        self.assertFalse(report["publishing_performed"])
+        self.assertFalse(report["social_posting_performed"])
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("from anthropic", module_source)
+        self.assertNotIn("google.generativeai", module_source)
+
+    def test_cli_writes_ranking_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_output = pathlib.Path(tmpdir) / "llm_audit.json"
+            ranking_output = pathlib.Path(tmpdir) / "ranking.json"
+            llm_audit.main(["--raw-fixture", str(FIXTURE_PATH), "--output", str(audit_output)])
+            exit_code = ranking.main(
+                ["--intelligence-report", str(audit_output), "--output", str(ranking_output), "--top-n", "10"]
+            )
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(ranking_output.read_text(encoding="utf-8"))
+            self.assertEqual(report["audit_summary"]["signals_seen"], 4)
+            self.assertEqual(report["audit_summary"]["returned"], 4)
+            self.assertEqual(report["top_n"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add DysonX Signal Scoring & Ranking Engine V1 to transform IntelligenceSignal records into ranked decision-priority signals. This supports the Constitution principle: Decision > Content.

## Scope

- Add docs/DYSONX_SIGNAL_RANKING_ENGINE_V1.md
- Add SignalScoreV1 and deterministic scoring rules
- Add RankingResultV1 and stable ranking logic
- Add CLI for ranking reports from LLM audit/intelligence reports
- Add tests for deterministic scoring, composite score math, stable ordering, low-confidence handling, invalid field safety, and no LLM/publishing/social behavior

## Files Changed

- docs/DYSONX_SIGNAL_RANKING_ENGINE_V1.md
- scripts/dysonx_signal_scoring.py
- scripts/dysonx_signal_ranking.py
- tests/test_dysonx_signal_ranking.py

## Governance Compliance

- AGENTS.md and all canonical DYSONX governance documents were reviewed before implementation.
- Reviewed PR #22, #23, #24, #25, and #26 before implementation.
- Keeps the pipeline downstream of LLM Intelligence and LLM Job Audit.
- Supports Decision > Content by ranking structured Intelligence Signals for decision priority.
- Adds no real LLM provider integration, publishing, social posting, Knowledge Graph, Prediction Engine, dashboard, billing, enterprise, or multi-tenant features.

## Architecture Impact

Adds the deterministic V1 ranking layer: Intelligence Signal -> Scoring -> Ranking -> Top Signals -> Audit Report. It does not bypass LLM interpretation and does not introduce public distribution paths.

## Validation Results

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_llm_audit.py --raw-fixture tests/fixtures/raw_items_v1.json --output tmp/dysonx_llm_audit_report.json
- python3 scripts/dysonx_signal_ranking.py --intelligence-report tmp/dysonx_llm_audit_report.json --output tmp/dysonx_signal_ranking_report.json --top-n 10
- git diff --check

All passed.

## Sample Ranking Report

- signals_seen: 4
- signals_ranked: 4
- returned: 4
- top_n: 10
- scoring_version: dysonx-signal-score-v1
- rank 1: EU AI Act regulation signal, composite_score=0.9275
- rank 2: OpenAI model release signal, composite_score=0.9275
- rank 3: Google DeepMind research update, composite_score=0.7925
- rank 4: Anthropic company announcement, composite_score=0.7725
- real_llm_api_used: false
- publishing_performed: false
- social_posting_performed: false

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Known Limitations

- V1 scoring is deterministic and intentionally simple.
- Authority scoring uses conservative source-name/source-id patterns until source authority history is available.
- No Knowledge Graph, Prediction Engine, publishing, or social distribution integration is included.