### PR TITLE
feat: add DysonX V1 Pipeline Orchestrator

### DIFF
--- a/docs/DYSONX_V1_PIPELINE_ORCHESTRATOR.md
+++ b/docs/DYSONX_V1_PIPELINE_ORCHESTRATOR.md
@@ -1,0 +1,64 @@
+# DysonX V1 Pipeline Orchestrator
+
+This document defines the dry-run V1 pipeline orchestrator.
+
+The orchestrator is a local fixture workflow. It does not connect to real
+providers, perform network requests, write website pages, write public content
+files, post to social platforms, merge, or deploy.
+
+## Target Flow
+
+```text
+Raw Items Fixture
+-> Signal Candidate Pipeline
+-> LLM Job & Audit
+-> Signal Ranking
+-> Quality Review
+-> Publish Package
+-> Final V1 Pipeline Report
+```
+
+## CLI
+
+```bash
+python3 scripts/dysonx_v1_pipeline.py \
+  --raw-fixture tests/fixtures/raw_items_v1.json \
+  --output-dir tmp/dysonx_v1_pipeline \
+  --dry-run
+```
+
+The `--dry-run` flag is required. The orchestrator fails closed without it.
+
+## Outputs
+
+The orchestrator writes:
+
+- `tmp/dysonx_v1_pipeline/llm_audit_report.json`
+- `tmp/dysonx_v1_pipeline/signal_ranking_report.json`
+- `tmp/dysonx_v1_pipeline/quality_review_report.json`
+- `tmp/dysonx_v1_pipeline/publish_package_report.json`
+- `tmp/dysonx_v1_pipeline/pipeline_summary.json`
+
+## Pipeline Summary
+
+`pipeline_summary.json` includes:
+
+- `raw_items_seen`
+- `candidates_created`
+- `signals_generated`
+- `signals_ranked`
+- `publish_ready`
+- `packages_created`
+- `rejected`
+- `warnings`
+- `real_llm_api_used`
+- `publishing_performed`
+- `social_posting_performed`
+- `network_requests_performed`
+- `dry_run`
+
+## Governance Notes
+
+The orchestrator composes existing V1 modules instead of duplicating business
+logic. It is useful for local auditability and PR validation, but it is not a
+production job runner and does not publish anything.

--- a/scripts/dysonx_v1_pipeline.py
+++ b/scripts/dysonx_v1_pipeline.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""DysonX V1 Pipeline Orchestrator.
+
+Runs the fixture-based V1 pipeline as a safe dry run. It writes only JSON audit
+reports into the requested output directory and performs no real provider calls,
+network requests, website publishing, public content file writes, or social
+posting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+import dysonx_llm_audit as llm_audit
+import dysonx_publish_eligibility as publish_eligibility
+import dysonx_publish_package as publish_package
+import dysonx_signal_candidate_pipeline as candidate_pipeline
+import dysonx_signal_ranking as signal_ranking
+
+
+def write_json_report(report: dict[str, Any], output_path: pathlib.Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def summarize_pipeline(
+    raw_records: list[dict[str, Any]],
+    candidate_report: dict[str, Any],
+    llm_audit_report: dict[str, Any],
+    ranking_report: dict[str, Any],
+    quality_report: dict[str, Any],
+    package_report: dict[str, Any],
+    dry_run: bool,
+    generated_at: str,
+) -> dict[str, Any]:
+    warnings: list[str] = []
+    warnings.extend(str(warning) for warning in candidate_report.get("processing_warnings", []))
+    warnings.extend(str(item) for item in ranking_report.get("audit_summary", {}).get("warnings", []))
+    warnings.extend(str(item) for item in package_report.get("skipped", []))
+
+    return {
+        "generated_at": generated_at,
+        "raw_items_seen": len(raw_records),
+        "candidates_created": int(candidate_report.get("candidates_created", 0)),
+        "signals_generated": int(llm_audit_report.get("signals_generated", 0)),
+        "signals_ranked": int(ranking_report.get("audit_summary", {}).get("signals_ranked", 0)),
+        "publish_ready": int(quality_report.get("status_counts", {}).get("publish_ready", 0)),
+        "packages_created": int(package_report.get("packages_created", 0)),
+        "rejected": int(quality_report.get("status_counts", {}).get("rejected", 0)),
+        "warnings": warnings,
+        "real_llm_api_used": False,
+        "publishing_performed": False,
+        "social_posting_performed": False,
+        "network_requests_performed": False,
+        "dry_run": dry_run,
+    }
+
+
+def run_pipeline(raw_fixture: str | pathlib.Path, output_dir: str | pathlib.Path, dry_run: bool) -> dict[str, Any]:
+    if not dry_run:
+        raise ValueError("DysonX V1 pipeline orchestrator only supports --dry-run")
+
+    generated_at = datetime.now(timezone.utc).isoformat()
+    output_path = pathlib.Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    raw_records = candidate_pipeline.load_raw_item_records(raw_fixture)
+    candidate_report = candidate_pipeline.run_pipeline(raw_records, created_at=generated_at)
+
+    candidate_records = list(candidate_report["candidates"])
+    llm_audit_report = llm_audit.run_llm_audit(candidate_records, created_at=generated_at)
+    write_json_report(llm_audit_report, output_path / "llm_audit_report.json")
+
+    ranking_result = signal_ranking.rank_signals(llm_audit_report["signals"], top_n=10, created_at=generated_at)
+    ranking_report = signal_ranking.ranking_result_to_report(ranking_result)
+    write_json_report(ranking_report, output_path / "signal_ranking_report.json")
+
+    quality_report = publish_eligibility.run_quality_review(ranking_report, created_at=generated_at)
+    write_json_report(quality_report, output_path / "quality_review_report.json")
+
+    package_report = publish_package.run_publish_package(quality_report, created_at=generated_at)
+    write_json_report(package_report, output_path / "publish_package_report.json")
+
+    summary = summarize_pipeline(
+        raw_records=raw_records,
+        candidate_report=candidate_report,
+        llm_audit_report=llm_audit_report,
+        ranking_report=ranking_report,
+        quality_report=quality_report,
+        package_report=package_report,
+        dry_run=dry_run,
+        generated_at=generated_at,
+    )
+    write_json_report(summary, output_path / "pipeline_summary.json")
+    return summary
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the DysonX V1 fixture pipeline as a dry run.")
+    parser.add_argument("--raw-fixture", required=True, help="Path to RawItem fixture JSON.")
+    parser.add_argument("--output-dir", required=True, help="Directory to write V1 pipeline reports.")
+    parser.add_argument("--dry-run", action="store_true", required=True, help="Required safety flag.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = run_pipeline(raw_fixture=args.raw_fixture, output_dir=args.output_dir, dry_run=args.dry_run)
+    print(
+        "[v1-pipeline] wrote reports: "
+        f"{args.output_dir} raw_items={summary['raw_items_seen']} "
+        f"signals={summary['signals_generated']} packages={summary['packages_created']} dry_run={summary['dry_run']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_v1_pipeline.py
+++ b/tests/test_dysonx_v1_pipeline.py
@@ -1,0 +1,78 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_v1_pipeline as pipeline
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+
+
+class DysonXV1PipelineTests(unittest.TestCase):
+    def test_full_dry_run_pipeline_completes_and_creates_reports(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            summary = pipeline.run_pipeline(FIXTURE_PATH, tmpdir, dry_run=True)
+            output_dir = pathlib.Path(tmpdir)
+
+            expected_reports = (
+                "llm_audit_report.json",
+                "signal_ranking_report.json",
+                "quality_review_report.json",
+                "publish_package_report.json",
+                "pipeline_summary.json",
+            )
+            for report_name in expected_reports:
+                self.assertTrue((output_dir / report_name).exists(), report_name)
+
+            disk_summary = json.loads((output_dir / "pipeline_summary.json").read_text(encoding="utf-8"))
+            self.assertEqual(summary, disk_summary)
+
+    def test_output_counts_are_consistent_across_stages(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            summary = pipeline.run_pipeline(FIXTURE_PATH, tmpdir, dry_run=True)
+            output_dir = pathlib.Path(tmpdir)
+            llm_audit = json.loads((output_dir / "llm_audit_report.json").read_text(encoding="utf-8"))
+            ranking = json.loads((output_dir / "signal_ranking_report.json").read_text(encoding="utf-8"))
+            quality = json.loads((output_dir / "quality_review_report.json").read_text(encoding="utf-8"))
+            packages = json.loads((output_dir / "publish_package_report.json").read_text(encoding="utf-8"))
+
+            self.assertEqual(summary["raw_items_seen"], 5)
+            self.assertEqual(summary["candidates_created"], 4)
+            self.assertEqual(summary["signals_generated"], llm_audit["signals_generated"])
+            self.assertEqual(summary["signals_ranked"], ranking["audit_summary"]["signals_ranked"])
+            self.assertEqual(summary["publish_ready"], quality["status_counts"]["publish_ready"])
+            self.assertEqual(summary["packages_created"], packages["packages_created"])
+
+    def test_dry_run_and_no_side_effect_flags_remain_true(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            summary = pipeline.run_pipeline(FIXTURE_PATH, tmpdir, dry_run=True)
+
+            self.assertTrue(summary["dry_run"])
+            self.assertFalse(summary["real_llm_api_used"])
+            self.assertFalse(summary["publishing_performed"])
+            self.assertFalse(summary["social_posting_performed"])
+            self.assertFalse(summary["network_requests_performed"])
+
+    def test_pipeline_fails_closed_without_dry_run(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with self.assertRaises(ValueError):
+                pipeline.run_pipeline(FIXTURE_PATH, tmpdir, dry_run=False)
+
+    def test_cli_writes_pipeline_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            exit_code = pipeline.main(["--raw-fixture", str(FIXTURE_PATH), "--output-dir", tmpdir, "--dry-run"])
+
+            self.assertEqual(exit_code, 0)
+            summary = json.loads((pathlib.Path(tmpdir) / "pipeline_summary.json").read_text(encoding="utf-8"))
+            self.assertEqual(summary["raw_items_seen"], 5)
+            self.assertEqual(summary["packages_created"], 4)
+            self.assertTrue(summary["dry_run"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add a safe dry-run orchestration command that runs the full fixture-based DysonX V1 pipeline from raw items to publish packages and writes stage reports plus a pipeline summary.

## Scope

- Add docs/DYSONX_V1_PIPELINE_ORCHESTRATOR.md
- Add scripts/dysonx_v1_pipeline.py
- Add tests/test_dysonx_v1_pipeline.py
- Compose existing V1 modules instead of duplicating stage logic
- Write dry-run JSON reports under the requested output directory

## Files Changed

- docs/DYSONX_V1_PIPELINE_ORCHESTRATOR.md
- scripts/dysonx_v1_pipeline.py
- tests/test_dysonx_v1_pipeline.py

## Governance Compliance

- AGENTS.md and all canonical DYSONX governance documents were reviewed before implementation.
- Reviewed PRs #22 through #29 before implementation.
- The orchestrator is dry-run only and fails closed without --dry-run.
- Adds no real LLM provider integration, website page generation, public content file writing, social posting, Knowledge Graph implementation, Prediction Engine, dashboard, billing, enterprise, or multi-tenant features.

## Architecture Impact

Adds a local V1 dry-run orchestration layer: Raw Items Fixture -> Signal Candidate Pipeline -> LLM Job & Audit -> Signal Ranking -> Quality Review -> Publish Package -> Final V1 Pipeline Report. No publishing or deployment path is introduced.

## Validation Results

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_v1_pipeline.py --raw-fixture tests/fixtures/raw_items_v1.json --output-dir tmp/dysonx_v1_pipeline --dry-run
- git diff --check

All passed.

## Sample Pipeline Summary

- raw_items_seen: 5
- candidates_created: 4
- signals_generated: 4
- signals_ranked: 4
- publish_ready: 4
- packages_created: 4
- rejected: 0
- warnings: []
- real_llm_api_used: false
- publishing_performed: false
- social_posting_performed: false
- network_requests_performed: false
- dry_run: true

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Known Limitations

- Fixture/raw JSON only.
- Dry-run only.
- Writes JSON audit reports only under the requested output directory.
- No production scheduler, provider integration, website publishing, or social distribution is included.