### PR TITLE
feat: add DysonX Quality Review Gate V1

### DIFF
--- a/docs/DYSONX_QUALITY_REVIEW_GATE_V1.md
+++ b/docs/DYSONX_QUALITY_REVIEW_GATE_V1.md
@@ -1,0 +1,105 @@
+# DysonX Quality Review Gate V1
+
+This document defines the deterministic V1 quality gate for ranked DysonX
+Intelligence Signals.
+
+This is pre-publishing. It does not publish pages or post to social platforms.
+
+## Target Flow
+
+```text
+Ranked Intelligence Signal
+-> Quality Review Gate
+-> Publish Eligibility Decision
+-> Audit Report
+```
+
+## Scope
+
+Allowed in V1:
+
+- Read ranking reports from Signal Ranking Engine V1.
+- Evaluate each ranked Intelligence Signal with deterministic checks.
+- Classify each signal as `publish_ready`, `needs_review`, or `rejected`.
+- Produce publish eligibility records.
+- Produce an audit report.
+
+Not included in V1:
+
+- Page publishing.
+- Social posting.
+- Real LLM provider calls.
+- Knowledge Graph writes.
+- Prediction Engine behavior.
+- Dashboard, billing, enterprise, or multi-tenant features.
+
+## QualityReviewV1
+
+- `review_id`
+- `signal_id`
+- `ranking_id`
+- `status`
+- `decision`
+- `reasons`
+- `required_fields_checked`
+- `failed_checks`
+- `reviewer_type`
+- `created_at`
+
+## PublishEligibilityV1
+
+- `signal_id`
+- `eligible`
+- `eligibility_status`
+- `reasons`
+- `required_manual_review`
+- `created_at`
+
+## Deterministic Rules
+
+A signal can be `publish_ready` only if:
+
+- `source_id` exists.
+- `source_name` exists.
+- `title` exists.
+- `summary` exists.
+- `confidence_score >= 0.70`.
+- `composite_score >= 0.70`.
+- Importance is valid.
+- No validation failure exists.
+- No unsupported-claim warning exists.
+- No duplicate warning exists.
+
+A signal must be `needs_review` if:
+
+- Confidence is between `0.50` and `0.70`.
+- Composite score is between `0.50` and `0.70`.
+- Important fields are present but weak.
+- Warnings exist but are not fatal.
+
+A signal must be `rejected` if:
+
+- Source attribution is missing.
+- Summary is missing.
+- Confidence is below `0.50`.
+- Composite score is below `0.50`.
+- Validation failed.
+- Duplicate warning is fatal.
+
+## Audit Report
+
+The quality review report includes:
+
+- Ranking ID.
+- Signals reviewed.
+- Status counts.
+- Quality review records.
+- Publish eligibility records.
+- Confirmation that no publishing, social posting, real LLM API call, or network
+  request occurred.
+
+## Governance Notes
+
+This gate protects DysonX from publishing thin, unsupported, duplicated, or
+low-confidence content. It strengthens the Quality Gate layer while remaining
+pre-publishing and deterministic.

--- a/scripts/dysonx_publish_eligibility.py
+++ b/scripts/dysonx_publish_eligibility.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""DysonX Publish Eligibility V1.
+
+Converts ranked Intelligence Signals into deterministic pre-publishing
+eligibility decisions. This module does not publish pages, post to social
+platforms, call real LLM providers, or write to external systems.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from dysonx_quality_review import QualityReviewV1, review_ranked_signal, serialize_review
+
+
+@dataclass(frozen=True)
+class PublishEligibilityV1:
+    signal_id: str
+    eligible: bool
+    eligibility_status: str
+    reasons: tuple[str, ...]
+    required_manual_review: bool
+    created_at: str
+
+
+def load_ranking_report(path: str | pathlib.Path) -> dict[str, Any]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Ranking report must be a JSON object")
+    if not isinstance(data.get("ranked_signals"), list):
+        raise ValueError("Ranking report must contain ranked_signals")
+    return data
+
+
+def eligibility_from_review(review: QualityReviewV1) -> PublishEligibilityV1:
+    eligible = review.decision == "publish_ready"
+    required_manual_review = review.decision == "needs_review"
+    return PublishEligibilityV1(
+        signal_id=review.signal_id,
+        eligible=eligible,
+        eligibility_status=review.decision,
+        reasons=review.reasons,
+        required_manual_review=required_manual_review,
+        created_at=review.created_at,
+    )
+
+
+def serialize_eligibility(eligibility: PublishEligibilityV1) -> dict[str, Any]:
+    data = asdict(eligibility)
+    data["reasons"] = list(eligibility.reasons)
+    return data
+
+
+def run_quality_review(ranking_report: dict[str, Any], created_at: str | None = None) -> dict[str, Any]:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    ranking_id = str(ranking_report.get("ranking_id") or "unknown_ranking")
+    ranked_signals = ranking_report["ranked_signals"]
+
+    reviews = [review_ranked_signal(item, ranking_id=ranking_id, created_at=timestamp) for item in ranked_signals]
+    eligibilities = [eligibility_from_review(review) for review in reviews]
+
+    status_counts: dict[str, int] = {"publish_ready": 0, "needs_review": 0, "rejected": 0}
+    for review in reviews:
+        status_counts[review.status] = status_counts.get(review.status, 0) + 1
+
+    return {
+        "generated_at": timestamp,
+        "ranking_id": ranking_id,
+        "signals_reviewed": len(reviews),
+        "status_counts": status_counts,
+        "reviews": [serialize_review(review) for review in reviews],
+        "eligibilities": [serialize_eligibility(eligibility) for eligibility in eligibilities],
+        "publishing_performed": False,
+        "social_posting_performed": False,
+        "real_llm_api_used": False,
+        "network_requests_performed": False,
+    }
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Quality Review Gate V1.")
+    parser.add_argument("--ranking-report", required=True, help="Path to Signal Ranking report JSON.")
+    parser.add_argument("--output", required=True, help="Path to write quality review report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    ranking_report = load_ranking_report(args.ranking_report)
+    report = run_quality_review(ranking_report)
+    write_report(report, args.output)
+    print(
+        "[quality-review] wrote report: "
+        f"{args.output} reviewed={report['signals_reviewed']} "
+        f"publish_ready={report['status_counts'].get('publish_ready', 0)} "
+        f"needs_review={report['status_counts'].get('needs_review', 0)} "
+        f"rejected={report['status_counts'].get('rejected', 0)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_quality_review.py
+++ b/scripts/dysonx_quality_review.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""DysonX Quality Review Gate V1."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+
+VALID_IMPORTANCE_VALUES = frozenset({"low", "medium", "high"})
+QUALITY_GATE_VERSION = "dysonx-quality-review-v1"
+
+
+@dataclass(frozen=True)
+class QualityReviewV1:
+    review_id: str
+    signal_id: str
+    ranking_id: str
+    status: str
+    decision: str
+    reasons: tuple[str, ...]
+    required_fields_checked: tuple[str, ...]
+    failed_checks: tuple[str, ...]
+    reviewer_type: str
+    created_at: str
+
+
+def stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:16]}"
+
+
+def has_text(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def warnings_for_ranked_signal(ranked_signal: dict[str, Any]) -> list[str]:
+    warnings: list[str] = []
+    signal = ranked_signal.get("signal", {})
+    score = ranked_signal.get("score", {})
+
+    for source in (signal, score, ranked_signal):
+        raw_warnings = source.get("warnings")
+        if isinstance(raw_warnings, list):
+            warnings.extend(str(warning).lower() for warning in raw_warnings)
+
+    return warnings
+
+
+def review_ranked_signal(
+    ranked_signal: dict[str, Any],
+    ranking_id: str,
+    created_at: str | None = None,
+) -> QualityReviewV1:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    signal = ranked_signal.get("signal", {})
+    score = ranked_signal.get("score", {})
+
+    signal_id = str(signal.get("signal_id") or score.get("signal_id") or "unknown_signal")
+    confidence_score = score.get("confidence_score", signal.get("confidence"))
+    composite_score = score.get("composite_score")
+    importance = str(signal.get("importance", "")).lower()
+    warnings = warnings_for_ranked_signal(ranked_signal)
+
+    required_fields = (
+        "source_id",
+        "source_name",
+        "title",
+        "summary",
+        "confidence_score",
+        "composite_score",
+        "importance",
+    )
+
+    failed_checks: list[str] = []
+    reasons: list[str] = []
+
+    if not has_text(signal.get("source_id")):
+        failed_checks.append("source_id")
+        reasons.append("missing source attribution")
+    if not has_text(signal.get("source_name")):
+        failed_checks.append("source_name")
+        reasons.append("missing source attribution")
+    if not has_text(signal.get("title")):
+        failed_checks.append("title")
+        reasons.append("missing title")
+    if not has_text(signal.get("summary")):
+        failed_checks.append("summary")
+        reasons.append("missing summary")
+
+    if not isinstance(confidence_score, int | float):
+        failed_checks.append("confidence_score")
+        reasons.append("confidence score missing or invalid")
+        confidence_value = 0.0
+    else:
+        confidence_value = float(confidence_score)
+
+    if not isinstance(composite_score, int | float):
+        failed_checks.append("composite_score")
+        reasons.append("composite score missing or invalid")
+        composite_value = 0.0
+    else:
+        composite_value = float(composite_score)
+
+    if importance not in VALID_IMPORTANCE_VALUES:
+        failed_checks.append("importance")
+        reasons.append("importance missing or invalid")
+
+    validation_failed = any("validation failed" in warning for warning in warnings)
+    unsupported_claim = any("unsupported_claim" in warning or "unsupported claim" in warning for warning in warnings)
+    duplicate_warning = any("duplicate" in warning for warning in warnings)
+    duplicate_fatal = any("duplicate fatal" in warning or "fatal duplicate" in warning for warning in warnings)
+
+    if validation_failed:
+        failed_checks.append("validation")
+        reasons.append("validation failed")
+    if unsupported_claim:
+        failed_checks.append("unsupported_claim")
+        reasons.append("unsupported claim warning")
+    if duplicate_warning:
+        reasons.append("duplicate warning")
+    if duplicate_fatal:
+        failed_checks.append("duplicate")
+        reasons.append("duplicate warning is fatal")
+
+    fatal_failure = (
+        "source_id" in failed_checks
+        or "source_name" in failed_checks
+        or "summary" in failed_checks
+        or confidence_value < 0.50
+        or composite_value < 0.50
+        or validation_failed
+        or duplicate_fatal
+    )
+
+    if confidence_value < 0.50:
+        reasons.append("confidence below rejection threshold")
+    if composite_value < 0.50:
+        reasons.append("composite score below rejection threshold")
+
+    if fatal_failure:
+        status = "rejected"
+        decision = "rejected"
+    elif confidence_value >= 0.70 and composite_value >= 0.70 and not unsupported_claim and not duplicate_warning:
+        status = "publish_ready"
+        decision = "publish_ready"
+        reasons.append("passed deterministic publish readiness checks")
+    else:
+        status = "needs_review"
+        decision = "needs_review"
+        if 0.50 <= confidence_value < 0.70:
+            reasons.append("confidence requires manual review")
+        if 0.50 <= composite_value < 0.70:
+            reasons.append("composite score requires manual review")
+        if unsupported_claim or duplicate_warning:
+            reasons.append("non-fatal warning requires manual review")
+        if not reasons:
+            reasons.append("important fields present but weak")
+
+    return QualityReviewV1(
+        review_id=stable_id("quality_review", ranking_id, signal_id, timestamp),
+        signal_id=signal_id,
+        ranking_id=ranking_id,
+        status=status,
+        decision=decision,
+        reasons=tuple(dict.fromkeys(reasons)),
+        required_fields_checked=required_fields,
+        failed_checks=tuple(dict.fromkeys(failed_checks)),
+        reviewer_type="deterministic_v1",
+        created_at=timestamp,
+    )
+
+
+def serialize_review(review: QualityReviewV1) -> dict[str, Any]:
+    data = asdict(review)
+    data["reasons"] = list(review.reasons)
+    data["required_fields_checked"] = list(review.required_fields_checked)
+    data["failed_checks"] = list(review.failed_checks)
+    return data

--- a/tests/test_dysonx_quality_review.py
+++ b/tests/test_dysonx_quality_review.py
@@ -1,0 +1,139 @@
+import copy
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_llm_audit as llm_audit
+import dysonx_publish_eligibility as publish_eligibility
+import dysonx_signal_ranking as ranking
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+FIXED_TIME = "2026-06-17T10:00:00+00:00"
+
+
+class DysonXQualityReviewTests(unittest.TestCase):
+    def ranking_report(self):
+        candidate_records = llm_audit.load_candidate_records_from_raw_fixture(FIXTURE_PATH)
+        audit_report = llm_audit.run_llm_audit(candidate_records, created_at=FIXED_TIME)
+        result = ranking.rank_signals(audit_report["signals"], top_n=10, created_at=FIXED_TIME)
+        return ranking.ranking_result_to_report(result)
+
+    def high_quality_ranked_signal(self):
+        return self.ranking_report()["ranked_signals"][0]
+
+    def test_high_quality_ranked_signal_becomes_publish_ready(self):
+        report = publish_eligibility.run_quality_review(
+            {"ranking_id": "ranking_test", "ranked_signals": [self.high_quality_ranked_signal()]},
+            created_at=FIXED_TIME,
+        )
+
+        self.assertEqual(report["status_counts"]["publish_ready"], 1)
+        self.assertTrue(report["eligibilities"][0]["eligible"])
+        self.assertEqual(report["eligibilities"][0]["eligibility_status"], "publish_ready")
+
+    def test_weak_signal_becomes_needs_review(self):
+        weak = copy.deepcopy(self.high_quality_ranked_signal())
+        weak["score"]["confidence_score"] = 0.65
+        weak["signal"]["confidence"] = 0.65
+
+        report = publish_eligibility.run_quality_review(
+            {"ranking_id": "ranking_test", "ranked_signals": [weak]},
+            created_at=FIXED_TIME,
+        )
+
+        self.assertEqual(report["status_counts"]["needs_review"], 1)
+        self.assertTrue(report["eligibilities"][0]["required_manual_review"])
+
+    def test_invalid_signal_becomes_rejected(self):
+        invalid = copy.deepcopy(self.high_quality_ranked_signal())
+        invalid["score"]["confidence_score"] = 0.2
+        invalid["score"]["composite_score"] = 0.2
+
+        report = publish_eligibility.run_quality_review(
+            {"ranking_id": "ranking_test", "ranked_signals": [invalid]},
+            created_at=FIXED_TIME,
+        )
+
+        self.assertEqual(report["status_counts"]["rejected"], 1)
+        self.assertFalse(report["eligibilities"][0]["eligible"])
+
+    def test_missing_source_attribution_blocks_publish_ready(self):
+        missing_source = copy.deepcopy(self.high_quality_ranked_signal())
+        missing_source["signal"]["source_id"] = ""
+
+        report = publish_eligibility.run_quality_review(
+            {"ranking_id": "ranking_test", "ranked_signals": [missing_source]},
+            created_at=FIXED_TIME,
+        )
+
+        self.assertEqual(report["reviews"][0]["decision"], "rejected")
+        self.assertIn("source_id", report["reviews"][0]["failed_checks"])
+
+    def test_missing_summary_blocks_publish_ready(self):
+        missing_summary = copy.deepcopy(self.high_quality_ranked_signal())
+        missing_summary["signal"]["summary"] = ""
+
+        report = publish_eligibility.run_quality_review(
+            {"ranking_id": "ranking_test", "ranked_signals": [missing_summary]},
+            created_at=FIXED_TIME,
+        )
+
+        self.assertEqual(report["reviews"][0]["decision"], "rejected")
+        self.assertIn("summary", report["reviews"][0]["failed_checks"])
+
+    def test_duplicate_fatal_warning_blocks_publish_ready(self):
+        duplicate = copy.deepcopy(self.high_quality_ranked_signal())
+        duplicate["warnings"] = ["duplicate fatal"]
+
+        report = publish_eligibility.run_quality_review(
+            {"ranking_id": "ranking_test", "ranked_signals": [duplicate]},
+            created_at=FIXED_TIME,
+        )
+
+        self.assertEqual(report["reviews"][0]["decision"], "rejected")
+        self.assertIn("duplicate", report["reviews"][0]["failed_checks"])
+
+    def test_review_report_is_deterministic(self):
+        ranking_report = self.ranking_report()
+        first = publish_eligibility.run_quality_review(ranking_report, created_at=FIXED_TIME)
+        second = publish_eligibility.run_quality_review(ranking_report, created_at=FIXED_TIME)
+
+        self.assertEqual(first, second)
+
+    def test_no_publishing_social_posting_or_real_llm_calls_occur(self):
+        report = publish_eligibility.run_quality_review(self.ranking_report(), created_at=FIXED_TIME)
+        module_source = pathlib.Path(publish_eligibility.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertFalse(report["publishing_performed"])
+        self.assertFalse(report["social_posting_performed"])
+        self.assertFalse(report["real_llm_api_used"])
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("from anthropic", module_source)
+
+    def test_cli_writes_quality_review_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_output = pathlib.Path(tmpdir) / "llm_audit.json"
+            ranking_output = pathlib.Path(tmpdir) / "ranking.json"
+            quality_output = pathlib.Path(tmpdir) / "quality.json"
+
+            llm_audit.main(["--raw-fixture", str(FIXTURE_PATH), "--output", str(audit_output)])
+            ranking.main(["--intelligence-report", str(audit_output), "--output", str(ranking_output), "--top-n", "10"])
+            exit_code = publish_eligibility.main(["--ranking-report", str(ranking_output), "--output", str(quality_output)])
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(quality_output.read_text(encoding="utf-8"))
+            self.assertEqual(report["signals_reviewed"], 4)
+            self.assertEqual(report["status_counts"]["publish_ready"], 4)
+            self.assertFalse(report["publishing_performed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add DysonX Quality Review Gate V1 to classify ranked Intelligence Signals as publish_ready, needs_review, or rejected before any publishing work exists.

## Scope

- Add docs/DYSONX_QUALITY_REVIEW_GATE_V1.md
- Add QualityReviewV1 deterministic review records
- Add PublishEligibilityV1 eligibility decisions
- Add CLI for quality review reports from ranking reports
- Add tests for publish-ready, needs-review, rejected, missing attribution, missing summary, fatal duplicate warnings, determinism, and no publishing/social/real LLM behavior

## Files Changed

- docs/DYSONX_QUALITY_REVIEW_GATE_V1.md
- scripts/dysonx_quality_review.py
- scripts/dysonx_publish_eligibility.py
- tests/test_dysonx_quality_review.py

## Governance Compliance

- AGENTS.md and all canonical DYSONX governance documents were reviewed before implementation.
- Reviewed PR #22, #23, #24, #25, #26, and #27 before implementation.
- Adds a deterministic pre-publishing quality gate, which strengthens governance and protects against thin, unsupported, duplicated, or low-confidence content.
- Does not publish pages, post to social platforms, call real LLM providers, write Knowledge Graph data, implement Prediction Engine, dashboard, billing, enterprise, or multi-tenant features.

## Architecture Impact

Adds the V1 pre-publishing quality gate: Ranked Intelligence Signal -> Quality Review Gate -> Publish Eligibility Decision -> Audit Report. No publish path is introduced.

## Validation Results

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_llm_audit.py --raw-fixture tests/fixtures/raw_items_v1.json --output tmp/dysonx_llm_audit_report.json
- python3 scripts/dysonx_signal_ranking.py --intelligence-report tmp/dysonx_llm_audit_report.json --output tmp/dysonx_signal_ranking_report.json --top-n 10
- python3 scripts/dysonx_publish_eligibility.py --ranking-report tmp/dysonx_signal_ranking_report.json --output tmp/dysonx_quality_review_report.json
- git diff --check

All passed.

## Sample Quality Review Report

- signals_reviewed: 4
- publish_ready: 4
- needs_review: 0
- rejected: 0
- publishing_performed: false
- social_posting_performed: false
- real_llm_api_used: false
- network_requests_performed: false

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Known Limitations

- V1 is deterministic and pre-publishing only.
- No human review UI or workflow is added.
- No publishing, social posting, Knowledge Graph, or Prediction Engine integration is included.