### PR TITLE
chore: disable legacy aggregation workflows

### DIFF
--- a/.github/workflows/update-content.yml.disabled
+++ b/.github/workflows/update-content.yml.disabled
@@ -1,4 +1,7 @@
-name: Hourly Content Aggregation
+# DISABLED: Legacy news aggregation disabled. DysonX V1 pipeline is the active path.
+# This workflow is retained temporarily for decommission audit context only.
+
+name: Hourly Content Aggregation [DISABLED]
 
 on:
   schedule:

--- a/.github/workflows/update.yml.disabled
+++ b/.github/workflows/update.yml.disabled
@@ -1,4 +1,7 @@
-name: Manual Update (on-demand)
+# DISABLED: Legacy news aggregation disabled. DysonX V1 pipeline is the active path.
+# This workflow is retained temporarily for decommission audit context only.
+
+name: Manual Update (on-demand) [DISABLED]
 
 on:
   workflow_dispatch:

--- a/docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md
+++ b/docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md
@@ -377,7 +377,7 @@ Legacy sitemap replacement:
 
 1. `chore/dysonx-disable-legacy-aggregation-workflows`
 
-   Remove `.github/workflows/update.yml` and
+   Disable `.github/workflows/update.yml` and
    `.github/workflows/update-content.yml`. Confirm no scheduled legacy content
    job remains.
 
@@ -419,8 +419,8 @@ Next PR:
 
 Scope:
 
-- Delete `.github/workflows/update.yml`.
-- Delete `.github/workflows/update-content.yml`.
+- Disable `.github/workflows/update.yml`.
+- Disable `.github/workflows/update-content.yml`.
 - Add or keep tests proving the DysonX V1 pipeline does not use the legacy
   aggregator.
 - Run the full governance and V1 dry-run validation suite.
@@ -430,6 +430,24 @@ Rationale:
 Stopping scheduled legacy generation first is the safest removal step because it
 prevents deleted legacy files from being recreated and avoids accidental OpenAI
 or RSS execution from the old path.
+
+## Legacy Workflow Disablement
+
+Implemented disablement path:
+
+- `.github/workflows/update.yml` was renamed to
+  `.github/workflows/update.yml.disabled`.
+- `.github/workflows/update-content.yml` was renamed to
+  `.github/workflows/update-content.yml.disabled`.
+- Both disabled files now include the banner:
+  `Legacy news aggregation disabled. DysonX V1 pipeline is the active path.`
+- Active workflow files ending in `.yml` or `.yaml` are checked to ensure they
+  do not run `scripts/aggregator.py`, `scripts/openai_summary.py`,
+  `scripts/generate_sitemap.py`, legacy `feeds.json` cache keys, or legacy
+  `posts/` plus `sitemap.xml` commits.
+
+This cuts off automated RSS/news/article aggregation while preserving the old
+workflow definitions temporarily for audit review and later deletion.
 
 ## Go / No-Go
 

--- a/tests/test_dysonx_legacy_independence.py
+++ b/tests/test_dysonx_legacy_independence.py
@@ -5,6 +5,7 @@ import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 SCRIPTS_DIR = ROOT / "scripts"
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 
 
 def imported_modules(path: pathlib.Path) -> set[str]:
@@ -34,6 +35,26 @@ class DysonXLegacyIndependenceTests(unittest.TestCase):
             overlap = imported_modules(path) & legacy_modules
             if overlap:
                 offenders[path.name] = sorted(overlap)
+
+        self.assertEqual({}, offenders)
+
+    def test_active_workflows_do_not_run_legacy_aggregation(self):
+        legacy_tokens = (
+            "scripts/aggregator.py",
+            "scripts/openai_summary.py",
+            "scripts/generate_sitemap.py",
+            "hashFiles('feeds.json')",
+            "git add posts/ sitemap.xml",
+            "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}",
+            "group: aggregator-${{ github.repository }}-${{ github.ref_name }}",
+        )
+        offenders = {}
+
+        for path in sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml")):
+            text = path.read_text(encoding="utf-8")
+            matches = [token for token in legacy_tokens if token in text]
+            if matches:
+                offenders[path.name] = matches
 
         self.assertEqual({}, offenders)
 


### PR DESCRIPTION
## Scope

Disable legacy RSS/news/article aggregation automation before deleting legacy code.

This PR renames the legacy aggregation workflows to `.disabled`, adds explicit deprecation banners, updates the decommission plan, and adds a static test proving active workflow files no longer invoke the old aggregation path.

## Files Changed

- `.github/workflows/update.yml` -> `.github/workflows/update.yml.disabled`
- `.github/workflows/update-content.yml` -> `.github/workflows/update-content.yml.disabled`
- `docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md`
- `tests/test_dysonx_legacy_independence.py`

## Governance

Reviewed before work:
- `AGENTS.md`
- `docs/DYSONX_OWNER_INTENT.md`
- `docs/DYSONX_PROJECT_CONTEXT.md`
- `docs/DYSONX_PRODUCT_CONSTITUTION.md`
- `docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- `docs/DYSONX_ENGINEERING_GOVERNANCE.md`

Reviewed PRs #22 through #32.

## Disabled Legacy Automation

- Disabled manual legacy update workflow.
- Disabled hourly legacy content aggregation workflow.
- Active `.yml`/`.yaml` workflows no longer reference `scripts/aggregator.py`, `scripts/openai_summary.py`, `scripts/generate_sitemap.py`, legacy `feeds.json` cache keys, or `posts/` plus `sitemap.xml` commits.

## Validation

- `python3 scripts/constitution_guard.py`
- `python3 scripts/architecture_guard.py`
- `python3 scripts/release_guard.py`
- `python3 -m py_compile scripts/*.py`
- `python3 -m unittest discover -s tests`
- `python3 scripts/dysonx_v1_pipeline.py --raw-fixture tests/fixtures/raw_items_v1.json --output-dir tmp/dysonx_v1_pipeline --dry-run`
- `git diff --check`

## Explicit Non-Actions

No real Notion API use, real LLM API use, publishing, social posting, deployment, merge, or production operation was performed.