### PR TITLE
test: add DysonX static preview safety check

### DIFF
--- a/docs/DYSONX_STATIC_PREVIEW_SAFETY.md
+++ b/docs/DYSONX_STATIC_PREVIEW_SAFETY.md
@@ -1,0 +1,57 @@
+# DysonX Static Preview Safety
+
+This document defines the offline safety check for the temporary DysonX static landing shell.
+
+The check exists to verify that the root page is safe to inspect as a static preview before any real external integrations or production publishing paths are introduced.
+
+## Command
+
+```bash
+python3 scripts/dysonx_static_preview_check.py
+```
+
+The script performs local filesystem checks only. It does not require network access.
+
+## What Is Checked
+
+- `index.html` exists.
+- `index.html` declares English canonical metadata with `<html lang="en">`, a DysonX title, description metadata, Open Graph metadata, Twitter/X metadata, and canonical root URL.
+- `index.html` includes viewport metadata for basic static preview readiness.
+- `index.html` preserves DysonX identity as an AI / AGI Intelligence OS and Signal-first shell.
+- `index.html` includes the EN / Chinese switch placeholder.
+- `index.html` does not reference removed legacy generated pages such as `posts/page1.html` through `posts/page4.html`.
+- `index.html` does not reference removed `sitemap.xml`.
+- `robots.txt` does not reference removed `sitemap.xml`.
+- Active `.yml` and `.yaml` workflows do not reference deleted legacy aggregation scripts or legacy generated artifacts.
+- The DysonX V1 fixture dry-run pipeline still runs and reports no real LLM API use, no network requests, no publishing, and no social posting.
+
+## What Is Not Checked
+
+- Real GitHub Pages deployment behavior.
+- DNS, CDN, caching, custom domain, TLS, or production routing.
+- Real Notion API behavior.
+- Real LLM provider behavior.
+- Real social posting behavior.
+- Knowledge Graph writes.
+- Prediction Engine behavior.
+- Production sitemap generation.
+- Accessibility, visual QA, or browser layout correctness beyond static metadata checks.
+
+## Why This Is Not Production Publishing
+
+The current root shell is a preview/static-site shell only. It presents DysonX identity and V1 status, but it does not publish Signal pages, write public content from publish packages, call Notion, call real LLM providers, post to social platforms, or update production infrastructure.
+
+The V1 pipeline command used by the check is fixture-based and dry-run only. It writes JSON audit reports under `tmp/` and confirms that publishing and external-provider flags remain false.
+
+## Future GitHub Pages Preview Validation
+
+Before enabling a future GitHub Pages preview, validate at minimum:
+
+1. Run all governance guards, unit tests, V1 dry-run pipeline, and `dysonx_static_preview_check.py`.
+2. Confirm the preview branch or environment does not publish pages from Signal packages unless a separate publishing PR explicitly adds and reviews that behavior.
+3. Confirm any sitemap or robots behavior points only to routes that exist in the preview output.
+4. Confirm English remains canonical and Chinese remains a switchable localization layer.
+5. Confirm no workflow uses deleted legacy aggregation scripts or hardcoded monitored source lists.
+6. Confirm the preview workflow requires review before any production deployment path can run.
+
+Production publishing still requires a separate reviewed PR, explicit approval, passing CI, and no merge or deployment by an AI agent.

--- a/scripts/dysonx_static_preview_check.py
+++ b/scripts/dysonx_static_preview_check.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Offline safety checks for the DysonX static preview shell."""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+from html.parser import HTMLParser
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INDEX = ROOT / "index.html"
+ROBOTS = ROOT / "robots.txt"
+WORKFLOWS = ROOT / ".github" / "workflows"
+RAW_FIXTURE = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
+PIPELINE_OUTPUT_DIR = ROOT / "tmp" / "dysonx_static_preview_check" / "v1_pipeline"
+
+REMOVED_PUBLIC_ARTIFACTS = (
+    "posts/page1.html",
+    "posts/page2.html",
+    "posts/page3.html",
+    "posts/page4.html",
+    "sitemap.xml",
+)
+
+DELETED_LEGACY_SCRIPT_TOKENS = (
+    "scripts/aggregator.py",
+    "scripts/openai_summary.py",
+    "scripts/generate_sitemap.py",
+    "hashFiles('feeds.json')",
+    "git add posts/ sitemap.xml",
+    "OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}",
+)
+
+
+class IndexMetadataParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.html_lang = ""
+        self.title = ""
+        self._in_title = False
+        self.meta: list[dict[str, str]] = []
+        self.links: list[dict[str, str]] = []
+        self.visible_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {key.lower(): value or "" for key, value in attrs}
+        if tag == "html":
+            self.html_lang = attr_map.get("lang", "")
+        elif tag == "title":
+            self._in_title = True
+        elif tag == "meta":
+            self.meta.append(attr_map)
+        elif tag == "link":
+            self.links.append(attr_map)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        text = data.strip()
+        if not text:
+            return
+        if self._in_title:
+            self.title += text
+        self.visible_text.append(text)
+
+    def meta_content(self, key: str, value: str) -> str:
+        key = key.lower()
+        value = value.lower()
+        for item in self.meta:
+            if item.get(key, "").lower() == value:
+                return item.get("content", "")
+        return ""
+
+    def canonical_href(self) -> str:
+        for item in self.links:
+            if item.get("rel", "").lower() == "canonical":
+                return item.get("href", "")
+        return ""
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def read(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def parse_index() -> tuple[str, IndexMetadataParser]:
+    if not INDEX.exists():
+        fail("index.html is missing")
+    html = read(INDEX)
+    parser = IndexMetadataParser()
+    parser.feed(html)
+    return html, parser
+
+
+def check_index_metadata(html: str, parser: IndexMetadataParser) -> None:
+    if parser.html_lang.lower() != "en":
+        fail('index.html must declare <html lang="en">')
+    if "DysonX" not in parser.title or "AGI" not in parser.title:
+        fail("index.html title must use DysonX AGI identity")
+    if not parser.meta_content("name", "viewport"):
+        fail("index.html must include viewport metadata")
+    description = parser.meta_content("name", "description")
+    if not description:
+        fail("index.html must include English description metadata")
+    if "DysonX" not in description or "Signals" not in description:
+        fail("index.html description must preserve DysonX Signal identity")
+    if parser.canonical_href() != "https://dysonx.ai/":
+        fail("index.html must use the English canonical root URL")
+    if not parser.meta_content("property", "og:title"):
+        fail("index.html must include Open Graph title metadata")
+    if not parser.meta_content("name", "twitter:title"):
+        fail("index.html must include Twitter/X title metadata")
+    if "<html lang=\"en\"" not in html:
+        fail("index.html English canonical metadata should be explicit")
+
+
+def check_identity_and_language_placeholder(parser: IndexMetadataParser) -> None:
+    text = "\n".join(parser.visible_text)
+    required_tokens = (
+        "DysonX tracks the signals shaping AGI.",
+        "AI / AGI Intelligence OS",
+        "Signals",
+        "Trackers",
+        "AGI Map",
+        "EN",
+        "中文",
+        "Real publishing not enabled yet",
+    )
+    missing = [token for token in required_tokens if token not in text]
+    if missing:
+        fail(f"index.html is missing DysonX preview identity tokens: {', '.join(missing)}")
+
+
+def check_deleted_artifact_references(html: str) -> None:
+    robot_text = read(ROBOTS) if ROBOTS.exists() else ""
+    lower_html = html.lower()
+    lower_robots = robot_text.lower()
+    for artifact in REMOVED_PUBLIC_ARTIFACTS:
+        if artifact.lower() in lower_html:
+            fail(f"index.html references deleted artifact: {artifact}")
+    if "sitemap.xml" in lower_robots:
+        fail("robots.txt references deleted sitemap.xml")
+
+
+def check_active_workflows() -> None:
+    if not WORKFLOWS.exists():
+        return
+    offenders: dict[str, list[str]] = {}
+    active_workflows = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+    for path in active_workflows:
+        text = read(path)
+        matches = [token for token in DELETED_LEGACY_SCRIPT_TOKENS if token in text]
+        if matches:
+            offenders[path.name] = matches
+    if offenders:
+        details = "; ".join(f"{name}: {', '.join(tokens)}" for name, tokens in offenders.items())
+        fail(f"active workflows reference deleted legacy scripts or artifacts: {details}")
+
+
+def check_v1_dry_run_pipeline() -> None:
+    command = [
+        sys.executable,
+        str(ROOT / "scripts" / "dysonx_v1_pipeline.py"),
+        "--raw-fixture",
+        str(RAW_FIXTURE),
+        "--output-dir",
+        str(PIPELINE_OUTPUT_DIR),
+        "--dry-run",
+    ]
+    result = subprocess.run(command, cwd=ROOT, text=True, capture_output=True, check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        fail(f"V1 dry-run pipeline failed: {detail}")
+    summary_path = PIPELINE_OUTPUT_DIR / "pipeline_summary.json"
+    if not summary_path.exists():
+        fail("V1 dry-run pipeline did not write pipeline_summary.json")
+    summary = read(summary_path)
+    required_safety_flags = (
+        '"dry_run": true',
+        '"network_requests_performed": false',
+        '"publishing_performed": false',
+        '"real_llm_api_used": false',
+        '"social_posting_performed": false',
+    )
+    missing = [flag for flag in required_safety_flags if flag not in summary]
+    if missing:
+        fail(f"V1 dry-run pipeline summary is missing safety flags: {', '.join(missing)}")
+
+
+def run_checks() -> list[str]:
+    html, parser = parse_index()
+    checks = [
+        ("index.html exists", lambda: None),
+        ("index.html has English canonical metadata", lambda: check_index_metadata(html, parser)),
+        ("index.html has viewport metadata", lambda: parser.meta_content("name", "viewport") or fail("viewport metadata missing")),
+        ("index.html has DysonX identity", lambda: check_identity_and_language_placeholder(parser)),
+        ("index.html has EN / Chinese switch placeholder", lambda: ("EN" in html and "中文" in html) or fail("language switch placeholder missing")),
+        ("index.html avoids deleted public artifacts", lambda: check_deleted_artifact_references(html)),
+        ("robots.txt avoids deleted sitemap.xml", lambda: check_deleted_artifact_references(html)),
+        ("active workflows avoid deleted legacy scripts", check_active_workflows),
+        ("V1 dry-run pipeline still works", check_v1_dry_run_pipeline),
+    ]
+
+    passed: list[str] = []
+    for name, check in checks:
+        check()
+        passed.append(name)
+    return passed
+
+
+def main() -> int:
+    try:
+        passed = run_checks()
+    except AssertionError as exc:
+        print(f"[dysonx-static-preview-check] FAIL: {exc}")
+        return 1
+    for name in passed:
+        print(f"[dysonx-static-preview-check] PASS: {name}")
+    print("[dysonx-static-preview-check] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_static_preview_check.py
+++ b/tests/test_dysonx_static_preview_check.py
@@ -1,0 +1,40 @@
+import pathlib
+import unittest
+
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_static_preview_check as preview_check  # noqa: E402
+
+
+class DysonXStaticPreviewCheckTests(unittest.TestCase):
+    def test_static_preview_check_passes(self):
+        passed = preview_check.run_checks()
+
+        self.assertIn("index.html exists", passed)
+        self.assertIn("index.html has English canonical metadata", passed)
+        self.assertIn("active workflows avoid deleted legacy scripts", passed)
+        self.assertIn("V1 dry-run pipeline still works", passed)
+
+    def test_active_workflow_scan_excludes_disabled_legacy_workflows(self):
+        active_names = [
+            path.name
+            for path in sorted(preview_check.WORKFLOWS.glob("*.yml"))
+            + sorted(preview_check.WORKFLOWS.glob("*.yaml"))
+        ]
+
+        self.assertNotIn("update.yml.disabled", active_names)
+        self.assertNotIn("update-content.yml.disabled", active_names)
+
+    def test_removed_artifact_tokens_are_explicit(self):
+        self.assertIn("posts/page1.html", preview_check.REMOVED_PUBLIC_ARTIFACTS)
+        self.assertIn("sitemap.xml", preview_check.REMOVED_PUBLIC_ARTIFACTS)
+        self.assertIn("scripts/aggregator.py", preview_check.DELETED_LEGACY_SCRIPT_TOKENS)
+        self.assertIn("scripts/generate_sitemap.py", preview_check.DELETED_LEGACY_SCRIPT_TOKENS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add an offline DysonX Static Preview Safety Check for the new static landing shell before any real external integrations or production publishing paths are introduced.

## Scope

- Add `scripts/dysonx_static_preview_check.py`
- Add `tests/test_dysonx_static_preview_check.py`
- Add `docs/DYSONX_STATIC_PREVIEW_SAFETY.md`
- Validate root static shell metadata, DysonX identity, EN / 中文 placeholder, deleted legacy artifact references, active workflow safety, robots.txt sitemap safety, and V1 dry-run pipeline health

## Governance Review

Reviewed before implementation:

- `AGENTS.md`
- `docs/DYSONX_OWNER_INTENT.md`
- `docs/DYSONX_PROJECT_CONTEXT.md`
- `docs/DYSONX_PRODUCT_CONSTITUTION.md`
- `docs/DYSONX_SYSTEM_ARCHITECTURE.md`
- `docs/DYSONX_ENGINEERING_GOVERNANCE.md`

Reviewed PRs #22 through #36 before implementation.

## Governance Compliance

- Preserves DysonX as an AI / AGI Intelligence OS, not a generic news site
- Preserves English-default canonical metadata and Chinese switchability placeholder
- Preserves Signal-first positioning
- Does not hardcode monitored source lists
- Does not call real Notion API or real LLM APIs
- Does not publish pages from Signal packages
- Does not social post
- Does not implement Knowledge Graph, Prediction Engine, dashboard, billing, enterprise, or multi-tenant features

## Static Preview Safety Summary

The new check verifies:

- `index.html` exists
- English canonical metadata exists
- viewport metadata exists
- DysonX identity is present
- EN / 中文 switch placeholder is present
- `index.html` does not reference deleted `posts/page*.html` or `sitemap.xml`
- `robots.txt` does not reference deleted `sitemap.xml`
- active workflows do not reference deleted legacy scripts
- V1 dry-run pipeline still works and reports no network, publishing, social posting, or real LLM use

## Validation Results

- `python3 scripts/constitution_guard.py`: PASS
- `python3 scripts/architecture_guard.py`: PASS
- `python3 scripts/release_guard.py`: PASS
- `python3 -m py_compile scripts/*.py`: PASS
- `python3 -m unittest discover -s tests`: PASS, 96 tests
- `python3 scripts/dysonx_v1_pipeline.py --raw-fixture tests/fixtures/raw_items_v1.json --output-dir tmp/dysonx_v1_pipeline --dry-run`: PASS
- `python3 scripts/dysonx_static_preview_check.py`: PASS
- `git diff --check`: PASS

## Deployment Impact

No deployment impact. No merge or production deployment was performed.

## Known Limitations

- This is static/offline validation only.
- It does not validate real GitHub Pages deployment behavior, DNS, CDN, custom domain, production routing, visual QA, accessibility, real Notion API behavior, real LLM providers, social posting, Knowledge Graph writes, or Prediction Engine behavior.

No merge or production deployment was performed.
