### PR TITLE
feat: add DysonX Publish Package V1

### DIFF
--- a/docs/DYSONX_PUBLISH_PACKAGE_V1.md
+++ b/docs/DYSONX_PUBLISH_PACKAGE_V1.md
@@ -1,0 +1,102 @@
+# DysonX Publish Package V1
+
+This document defines the V1 publish package layer for DysonX.
+
+This is still pre-publishing. It creates structured package metadata only. It
+does not write website pages, write public content files, publish pages, or post
+to social platforms.
+
+## Target Flow
+
+```text
+Publish-Ready Signal
+-> Publish Package
+-> SEO Metadata
+-> Social Draft Metadata
+-> Audit Report
+```
+
+## Scope
+
+Allowed in V1:
+
+- Read quality review reports.
+- Convert only `publish_ready` Intelligence Signals into publish packages.
+- Generate deterministic slugs from titles.
+- Generate SEO metadata.
+- Generate social draft metadata with `draft_only` status.
+- Produce an audit report.
+
+Not included in V1:
+
+- Website page generation.
+- Writing files into public content directories.
+- Social posting.
+- Real LLM provider integration.
+- Knowledge Graph writes.
+- Prediction Engine behavior.
+- Dashboard, billing, enterprise, or multi-tenant features.
+
+## PublishPackageV1
+
+- `package_id`
+- `signal_id`
+- `title`
+- `slug`
+- `summary`
+- `source_url`
+- `source_name`
+- `canonical_language`
+- `localized_languages`
+- `seo_metadata`
+- `social_drafts`
+- `status`
+- `created_at`
+
+## SEOMetadataV1
+
+- `title`
+- `description`
+- `canonical_url`
+- `og_title`
+- `og_description`
+- `x_title`
+- `x_description`
+
+## SocialDraftV1
+
+- `platform`
+- `draft_text`
+- `link_url`
+- `status`
+
+V1 requires `status = draft_only`.
+
+## Deterministic Rules
+
+- English is canonical.
+- Chinese is optional localization metadata only.
+- Slugs are generated from English titles.
+- Social drafts are metadata only and remain `draft_only`.
+- No platform posting occurs.
+- No file or page publishing occurs.
+- No website write occurs.
+
+## Audit Report
+
+The publish package audit report includes:
+
+- Packages created.
+- Signals seen.
+- Skipped signals and reasons.
+- Package metadata.
+- SEO metadata.
+- Social draft metadata.
+- Confirmation that no website publishing, public content file write, social
+  posting, real LLM API call, or network request occurred.
+
+## Governance Notes
+
+This layer packages already quality-approved intelligence for future publishing
+review. It does not bypass the Quality Gate and does not create a public
+distribution path.

--- a/scripts/dysonx_publish_eligibility.py
+++ b/scripts/dysonx_publish_eligibility.py
@@ -75,6 +75,7 @@ def run_quality_review(ranking_report: dict[str, Any], created_at: str | None = 
         "status_counts": status_counts,
         "reviews": [serialize_review(review) for review in reviews],
         "eligibilities": [serialize_eligibility(eligibility) for eligibility in eligibilities],
+        "ranking_report": ranking_report,
         "publishing_performed": False,
         "social_posting_performed": False,
         "real_llm_api_used": False,

--- a/scripts/dysonx_publish_package.py
+++ b/scripts/dysonx_publish_package.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""DysonX Publish Package V1.
+
+Converts publish-ready Intelligence Signals into structured publish packages.
+This is still pre-publishing: it writes only an audit JSON report and does not
+generate website pages, post to social platforms, or write public content files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from dysonx_seo_metadata import build_seo_metadata, serialize_seo_metadata
+from dysonx_social_draft import build_social_drafts, serialize_social_draft
+
+
+CANONICAL_LANGUAGE = "en"
+OPTIONAL_LOCALIZED_LANGUAGES = ("zh",)
+
+
+@dataclass(frozen=True)
+class PublishPackageV1:
+    package_id: str
+    signal_id: str
+    title: str
+    slug: str
+    summary: str
+    source_url: str
+    source_name: str
+    canonical_language: str
+    localized_languages: tuple[str, ...]
+    seo_metadata: dict[str, str]
+    social_drafts: tuple[dict[str, str], ...]
+    status: str
+    created_at: str
+
+
+def slugify(title: str) -> str:
+    normalized = title.lower()
+    normalized = re.sub(r"[^a-z0-9]+", "-", normalized)
+    normalized = re.sub(r"-+", "-", normalized).strip("-")
+    return normalized or "untitled-signal"
+
+
+def stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:16]}"
+
+
+def load_quality_report(path: str | pathlib.Path) -> dict[str, Any]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Quality report must be a JSON object")
+    if not isinstance(data.get("reviews"), list):
+        raise ValueError("Quality report must contain reviews")
+    return data
+
+
+def eligibility_status_by_signal(quality_report: dict[str, Any]) -> dict[str, str]:
+    statuses: dict[str, str] = {}
+    for eligibility in quality_report.get("eligibilities", []):
+        if isinstance(eligibility, dict):
+            statuses[str(eligibility.get("signal_id"))] = str(eligibility.get("eligibility_status"))
+    return statuses
+
+
+def signal_by_id_from_ranking_report(ranking_report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    signals: dict[str, dict[str, Any]] = {}
+    for ranked in ranking_report.get("ranked_signals", []):
+        if isinstance(ranked, dict) and isinstance(ranked.get("signal"), dict):
+            signal = ranked["signal"]
+            signals[str(signal.get("signal_id"))] = signal
+    return signals
+
+
+def signal_by_id_from_quality_report(quality_report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    ranking_report = quality_report.get("ranking_report")
+    if isinstance(ranking_report, dict):
+        return signal_by_id_from_ranking_report(ranking_report)
+    signals = quality_report.get("signals")
+    if isinstance(signals, list):
+        return {str(signal.get("signal_id")): signal for signal in signals if isinstance(signal, dict)}
+    return {}
+
+
+def create_publish_package(signal: dict[str, Any], created_at: str) -> PublishPackageV1:
+    signal_id = str(signal["signal_id"])
+    title = str(signal["title"])
+    summary = str(signal["summary"])
+    source_name = str(signal["source_name"])
+    source_url = str(signal.get("url") or signal.get("source_url") or "")
+    slug = slugify(title)
+    seo_metadata = build_seo_metadata(title=title, summary=summary, slug=slug)
+    social_drafts = build_social_drafts(title=title, summary=summary, link_url=seo_metadata.canonical_url)
+
+    return PublishPackageV1(
+        package_id=stable_id("publish_package", signal_id, slug),
+        signal_id=signal_id,
+        title=title,
+        slug=slug,
+        summary=summary,
+        source_url=source_url,
+        source_name=source_name,
+        canonical_language=CANONICAL_LANGUAGE,
+        localized_languages=OPTIONAL_LOCALIZED_LANGUAGES,
+        seo_metadata=serialize_seo_metadata(seo_metadata),
+        social_drafts=tuple(serialize_social_draft(draft) for draft in social_drafts),
+        status="package_ready",
+        created_at=created_at,
+    )
+
+
+def serialize_publish_package(package: PublishPackageV1) -> dict[str, Any]:
+    data = asdict(package)
+    data["localized_languages"] = list(package.localized_languages)
+    data["social_drafts"] = list(package.social_drafts)
+    return data
+
+
+def run_publish_package(quality_report: dict[str, Any], created_at: str | None = None) -> dict[str, Any]:
+    timestamp = created_at or datetime.now(timezone.utc).isoformat()
+    eligibility_statuses = eligibility_status_by_signal(quality_report)
+    signals_by_id = signal_by_id_from_quality_report(quality_report)
+    skipped: list[dict[str, str]] = []
+    packages: list[PublishPackageV1] = []
+
+    for review in quality_report.get("reviews", []):
+        if not isinstance(review, dict):
+            continue
+        signal_id = str(review.get("signal_id"))
+        status = eligibility_statuses.get(signal_id, str(review.get("decision")))
+        if status != "publish_ready":
+            skipped.append({"signal_id": signal_id, "reason": f"eligibility_status={status}"})
+            continue
+        signal = signals_by_id.get(signal_id)
+        if signal is None:
+            skipped.append({"signal_id": signal_id, "reason": "signal payload missing"})
+            continue
+        packages.append(create_publish_package(signal, created_at=timestamp))
+
+    return {
+        "generated_at": timestamp,
+        "quality_report_id": str(quality_report.get("ranking_id") or "unknown_quality_report"),
+        "packages_created": len(packages),
+        "signals_seen": len(quality_report.get("reviews", [])),
+        "skipped": skipped,
+        "packages": [serialize_publish_package(package) for package in packages],
+        "canonical_language": CANONICAL_LANGUAGE,
+        "localized_languages": list(OPTIONAL_LOCALIZED_LANGUAGES),
+        "website_pages_written": False,
+        "public_content_files_written": False,
+        "publishing_performed": False,
+        "social_posting_performed": False,
+        "real_llm_api_used": False,
+        "network_requests_performed": False,
+    }
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Publish Package V1.")
+    parser.add_argument("--quality-report", required=True, help="Path to quality review report JSON.")
+    parser.add_argument("--output", required=True, help="Path to write publish package report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    quality_report = load_quality_report(args.quality_report)
+    report = run_publish_package(quality_report)
+    write_report(report, args.output)
+    print(
+        "[publish-package] wrote report: "
+        f"{args.output} packages={report['packages_created']} skipped={len(report['skipped'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_seo_metadata.py
+++ b/scripts/dysonx_seo_metadata.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""DysonX SEO metadata V1 for publish packages."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+
+
+DEFAULT_SITE_URL = "https://dysonx.ai"
+
+
+@dataclass(frozen=True)
+class SEOMetadataV1:
+    title: str
+    description: str
+    canonical_url: str
+    og_title: str
+    og_description: str
+    x_title: str
+    x_description: str
+
+
+def truncate_text(value: str, limit: int) -> str:
+    text = " ".join(value.split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def build_seo_metadata(title: str, summary: str, slug: str, site_url: str = DEFAULT_SITE_URL) -> SEOMetadataV1:
+    seo_title = truncate_text(title, 70)
+    description = truncate_text(summary, 160)
+    canonical_url = f"{site_url.rstrip('/')}/signals/{slug}"
+    return SEOMetadataV1(
+        title=seo_title,
+        description=description,
+        canonical_url=canonical_url,
+        og_title=seo_title,
+        og_description=description,
+        x_title=seo_title,
+        x_description=description,
+    )
+
+
+def serialize_seo_metadata(metadata: SEOMetadataV1) -> dict[str, str]:
+    return asdict(metadata)

--- a/scripts/dysonx_social_draft.py
+++ b/scripts/dysonx_social_draft.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""DysonX social draft metadata V1."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+
+
+DRAFT_ONLY_STATUS = "draft_only"
+
+
+@dataclass(frozen=True)
+class SocialDraftV1:
+    platform: str
+    draft_text: str
+    link_url: str
+    status: str
+
+    def __post_init__(self) -> None:
+        if self.status != DRAFT_ONLY_STATUS:
+            raise ValueError("SocialDraftV1 status must be draft_only")
+
+
+def build_social_drafts(title: str, summary: str, link_url: str) -> tuple[SocialDraftV1, ...]:
+    short_summary = " ".join(summary.split())
+    if len(short_summary) > 140:
+        short_summary = short_summary[:139].rstrip() + "..."
+
+    return (
+        SocialDraftV1(
+            platform="x",
+            draft_text=f"{title}\n\n{short_summary}\n\n{link_url}",
+            link_url=link_url,
+            status=DRAFT_ONLY_STATUS,
+        ),
+        SocialDraftV1(
+            platform="linkedin",
+            draft_text=f"{title}\n\n{summary}\n\nRead the Signal: {link_url}",
+            link_url=link_url,
+            status=DRAFT_ONLY_STATUS,
+        ),
+    )
+
+
+def serialize_social_draft(draft: SocialDraftV1) -> dict[str, str]:
+    return asdict(draft)

--- a/tests/test_dysonx_publish_package.py
+++ b/tests/test_dysonx_publish_package.py
@@ -1,0 +1,130 @@
+import copy
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_llm_audit as llm_audit
+import dysonx_publish_eligibility as publish_eligibility
+import dysonx_publish_package as publish_package
+import dysonx_signal_ranking as ranking
+from dysonx_social_draft import SocialDraftV1
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+FIXED_TIME = "2026-06-17T10:00:00+00:00"
+
+
+class DysonXPublishPackageTests(unittest.TestCase):
+    def quality_report(self):
+        candidate_records = llm_audit.load_candidate_records_from_raw_fixture(FIXTURE_PATH)
+        audit_report = llm_audit.run_llm_audit(candidate_records, created_at=FIXED_TIME)
+        ranking_result = ranking.rank_signals(audit_report["signals"], top_n=10, created_at=FIXED_TIME)
+        ranking_report = ranking.ranking_result_to_report(ranking_result)
+        quality_report = publish_eligibility.run_quality_review(ranking_report, created_at=FIXED_TIME)
+        quality_report["ranking_report"] = ranking_report
+        return quality_report
+
+    def test_only_publish_ready_signals_become_packages(self):
+        report = publish_package.run_publish_package(self.quality_report(), created_at=FIXED_TIME)
+
+        self.assertEqual(report["packages_created"], 4)
+        self.assertEqual(report["skipped"], [])
+
+    def test_needs_review_signals_do_not_become_packages(self):
+        quality = self.quality_report()
+        quality["eligibilities"][0]["eligibility_status"] = "needs_review"
+
+        report = publish_package.run_publish_package(quality, created_at=FIXED_TIME)
+
+        self.assertEqual(report["packages_created"], 3)
+        self.assertEqual(report["skipped"][0]["reason"], "eligibility_status=needs_review")
+
+    def test_rejected_signals_do_not_become_packages(self):
+        quality = self.quality_report()
+        quality["eligibilities"][0]["eligibility_status"] = "rejected"
+
+        report = publish_package.run_publish_package(quality, created_at=FIXED_TIME)
+
+        self.assertEqual(report["packages_created"], 3)
+        self.assertEqual(report["skipped"][0]["reason"], "eligibility_status=rejected")
+
+    def test_slug_generation_is_deterministic(self):
+        title = "OpenAI Releases GPT-6 for Advanced Reasoning!"
+
+        self.assertEqual(
+            publish_package.slugify(title),
+            "openai-releases-gpt-6-for-advanced-reasoning",
+        )
+        self.assertEqual(publish_package.slugify(title), publish_package.slugify(title))
+
+    def test_seo_metadata_is_generated(self):
+        report = publish_package.run_publish_package(self.quality_report(), created_at=FIXED_TIME)
+        metadata = report["packages"][0]["seo_metadata"]
+
+        self.assertIn("canonical_url", metadata)
+        self.assertIn("/signals/", metadata["canonical_url"])
+        self.assertLessEqual(len(metadata["title"]), 70)
+        self.assertTrue(report["packages"][0]["title"].startswith(metadata["title"].rstrip(".")))
+
+    def test_social_drafts_are_draft_only(self):
+        report = publish_package.run_publish_package(self.quality_report(), created_at=FIXED_TIME)
+
+        for package in report["packages"]:
+            for draft in package["social_drafts"]:
+                self.assertEqual(draft["status"], "draft_only")
+
+        with self.assertRaises(ValueError):
+            SocialDraftV1(platform="x", draft_text="post", link_url="https://example.com", status="posted")
+
+    def test_english_remains_canonical(self):
+        report = publish_package.run_publish_package(self.quality_report(), created_at=FIXED_TIME)
+
+        self.assertEqual(report["canonical_language"], "en")
+        self.assertIn("zh", report["localized_languages"])
+        self.assertTrue(all(package["canonical_language"] == "en" for package in report["packages"]))
+
+    def test_no_publishing_social_posting_or_real_llm_calls_occur(self):
+        report = publish_package.run_publish_package(self.quality_report(), created_at=FIXED_TIME)
+        module_source = pathlib.Path(publish_package.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertFalse(report["website_pages_written"])
+        self.assertFalse(report["public_content_files_written"])
+        self.assertFalse(report["publishing_performed"])
+        self.assertFalse(report["social_posting_performed"])
+        self.assertFalse(report["real_llm_api_used"])
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("from anthropic", module_source)
+
+    def test_cli_writes_publish_package_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_output = pathlib.Path(tmpdir) / "llm_audit.json"
+            ranking_output = pathlib.Path(tmpdir) / "ranking.json"
+            quality_output = pathlib.Path(tmpdir) / "quality.json"
+            package_output = pathlib.Path(tmpdir) / "packages.json"
+
+            llm_audit.main(["--raw-fixture", str(FIXTURE_PATH), "--output", str(audit_output)])
+            ranking.main(["--intelligence-report", str(audit_output), "--output", str(ranking_output), "--top-n", "10"])
+            publish_eligibility.main(["--ranking-report", str(ranking_output), "--output", str(quality_output)])
+
+            quality = json.loads(quality_output.read_text(encoding="utf-8"))
+            ranking_report = json.loads(ranking_output.read_text(encoding="utf-8"))
+            quality["ranking_report"] = ranking_report
+            quality_output.write_text(json.dumps(quality), encoding="utf-8")
+
+            exit_code = publish_package.main(["--quality-report", str(quality_output), "--output", str(package_output)])
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(package_output.read_text(encoding="utf-8"))
+            self.assertEqual(report["packages_created"], 4)
+            self.assertFalse(report["publishing_performed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add DysonX Publish Package V1 to convert publish_ready Intelligence Signals into structured publish packages with SEO metadata and draft-only social metadata. This remains pre-publishing.

## Scope

- Add docs/DYSONX_PUBLISH_PACKAGE_V1.md
- Add PublishPackageV1 package generation
- Add SEOMetadataV1 deterministic metadata generation
- Add SocialDraftV1 draft-only metadata generation
- Add CLI for publish package audit reports from quality review reports
- Carry ranking signal payload through the quality report so package generation can remain local and deterministic
- Add tests for publish_ready-only packaging, needs_review/rejected skips, deterministic slugs, SEO metadata, draft-only social drafts, English canonical language, and no publishing/social/real LLM behavior

## Files Changed

- docs/DYSONX_PUBLISH_PACKAGE_V1.md
- scripts/dysonx_publish_package.py
- scripts/dysonx_seo_metadata.py
- scripts/dysonx_social_draft.py
- scripts/dysonx_publish_eligibility.py
- tests/test_dysonx_publish_package.py

## Governance Compliance

- AGENTS.md and all canonical DYSONX governance documents were reviewed before implementation.
- Reviewed PR #22, #23, #24, #25, #26, #27, and #28 before implementation.
- Keeps English canonical and Chinese as optional localization metadata.
- SocialDraftV1 remains draft_only.
- Adds no website page generation, public content file writes, social posting, real LLM provider integration, Knowledge Graph, Prediction Engine, dashboard, billing, enterprise, or multi-tenant features.

## Architecture Impact

Adds the pre-publishing package layer: Publish-Ready Signal -> Publish Package -> SEO Metadata -> Social Draft Metadata -> Audit Report. No publishing path is introduced.

## Validation Results

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_llm_audit.py --raw-fixture tests/fixtures/raw_items_v1.json --output tmp/dysonx_llm_audit_report.json
- python3 scripts/dysonx_signal_ranking.py --intelligence-report tmp/dysonx_llm_audit_report.json --output tmp/dysonx_signal_ranking_report.json --top-n 10
- python3 scripts/dysonx_publish_eligibility.py --ranking-report tmp/dysonx_signal_ranking_report.json --output tmp/dysonx_quality_review_report.json
- python3 scripts/dysonx_publish_package.py --quality-report tmp/dysonx_quality_review_report.json --output tmp/dysonx_publish_package_report.json
- git diff --check

All passed.

## Sample Publish Package Report

- packages_created: 4
- signals_seen: 4
- skipped: 0
- canonical_language: en
- localized_languages: zh
- website_pages_written: false
- public_content_files_written: false
- publishing_performed: false
- social_posting_performed: false
- real_llm_api_used: false
- network_requests_performed: false

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Known Limitations

- V1 only emits package metadata to the requested audit JSON report.
- No website/public content files are generated.
- No social platform posting is performed.
- No real provider, Knowledge Graph, Prediction Engine, or publishing integration is included.