### PR TITLE
feat: add DysonX identity landing shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,110 @@
+# DysonX
 
-EnergizeOS™ News Aggregator
+DysonX is an AI / AGI Intelligence OS for tracking the signals shaping AGI.
 
-A multilingual, auto-updating energy news site covering PV, wind, storage, EV charging, and power electronics.
+It is an AGI signal tracker and first-source AI intelligence platform. The core
+object is the Signal, not the Article. DysonX is designed to turn high-authority
+AI and AGI source material into structured intelligence, rankings, quality
+review decisions, and decision-ready context.
 
-Features
+## Product Principles
 
-Hourly RSS fetch + English/Chinese summaries
+- Signal-first: Signals are the operating unit for intelligence value.
+- English-default: English is canonical for routes, metadata, and structured
+  output.
+- Chinese-switchable: Chinese is a future localization layer, not a separate
+  canonical product.
+- Notion-managed sources: monitored source configuration belongs in Notion, not
+  permanent hardcoded lists.
+- LLM-first interpretation: after collection, the first major interpretation
+  step is provider-neutral LLM analysis with audit records.
+- Quality-gated output: publishing must stay behind validation and review gates.
 
-One-click language toggle
+## Current V1 Status
 
-Tagging (PV / Wind / Storage / Charger / Power Electronics)
+The V1 dry-run pipeline is available and fixture-based.
 
-Lightweight, responsive UI
+Current dry-run flow:
 
-Automated via GitHub Actions; deployed on GitHub Pages
-
-Tech Stack
-
-Frontend: HTML, CSS, JavaScript
-
-Tasks: Python 3 (feedparser, newspaper3k, OpenAI API)
-
-CI/CD: GitHub Actions
-
-Hosting: GitHub Pages
-Quick Start
-```bash
-git clone https://github.com/enxpower/media.git
-cd media
-pip install -r requirements.txt
-export OPENAI_API_KEY=your_key_here
-python scripts/aggregator.py   # optional local run
+```text
+Raw Items Fixture
+-> Signal Candidate
+-> LLM Job / Audit
+-> Intelligence Signal
+-> Scoring / Ranking
+-> Quality Review
+-> Publish Package
+-> Pipeline Summary
 ```
 
-Automation
+The dry-run pipeline writes JSON audit reports under `tmp/` and does not publish
+website pages, post to social platforms, call real model providers, or fetch
+live Notion data.
 
-Workflow (e.g., update-content.yml) runs hourly:
+Run the V1 dry-run pipeline:
 
-Fetch RSS → summarize → categorize → write posts/pageX.html → commit.
-
-Manual trigger: GitHub “Actions” → Update workflow → Run.
-Structure (short)
 ```bash
-media/
-├─ posts/                 # generated pages
-├─ scripts/
-│  ├─ aggregator.py       # fetch/summarize entry
-│  └─ openai_summary.py   # GPT summarization
-├─ components/            # UI modules (lang toggle, pagination, etc.)
-├─ styles/
-├─ feeds.json             # RSS sources
-├─ index.html
-├─ .github/workflows/
-└─ requirements.txt
+python3 scripts/dysonx_v1_pipeline.py \
+  --raw-fixture tests/fixtures/raw_items_v1.json \
+  --output-dir tmp/dysonx_v1_pipeline \
+  --dry-run
 ```
 
-Deployment
+## Active Architecture
 
-GitHub Pages, branch: main, entry: index.html
+Key V1 layers already present:
 
-Local preview:
+- Notion source schema foundation
+- Local source fixture loader
+- Read-only Notion adapter interface
+- Source intake dry run
+- Raw Item to Signal Candidate pipeline
+- Provider-neutral LLM job and audit layer with fake provider
+- Intelligence Signal generation
+- Deterministic scoring and ranking
+- Quality review gate
+- Publish package metadata generation
+- Full V1 dry-run orchestrator
+
+## Governance
+
+Every task must read:
+
+- `AGENTS.md`
+- `docs/DYSONX_OWNER_INTENT.md`
+- `docs/DYSONX_PROJECT_CONTEXT.md`
+- `docs/DYSONX_PRODUCT_CONSTITUTION.md`
+- `docs/DYSONX_SYSTEM_ARCHITECTURE.md`
+- `docs/DYSONX_ENGINEERING_GOVERNANCE.md`
+
+Development is GitHub-first through branches and draft pull requests. No merge
+or production deployment should happen without explicit owner approval.
+
+## Validation
+
+Recommended checks:
+
 ```bash
-python3 -m http.server
-# open http://localhost:8000
+python3 scripts/constitution_guard.py
+python3 scripts/architecture_guard.py
+python3 scripts/release_guard.py
+python3 -m py_compile scripts/*.py
+python3 -m unittest discover -s tests
+python3 scripts/dysonx_v1_pipeline.py \
+  --raw-fixture tests/fixtures/raw_items_v1.json \
+  --output-dir tmp/dysonx_v1_pipeline \
+  --dry-run
+git diff --check
 ```
-License
 
-Copyright © 2025 Energize Solutions Inc.
-Licensed under CC BY-NC 4.0. See LICENSE.
+## Legacy Decommission
 
-Contact
+The old generated content path has been decommissioned in stages:
 
-Email: info@energizeos.com
+- legacy automation disabled
+- old aggregation scripts removed
+- hardcoded feed configuration removed
+- generated legacy pages and old sitemap removed
 
-GitHub: enxpower
+Remaining cleanup is tracked in
+`docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md`.

--- a/docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md
+++ b/docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md
@@ -319,14 +319,15 @@ Recommended sequence:
 
 4. Replace repository identity.
 
-   Update `README.md` from EnergizeOS News Aggregator to DysonX Intelligence OS
-   with clear notes that real integrations and publishing are not enabled yet.
+   Completed: updated `README.md` from old legacy positioning to DysonX
+   Intelligence OS with clear notes that real integrations and publishing are
+   not enabled yet.
 
 5. Replace or remove public static shell.
 
-   Either replace `index.html` with a minimal DysonX governance-aligned preview
-   page or remove legacy public UI when the future DysonX Signal publishing
-   surface exists.
+   Completed: replaced `index.html` with a minimal DysonX governance-aligned
+   landing shell. Legacy components and styles remain for separate review
+   because they are no longer loaded by the root shell.
 
 6. Remove legacy UI assets.
 
@@ -397,8 +398,8 @@ Legacy sitemap replacement:
 
 4. `docs/dysonx-repository-identity-readme`
 
-   Replace README wording with DysonX Intelligence OS positioning and current
-   dry-run status.
+   Completed: replace README wording with DysonX Intelligence OS positioning
+   and current dry-run status.
 
 5. `chore/dysonx-release-guard-realignment`
 
@@ -407,8 +408,8 @@ Legacy sitemap replacement:
 
 6. `chore/dysonx-remove-legacy-static-ui`
 
-   Remove or replace `index.html`, `components/`, and `styles/` after a DysonX
-   preview or publishing surface is ready.
+   Partially completed: `index.html` is replaced. Review `components/` and
+   `styles/` separately because they are not loaded by the new shell.
 
 7. `chore/dysonx-prune-legacy-dependencies`
 
@@ -510,8 +511,8 @@ Remaining cleanup should happen in smaller PRs:
 
 1. `docs/dysonx-repository-identity-readme`
 
-   Replace EnergizeOS News Aggregator README wording with DysonX Intelligence
-   OS positioning and current dry-run status.
+   Completed: README now uses DysonX Intelligence OS positioning and current
+   dry-run status.
 
 2. `chore/dysonx-release-guard-realignment`
 
@@ -520,15 +521,41 @@ Remaining cleanup should happen in smaller PRs:
 
 3. `chore/dysonx-review-public-shell`
 
-   Review `index.html`, `components/`, and `styles/` to decide whether to
-   replace them with a DysonX-aligned preview shell or remove them after a
-   future publishing surface exists.
+   Partially completed: `index.html` is now a DysonX-aligned landing shell.
+   Review `components/` and `styles/` separately to decide whether to remove or
+   repurpose them.
 
 4. `chore/dysonx-prune-legacy-dependencies`
 
    Remove legacy-only dependencies such as `feedparser`, `newspaper3k`,
    `lxml_html_clean`, and `nltk` after confirming no remaining check or
    workflow needs them.
+
+## Repository Identity And Landing Shell Migration
+
+Implemented identity migration:
+
+- Replaced `README.md` with DysonX AI / AGI Intelligence OS positioning.
+- Documented the project as an AGI signal tracker and first-source AI
+  intelligence platform.
+- Made Signal-first, English-default, Chinese-switchable, Notion-managed source,
+  and V1 dry-run status explicit.
+- Replaced `index.html` with an English-canonical DysonX landing shell.
+- Added a visible EN / Chinese placeholder without implementing full
+  localization.
+- Updated title, description, Open Graph, and X/Twitter card metadata to DysonX
+  positioning.
+- Kept real publishing disabled and did not wire the landing shell to Publish
+  Packages or external integrations.
+
+Remaining static cleanup:
+
+- `components/` contains legacy static modules that are no longer loaded by
+  `index.html`.
+- `styles/main.css` contains legacy styles that are no longer loaded by
+  `index.html`.
+- `static/data/ads.json` and related content sync workflows need separate review
+  before removal because they are outside the root landing shell.
 
 ## Go / No-Go
 

--- a/index.html
+++ b/index.html
@@ -1,87 +1,319 @@
-<!DOCTYPE html> 
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-  <title>EnergizeOS™ News Aggregator</title>
-
-  <!-- ✅ SEO meta tags -->
-  <meta name="description" content="Curated clean energy news from over 60 sources: solar, battery, wind, EV, grid and more. Updated hourly by EnergizeOS™." />
-  <meta name="keywords" content="solar, battery, BESS, wind, EV, energy storage, cleantech, aggregator, EnergizeOS" />
+  <title>DysonX | Signals Shaping AGI</title>
+  <meta name="description" content="DysonX tracks the signals shaping AGI: first-source AI intelligence structured into Signals, rankings, and decision-ready context." />
   <meta name="robots" content="index, follow" />
-
-  <!-- ✅ Open Graph (for social sharing) -->
-  <meta property="og:title" content="EnergizeOS™ News Aggregator" />
-  <meta property="og:description" content="Top curated clean energy news, updated hourly from 60+ global sources." />
-  <meta property="og:url" content="https://media.energizeos.com/" />
+  <meta property="og:title" content="DysonX tracks the signals shaping AGI." />
+  <meta property="og:description" content="First-source AI intelligence, structured into Signals, rankings, and decision-ready context." />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://media.energizeos.com/og-cover.jpg" />
-
-  <!-- ✅ Canonical -->
-  <link rel="canonical" href="https://media.energizeos.com/" />
-
-  <!-- ✅ Styles -->
-  <link rel="stylesheet" href="styles/main.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
-
-  <!-- ✅ Inline style (retain your h1 style) -->
+  <meta property="og:url" content="https://dysonx.ai/" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="DysonX tracks the signals shaping AGI." />
+  <meta name="twitter:description" content="First-source AI intelligence, structured into Signals, rankings, and decision-ready context." />
+  <link rel="canonical" href="https://dysonx.ai/" />
   <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --ink: #14171f;
+      --muted: #5c6472;
+      --line: #d9dee7;
+      --panel: #ffffff;
+      --accent: #126f7a;
+      --accent-2: #b15f24;
+      --good: #1f7a4c;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+
+    a {
+      color: inherit;
+      text-decoration: none;
+    }
+
+    .shell {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .topbar {
+      border-bottom: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.92);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    .topbar-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 14px 20px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .brand {
+      font-weight: 760;
+      letter-spacing: 0;
+      font-size: 20px;
+    }
+
+    nav {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      color: var(--muted);
+      font-size: 14px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    nav a {
+      white-space: nowrap;
+    }
+
+    .language-toggle {
+      display: inline-flex;
+      align-items: center;
+      border: 1px solid var(--line);
+      overflow: hidden;
+      font-size: 13px;
+      margin-left: 4px;
+    }
+
+    .language-toggle span {
+      padding: 5px 9px;
+    }
+
+    .language-toggle span:first-child {
+      background: var(--ink);
+      color: #ffffff;
+    }
+
+    main {
+      flex: 1;
+    }
+
+    .hero {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 84px 20px 54px;
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+      gap: 44px;
+      align-items: start;
+    }
+
+    .eyebrow {
+      color: var(--accent);
+      font-weight: 720;
+      font-size: 14px;
+      margin: 0 0 16px;
+    }
+
     h1 {
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-      font-weight: bold;
+      font-size: clamp(42px, 7vw, 86px);
+      line-height: 0.98;
+      letter-spacing: 0;
+      margin: 0;
+      max-width: 900px;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      font-size: 21px;
+      margin: 24px 0 0;
+      max-width: 720px;
+    }
+
+    .status-panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      padding: 22px;
+      display: grid;
+      gap: 16px;
+    }
+
+    .status-panel h2,
+    .section h2 {
+      font-size: 16px;
+      margin: 0;
+      letter-spacing: 0;
+    }
+
+    .status-item {
+      border-top: 1px solid var(--line);
+      padding-top: 14px;
+    }
+
+    .status-label {
+      display: block;
+      color: var(--muted);
+      font-size: 13px;
+      margin-bottom: 4px;
+    }
+
+    .status-value {
+      font-weight: 720;
+    }
+
+    .status-value.ready {
+      color: var(--good);
+    }
+
+    .status-value.pending {
+      color: var(--accent-2);
+    }
+
+    .content-band {
+      border-top: 1px solid var(--line);
+      background: #ffffff;
+    }
+
+    .sections {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 42px 20px 64px;
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+    }
+
+    .section {
+      border-left: 2px solid var(--accent);
+      padding: 4px 18px 4px 16px;
+    }
+
+    .section p {
+      color: var(--muted);
+      margin: 10px 0 0;
+      font-size: 15px;
+    }
+
+    footer {
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 13px;
+      background: #ffffff;
+    }
+
+    .footer-inner {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 20px;
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+
+    @media (max-width: 820px) {
+      .topbar-inner {
+        align-items: flex-start;
+        flex-direction: column;
+      }
+
+      nav {
+        justify-content: flex-start;
+      }
+
+      .hero {
+        grid-template-columns: 1fr;
+        padding-top: 54px;
+      }
+
+      .sections {
+        grid-template-columns: 1fr;
+      }
     }
   </style>
-
-  <!-- ✅ Google Analytics (GA4) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-6RWKYBH04S"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-6RWKYBH04S');
-  </script>
 </head>
 <body>
-  <header>
-    <h1>EnergizeOS™ News Aggregator</h1>
-    <div id="toolbar">
-      <input type="text" id="searchBox" placeholder="Search news..." />
-      <button id="langToggle">中文</button>
-    </div>
-  </header>
+  <div class="shell">
+    <header class="topbar">
+      <div class="topbar-inner">
+        <a class="brand" href="/" aria-label="DysonX home">DysonX</a>
+        <nav aria-label="Primary navigation">
+          <a href="#signals">Signals</a>
+          <a href="#trackers">Trackers</a>
+          <a href="#agi-map">AGI Map</a>
+          <a href="#companies">Companies</a>
+          <a href="#people">People</a>
+          <a href="#research">Research</a>
+          <a href="#reports">Reports</a>
+          <span class="language-toggle" aria-label="Language switch placeholder">
+            <span>EN</span>
+            <span>中文</span>
+          </span>
+        </nav>
+      </div>
+    </header>
 
-  <!-- 🔌 顶部横幅挂钩（默认隐藏；由 /static/data/ads.json 控制） -->
-  <section id="top-banner" class="banner banner-top" hidden></section>
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <div>
+          <p class="eyebrow">AI / AGI Intelligence OS</p>
+          <h1 id="hero-title">DysonX tracks the signals shaping AGI.</h1>
+          <p class="subtitle">First-source AI intelligence, structured into Signals, rankings, and decision-ready context.</p>
+        </div>
 
-  <div id="pagination"></div>
+        <aside class="status-panel" aria-label="V1 status">
+          <h2>V1 Status</h2>
+          <div class="status-item">
+            <span class="status-label">Pipeline</span>
+            <span class="status-value ready">V1 dry-run pipeline available</span>
+          </div>
+          <div class="status-item">
+            <span class="status-label">Publishing</span>
+            <span class="status-value pending">Real publishing not enabled yet</span>
+          </div>
+          <div class="status-item">
+            <span class="status-label">Canonical language</span>
+            <span class="status-value">English default; Chinese optional future localization</span>
+          </div>
+        </aside>
+      </section>
 
-  <main id="newsContainer">
-    <!-- News content will be loaded here -->
-  </main>
+      <section class="content-band" aria-label="DysonX foundations">
+        <div class="sections">
+          <article class="section" id="signals">
+            <h2>Signal-first intelligence</h2>
+            <p>DysonX treats Signals as the core object, preserving source, confidence, impact, and decision context.</p>
+          </article>
+          <article class="section" id="trackers">
+            <h2>Notion-managed sources</h2>
+            <p>Source configuration is designed to be managed from Notion, with local fixtures only for V1 dry runs.</p>
+          </article>
+          <article class="section" id="agi-map">
+            <h2>Decision-ready structure</h2>
+            <p>Candidate Signals move through LLM audit, ranking, quality review, and publish package preparation.</p>
+          </article>
+        </div>
+      </section>
+    </main>
 
-  <!-- ✅ 底部分页挂钩（与顶部同款；由 pagination-bottom.js 渲染为普通链接） -->
-  <div id="pagination-bottom"></div>
-
-  <!-- （可选）侧栏赞助挂钩 -->
-  <!-- <ul id="side-sponsors" class="sponsor-list" hidden></ul> -->
-
-  <!-- 🔌 底部 CTA 挂钩（默认隐藏；由 /static/data/ads.json 控制） -->
-  <section id="footer-cta" class="footer-cta" hidden></section>
-
-  <script src="components/search.js"></script>
-  <script src="components/langToggle.js"></script>
-  <script src="components/pagination.js"></script>
-  <script src="components/pagination-bottom.js"></script>
-  <script src="components/footer.js"></script>
-  <script src="components/outboundTracker.js?v=2"></script>
-  <script src="components/shareButtons.js"></script>
-  <script src="components/shareTracker.js"></script>
-
-  <!-- ✅ 原生内嵌赞助卡（监听 pager:update，从 /static/data/ads.json 注入） -->
-  <script src="components/nativeAds.js"></script>
-
-  <!-- 🔌 运营内容注入脚本（读取 /static/data/ads.json，填充挂钩位） -->
-  <script type="module" src="/components/ops.js"></script>
+    <footer>
+      <div class="footer-inner">
+        <span>DysonX Intelligence OS</span>
+        <span>No real publishing, social posting, or external provider integration is enabled in V1.</span>
+      </div>
+    </footer>
+  </div>
 </body>
 </html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,2 @@
 User-agent: *
 Allow: /
-
-Sitemap: https://media.energizeos.com/sitemap.xml

--- a/tests/test_dysonx_identity_landing.py
+++ b/tests/test_dysonx_identity_landing.py
@@ -1,0 +1,93 @@
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+INDEX = ROOT / "index.html"
+ROBOTS = ROOT / "robots.txt"
+
+
+def read_lower(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8").lower()
+
+
+class DysonXIdentityLandingTests(unittest.TestCase):
+    def test_readme_uses_dysonx_identity(self):
+        text = README.read_text(encoding="utf-8")
+
+        self.assertIn("AI / AGI Intelligence OS", text)
+        self.assertIn("AGI signal tracker", text)
+        self.assertIn("first-source AI intelligence platform", text)
+        self.assertIn("Signal, not the Article", text)
+        self.assertIn("English-default", text)
+        self.assertIn("Chinese-switchable", text)
+        self.assertIn("Notion-managed sources", text)
+        self.assertIn("V1 dry-run pipeline", text)
+
+    def test_readme_does_not_use_legacy_positioning(self):
+        text = read_lower(README)
+        forbidden_phrases = (
+            "news aggregator",
+            "rss news site",
+            "ai-generated news blog",
+            "automated article farm",
+            "hourly rss fetch",
+            "energizeos",
+        )
+
+        for phrase in forbidden_phrases:
+            self.assertNotIn(phrase, text)
+
+    def test_index_contains_dysonx_landing_identity(self):
+        html = INDEX.read_text(encoding="utf-8")
+
+        self.assertIn("DysonX tracks the signals shaping AGI.", html)
+        self.assertIn("First-source AI intelligence, structured into Signals, rankings, and decision-ready context.", html)
+        for nav_item in ("Signals", "Trackers", "AGI Map", "Companies", "People", "Research", "Reports"):
+            self.assertIn(nav_item, html)
+        self.assertIn("V1 dry-run pipeline available", html)
+        self.assertIn("Real publishing not enabled yet", html)
+        self.assertIn("EN", html)
+        self.assertIn("中文", html)
+
+    def test_index_metadata_is_english_default(self):
+        html = INDEX.read_text(encoding="utf-8")
+
+        self.assertIn('<html lang="en">', html)
+        self.assertIn("<title>DysonX | Signals Shaping AGI</title>", html)
+        self.assertIn('name="description"', html)
+        self.assertIn('property="og:title"', html)
+        self.assertIn('property="og:description"', html)
+        self.assertIn('name="twitter:title"', html)
+        self.assertIn('name="twitter:description"', html)
+        self.assertIn("English default; Chinese optional future localization", html)
+        self.assertIn('property="og:url" content="https://dysonx.ai/"', html)
+        self.assertIn('<link rel="canonical" href="https://dysonx.ai/" />', html)
+
+    def test_index_does_not_use_legacy_public_positioning(self):
+        html = read_lower(INDEX)
+        forbidden_phrases = (
+            "news aggregator",
+            "rss news site",
+            "ai-generated news blog",
+            "automated article farm",
+            "hourly rss",
+            "search news",
+            "newscontainer",
+            "posts/page",
+            "energizeos news",
+        )
+
+        for phrase in forbidden_phrases:
+            self.assertNotIn(phrase, html)
+
+    def test_robots_no_longer_points_to_removed_legacy_sitemap(self):
+        text = read_lower(ROBOTS)
+
+        self.assertNotIn("sitemap.xml", text)
+        self.assertNotIn("energizeos", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Replace the old repository and root-site identity with DysonX AI / AGI Intelligence OS positioning and a static English-default landing shell.

This PR does not implement real Signal publishing, real Notion integration, real LLM providers, social posting, Knowledge Graph, Prediction Engine, dashboard, billing, enterprise, or deployment behavior.

## Files Changed

- `README.md`
- `index.html`
- `robots.txt`
- `docs/DYSONX_LEGACY_AGGREGATOR_DECOMMISSION_PLAN.md`
- `tests/test_dysonx_identity_landing.py`

## Governance

Reviewed before work:
- `AGENTS.md`
- `docs/DYSONX_OWNER_INTENT.md`
- `docs/DYSONX_PROJECT_CONTEXT.md`
- `docs/DYSONX_PRODUCT_CONSTITUTION.md`
- `docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- `docs/DYSONX_ENGINEERING_GOVERNANCE.md`

Reviewed PRs #22 through #35.

## Identity Migration Summary

- README now describes DysonX as an AI / AGI Intelligence OS, AGI signal tracker, and first-source AI intelligence platform.
- README states Signal-first, English-default, Chinese-switchable, Notion-managed source, and V1 dry-run pipeline status.
- `index.html` now presents the headline: “DysonX tracks the signals shaping AGI.”
- The root shell includes primary navigation: Signals, Trackers, AGI Map, Companies, People, Research, Reports.
- The root shell includes EN / 中文 placeholder architecture and a V1 status section.
- Metadata now uses DysonX positioning.
- `robots.txt` no longer points to the removed legacy sitemap.

## Validation

- `python3 scripts/constitution_guard.py`
- `python3 scripts/architecture_guard.py`
- `python3 scripts/release_guard.py`
- `python3 -m py_compile scripts/*.py`
- `python3 -m unittest discover -s tests`
- `python3 scripts/dysonx_v1_pipeline.py --raw-fixture tests/fixtures/raw_items_v1.json --output-dir tmp/dysonx_v1_pipeline --dry-run`
- `git diff --check`

## Explicit Non-Actions

No real publishing, real Notion API use, real LLM API use, social posting, Knowledge Graph, Prediction Engine, dashboard, billing, enterprise, merge, deployment, or production operation was performed.