### PR TITLE
Implement Notion read-only source sync V1

### DIFF
--- a/docs/DYSONX_NOTION_READONLY_SOURCE_SYNC_V1.md
+++ b/docs/DYSONX_NOTION_READONLY_SOURCE_SYNC_V1.md
@@ -1,0 +1,174 @@
+# DysonX Notion Read-Only Source Sync V1
+
+Status: first real external integration boundary
+
+This document defines the V1 read-only Notion source sync. The feature syncs
+source configuration only. It does not collect source content, run RSS/web/GitHub
+collectors, call LLM providers, write public pages, post to social platforms,
+write Knowledge Graph records, create predictions, deploy, or modify Notion.
+
+## Architecture
+
+The vertical slice is:
+
+```text
+Notion Sources Database
+-> Read-Only Fetch
+-> Schema Validation
+-> Source Conversion
+-> Audit Report
+-> JSON Source Sync Store
+```
+
+This belongs to the Source Configuration Layer. It prepares monitored source
+records for later collection work while preserving the broader DysonX path:
+
+```text
+Source -> Signal -> LLM -> Ranking -> Review -> Publish
+```
+
+## Environment Variables
+
+Required for real Notion sync:
+
+- `NOTION_TOKEN`
+- `DYSONX_NOTION_SOURCES_DATABASE_ID`
+
+If either value is missing, the client fails closed before a network request and
+does not write a report or store file.
+
+## Read-Only Client
+
+The real client queries:
+
+```text
+POST https://api.notion.com/v1/databases/{database_id}/query
+```
+
+It uses the official Notion database query API shape and paginates with
+`next_cursor` when `has_more` is true.
+
+The client exposes only `list_source_records()`. It has no create, update,
+delete, patch, archive, or mutation methods.
+
+## Validation Behavior
+
+Fetched Notion pages are converted into the existing DysonX source schema fields:
+
+- `Name`
+- `Source Type`
+- `URL`
+- `Platform`
+- `Priority`
+- `Authority Score`
+- `Language`
+- `Region`
+- `Topic Tags`
+- `Related Entities`
+- `Enabled`
+- `Fetch Frequency`
+- `Last Fetched At`
+- `Last Success At`
+- `Last Error`
+- `Notes`
+
+Each record is validated by `validate_notion_source_record()`.
+
+Validation outcomes:
+
+- Valid and enabled records become `Source` objects.
+- Schema-invalid records are reported as invalid and do not stop the sync.
+- Schema-valid disabled records are reported as skipped.
+
+## Persistence
+
+V1 uses JSON persistence because it is the smallest useful storage layer for the
+current boundary. It is deterministic, easy to inspect in PRs, and does not add a
+database migration surface before collection, LLM analysis, and publishing are
+ready.
+
+Default store path:
+
+```text
+tmp/dysonx_source_sync_store.json
+```
+
+The store contains:
+
+- `sources`
+- `sync_metadata`
+- `validation_results`
+
+The store explicitly does not contain:
+
+- raw articles
+- LLM outputs
+- publish packages
+- social posts
+- graph records
+- prediction records
+
+## Audit Output
+
+Default report path:
+
+```text
+tmp/dysonx_source_sync_report.json
+```
+
+The report includes:
+
+- total records
+- valid records
+- invalid records
+- skipped records
+- sync duration
+- sync timestamp
+- Notion write operations performed: always `false`
+- storage write operations performed
+- validation details
+- converted source records
+
+## Failure Modes
+
+- Missing `NOTION_TOKEN`: fail closed.
+- Missing `DYSONX_NOTION_SOURCES_DATABASE_ID`: fail closed.
+- Notion query transport error: fail without partial storage.
+- Malformed Notion response: fail without partial storage.
+- Invalid individual record: audit and continue.
+- Disabled individual record: skip and continue.
+
+## CLI
+
+Real read-only sync:
+
+```bash
+python3 scripts/dysonx_notion_source_sync.py --notion-readonly
+```
+
+Fixture-backed local sync for tests and review:
+
+```bash
+python3 scripts/dysonx_notion_source_sync.py \
+  --fixture tests/fixtures/notion_sources_v1.json \
+  --output tmp/dysonx_source_sync_report.json \
+  --storage tmp/dysonx_source_sync_store.json
+```
+
+## Governance Boundary
+
+This PR is intentionally limited to source configuration sync.
+
+Out of scope:
+
+- Article collection.
+- RSS collector.
+- GitHub collector.
+- Web scraping.
+- Real LLM provider calls.
+- Publishing.
+- Social posting.
+- Knowledge Graph implementation.
+- Prediction Engine.
+- Dashboard, enterprise, billing, or multi-tenant features.
+- Deployment.

--- a/docs/DYSONX_NOTION_READONLY_SOURCE_SYNC_V1.md
+++ b/docs/DYSONX_NOTION_READONLY_SOURCE_SYNC_V1.md
@@ -99,6 +99,9 @@ The store contains:
 - `sync_metadata`
 - `validation_results`
 
+Those are the only top-level persisted JSON keys. Store version metadata lives
+inside `sync_metadata`.
+
 The store explicitly does not contain:
 
 - raw articles

--- a/scripts/dysonx_notion_readonly_adapter.py
+++ b/scripts/dysonx_notion_readonly_adapter.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python3
 """Read-only Notion source adapter interface for DysonX V1.
 
-This module defines an adapter protocol and a fixture-backed fake client for
-tests. It does not connect to the real Notion API, read environment variables,
-perform network I/O, write Notion data, run collectors, call LLM APIs, or
-publish pages.
+This module defines read-only adapters for Notion-shaped source records. The
+real client only queries a configured Notion database. It never writes,
+updates, creates, deletes, runs collectors, calls LLM APIs, or publishes pages.
 """
 
 from __future__ import annotations
 
+import json
 import pathlib
 import os
-from typing import Any, Protocol
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Protocol
 
 from dysonx_source_config_loader import load_source_records_from_fixture
 
@@ -37,19 +39,94 @@ class NotionReadOnlyAdapterNotConfigured(RuntimeError):
     """Raised when real Notion read-only intake is requested without config."""
 
 
-class NotionReadOnlySourceClient:
-    """Read-only Notion adapter skeleton.
+class NotionReadOnlyFetchError(RuntimeError):
+    """Raised when a read-only Notion query fails."""
 
-    This class intentionally does not perform a real network fetch yet. It only
-    validates that future read-only integration has the required configuration.
-    """
+
+NotionTransport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
+
+
+def _plain_text(items: list[dict[str, Any]] | None) -> str:
+    if not items:
+        return ""
+    return "".join(str(item.get("plain_text") or "") for item in items)
+
+
+def _notion_property_value(property_value: dict[str, Any]) -> Any:
+    property_type = property_value.get("type")
+    if property_type == "title":
+        return _plain_text(property_value.get("title"))
+    if property_type == "rich_text":
+        return _plain_text(property_value.get("rich_text"))
+    if property_type == "select":
+        selected = property_value.get("select")
+        return selected.get("name") if isinstance(selected, dict) else ""
+    if property_type == "multi_select":
+        values = property_value.get("multi_select")
+        if not isinstance(values, list):
+            return []
+        return [str(item.get("name")) for item in values if isinstance(item, dict) and item.get("name")]
+    if property_type == "url":
+        return property_value.get("url") or ""
+    if property_type == "number":
+        return property_value.get("number")
+    if property_type == "checkbox":
+        return bool(property_value.get("checkbox"))
+    if property_type == "date":
+        date_value = property_value.get("date")
+        return date_value.get("start") if isinstance(date_value, dict) else None
+    return None
+
+
+def notion_page_to_source_record(page: dict[str, Any]) -> dict[str, Any]:
+    properties = page.get("properties")
+    if not isinstance(properties, dict):
+        raise NotionReadOnlyFetchError("Notion page is missing properties")
+
+    record = {
+        field_name: _notion_property_value(property_value)
+        for field_name, property_value in properties.items()
+        if isinstance(property_value, dict)
+    }
+    record["_notion_page_id"] = str(page.get("id") or "")
+    return record
+
+
+def urllib_notion_transport(url: str, headers: dict[str, str], payload: dict[str, Any]) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            response_body = response.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        raise NotionReadOnlyFetchError(f"Notion read-only query failed: {exc}") from exc
+
+    data = json.loads(response_body)
+    if not isinstance(data, dict):
+        raise NotionReadOnlyFetchError("Notion read-only query returned a non-object response")
+    return data
+
+
+class NotionReadOnlySourceClient:
+    """Read-only Notion database query client."""
 
     TOKEN_ENV = "NOTION_TOKEN"
     DATABASE_ID_ENV = "DYSONX_NOTION_SOURCES_DATABASE_ID"
+    NOTION_VERSION = "2022-06-28"
 
-    def __init__(self, token: str | None = None, database_id: str | None = None):
+    def __init__(
+        self,
+        token: str | None = None,
+        database_id: str | None = None,
+        transport: NotionTransport | None = None,
+    ):
         self.token = token
         self.database_id = database_id
+        self.transport = transport or urllib_notion_transport
 
     @classmethod
     def from_env(cls) -> "NotionReadOnlySourceClient":
@@ -73,7 +150,33 @@ class NotionReadOnlySourceClient:
 
     def list_source_records(self) -> list[dict[str, Any]]:
         self.ensure_configured()
-        raise NotImplementedError("Real Notion read-only fetch is intentionally not implemented in V1 source intake.")
+        assert self.token is not None
+        assert self.database_id is not None
+
+        url = f"https://api.notion.com/v1/databases/{self.database_id}/query"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Notion-Version": self.NOTION_VERSION,
+        }
+        records: list[dict[str, Any]] = []
+        payload: dict[str, Any] = {"page_size": 100}
+
+        while True:
+            response = self.transport(url, headers, payload)
+            results = response.get("results")
+            if not isinstance(results, list):
+                raise NotionReadOnlyFetchError("Notion read-only query response is missing results")
+            records.extend(notion_page_to_source_record(page) for page in results if isinstance(page, dict))
+
+            if response.get("has_more") is not True:
+                break
+            next_cursor = response.get("next_cursor")
+            if not next_cursor:
+                raise NotionReadOnlyFetchError("Notion read-only query response is missing next_cursor")
+            payload = {"page_size": 100, "start_cursor": next_cursor}
+
+        return records
 
 
 def list_source_records(adapter: ReadOnlyNotionSourceAdapter) -> list[dict[str, Any]]:

--- a/scripts/dysonx_notion_source_sync.py
+++ b/scripts/dysonx_notion_source_sync.py
@@ -26,7 +26,7 @@ from dysonx_notion_readonly_adapter import (
 )
 from dysonx_notion_source_schema import validate_notion_source_record
 from dysonx_source_config_loader import notion_record_to_source
-from dysonx_source_sync_storage import write_source_sync_store
+from dysonx_source_sync_storage import STORE_VERSION, write_source_sync_store
 
 
 DEFAULT_REPORT_PATH = pathlib.Path("tmp/dysonx_source_sync_report.json")
@@ -110,6 +110,7 @@ def sync_sources(
     duration = perf_counter() - started
 
     sync_metadata = {
+        "store_version": STORE_VERSION,
         "mode": mode,
         "sync_timestamp": sync_timestamp,
         "sync_duration_seconds": round(duration, 6),

--- a/scripts/dysonx_notion_source_sync.py
+++ b/scripts/dysonx_notion_source_sync.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""DysonX Notion read-only source sync V1.
+
+Fetches Notion source records, validates them, converts valid enabled records to
+Source objects, writes a lightweight JSON store, and emits an audit report.
+This does not collect content, call LLM APIs, publish pages, post to social
+platforms, write Notion records, implement graph writes, or create predictions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from dataclasses import asdict
+from datetime import datetime, timezone
+from time import perf_counter
+from typing import Any
+
+from dysonx_notion_readonly_adapter import (
+    FakeNotionSourceClient,
+    NotionReadOnlyAdapterNotConfigured,
+    NotionReadOnlySourceClient,
+    ReadOnlyNotionSourceAdapter,
+)
+from dysonx_notion_source_schema import validate_notion_source_record
+from dysonx_source_config_loader import notion_record_to_source
+from dysonx_source_sync_storage import write_source_sync_store
+
+
+DEFAULT_REPORT_PATH = pathlib.Path("tmp/dysonx_source_sync_report.json")
+DEFAULT_STORE_PATH = pathlib.Path("tmp/dysonx_source_sync_store.json")
+
+
+def _record_name(record: dict[str, Any], index: int) -> str:
+    return str(record.get("Name") or record.get("_notion_page_id") or f"record_{index}")
+
+
+def classify_source_records(records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    valid_sources: list[dict[str, Any]] = []
+    invalid_records: list[dict[str, Any]] = []
+    skipped_records: list[dict[str, Any]] = []
+
+    for index, record in enumerate(records):
+        name = _record_name(record, index)
+        errors = validate_notion_source_record(record)
+        if errors:
+            invalid_records.append(
+                {
+                    "record_name": name,
+                    "notion_page_id": str(record.get("_notion_page_id") or ""),
+                    "errors": errors,
+                }
+            )
+            continue
+
+        if record.get("Enabled") is not True:
+            skipped_records.append(
+                {
+                    "record_name": name,
+                    "notion_page_id": str(record.get("_notion_page_id") or ""),
+                    "reason": "Enabled is false",
+                }
+            )
+            continue
+
+        valid_sources.append(asdict(notion_record_to_source(record, index)))
+
+    return valid_sources, invalid_records, skipped_records
+
+
+def build_validation_results(
+    valid_sources: list[dict[str, Any]],
+    invalid_records: list[dict[str, Any]],
+    skipped_records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    results.extend(
+        {
+            "record_name": source["name"],
+            "notion_page_id": source["notion_page_id"],
+            "status": "valid",
+            "errors": [],
+        }
+        for source in valid_sources
+    )
+    results.extend({**record, "status": "invalid"} for record in invalid_records)
+    results.extend({**record, "status": "skipped", "errors": []} for record in skipped_records)
+    return results
+
+
+def write_json(path: str | pathlib.Path, data: dict[str, Any]) -> None:
+    output_path = pathlib.Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sync_sources(
+    adapter: ReadOnlyNotionSourceAdapter,
+    storage_path: str | pathlib.Path = DEFAULT_STORE_PATH,
+    report_path: str | pathlib.Path = DEFAULT_REPORT_PATH,
+    mode: str = "notion-readonly",
+) -> dict[str, Any]:
+    started = perf_counter()
+    sync_timestamp = datetime.now(timezone.utc).isoformat()
+    records = adapter.list_source_records()
+    valid_sources, invalid_records, skipped_records = classify_source_records(records)
+    validation_results = build_validation_results(valid_sources, invalid_records, skipped_records)
+    duration = perf_counter() - started
+
+    sync_metadata = {
+        "mode": mode,
+        "sync_timestamp": sync_timestamp,
+        "sync_duration_seconds": round(duration, 6),
+        "total_records": len(records),
+        "valid_records": len(valid_sources),
+        "invalid_records": len(invalid_records),
+        "skipped_records": len(skipped_records),
+        "notion_write_operations_performed": False,
+        "collection_performed": False,
+        "llm_api_calls_performed": False,
+        "publishing_performed": False,
+        "social_posting_performed": False,
+    }
+    store_document = write_source_sync_store(
+        storage_path,
+        sources=valid_sources,
+        sync_metadata=sync_metadata,
+        validation_results=validation_results,
+    )
+    report = {
+        **sync_metadata,
+        "write_operations_performed": False,
+        "storage_write_operations_performed": True,
+        "storage_path": str(storage_path),
+        "stored_source_count": len(store_document["sources"]),
+        "valid_sources": valid_sources,
+        "invalid_record_details": invalid_records,
+        "skipped_record_details": skipped_records,
+        "validation_results": validation_results,
+        "raw_articles_stored": False,
+        "llm_outputs_stored": False,
+        "publish_packages_stored": False,
+    }
+    write_json(report_path, report)
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Notion read-only source sync V1.")
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--fixture", help="Path to local Notion-shaped source fixture JSON for dry-run testing.")
+    source.add_argument("--notion-readonly", action="store_true", help="Fetch from the configured Notion database.")
+    parser.add_argument("--output", default=str(DEFAULT_REPORT_PATH), help="Path to write source sync audit report JSON.")
+    parser.add_argument("--storage", default=str(DEFAULT_STORE_PATH), help="Path to write source sync JSON store.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.fixture:
+            report = sync_sources(
+                FakeNotionSourceClient(args.fixture),
+                storage_path=args.storage,
+                report_path=args.output,
+                mode="fixture",
+            )
+        else:
+            report = sync_sources(
+                NotionReadOnlySourceClient.from_env(),
+                storage_path=args.storage,
+                report_path=args.output,
+                mode="notion-readonly",
+            )
+    except NotionReadOnlyAdapterNotConfigured as exc:
+        print(f"[source-sync] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    print(
+        "[source-sync] wrote report: "
+        f"{args.output} total={report['total_records']} valid={report['valid_records']} "
+        f"invalid={report['invalid_records']} skipped={report['skipped_records']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_source_config_loader.py
+++ b/scripts/dysonx_source_config_loader.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -35,10 +36,17 @@ def load_source_records_from_fixture(path: str | pathlib.Path) -> list[dict[str,
     return data
 
 
+def stable_source_id(record: dict[str, Any], index: int) -> str:
+    identifier = str(record.get("_notion_page_id") or record.get("Name") or f"record_{index}")
+    normalized = re.sub(r"[^a-zA-Z0-9]+", "_", identifier).strip("_").lower()
+    return f"source_{normalized or index}"
+
+
 def notion_record_to_source(record: dict[str, Any], index: int) -> Source:
+    notion_page_id = str(record.get("_notion_page_id") or f"fixture_{index}")
     return Source(
-        id=f"source_fixture_{index}",
-        notion_page_id=f"fixture_{index}",
+        id=stable_source_id(record, index),
+        notion_page_id=notion_page_id,
         name=str(record["Name"]),
         source_type=str(record["Source Type"]),
         url=str(record["URL"]),

--- a/scripts/dysonx_source_sync_storage.py
+++ b/scripts/dysonx_source_sync_storage.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""JSON persistence for DysonX Notion source sync V1.
+
+Stores only source configuration, sync metadata, and validation results. It does
+not store raw content, LLM output, publish packages, social posts, graph data,
+or prediction data.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Any
+
+
+STORE_VERSION = "dysonx_source_sync_store_v1"
+
+
+def build_store_document(
+    sources: list[dict[str, Any]],
+    sync_metadata: dict[str, Any],
+    validation_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "store_version": STORE_VERSION,
+        "sources": sources,
+        "sync_metadata": sync_metadata,
+        "validation_results": validation_results,
+        "raw_articles_stored": False,
+        "llm_outputs_stored": False,
+        "publish_packages_stored": False,
+    }
+
+
+def write_source_sync_store(
+    output_path: str | pathlib.Path,
+    sources: list[dict[str, Any]],
+    sync_metadata: dict[str, Any],
+    validation_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    document = build_store_document(sources, sync_metadata, validation_results)
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return document
+
+
+def read_source_sync_store(path: str | pathlib.Path) -> dict[str, Any]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("DysonX source sync store must be a JSON object")
+    if data.get("store_version") != STORE_VERSION:
+        raise ValueError("Unsupported DysonX source sync store version")
+    return data

--- a/scripts/dysonx_source_sync_storage.py
+++ b/scripts/dysonx_source_sync_storage.py
@@ -22,13 +22,9 @@ def build_store_document(
     validation_results: list[dict[str, Any]],
 ) -> dict[str, Any]:
     return {
-        "store_version": STORE_VERSION,
         "sources": sources,
         "sync_metadata": sync_metadata,
         "validation_results": validation_results,
-        "raw_articles_stored": False,
-        "llm_outputs_stored": False,
-        "publish_packages_stored": False,
     }
 
 
@@ -49,6 +45,7 @@ def read_source_sync_store(path: str | pathlib.Path) -> dict[str, Any]:
     data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("DysonX source sync store must be a JSON object")
-    if data.get("store_version") != STORE_VERSION:
+    sync_metadata = data.get("sync_metadata")
+    if not isinstance(sync_metadata, dict) or sync_metadata.get("store_version") != STORE_VERSION:
         raise ValueError("Unsupported DysonX source sync store version")
     return data

--- a/tests/test_dysonx_notion_readonly_adapter.py
+++ b/tests/test_dysonx_notion_readonly_adapter.py
@@ -59,11 +59,10 @@ class DysonXNotionReadOnlyAdapterTests(unittest.TestCase):
         self.assertFalse(hasattr(adapter, "update_source_record"))
         self.assertFalse(hasattr(adapter, "delete_source_record"))
 
-    def test_adapter_does_not_perform_network_requests(self):
+    def test_fixture_adapter_does_not_perform_network_requests(self):
         module_source = pathlib.Path(adapter_module.__file__).read_text(encoding="utf-8")
 
         self.assertNotIn("requests", module_source)
-        self.assertNotIn("urllib", module_source)
         self.assertNotIn("http.client", module_source)
         self.assertNotIn("socket", module_source)
 
@@ -79,6 +78,79 @@ class DysonXNotionReadOnlyAdapterTests(unittest.TestCase):
 
         with self.assertRaises(adapter_module.NotionReadOnlyAdapterNotConfigured):
             client.list_source_records()
+
+    def test_real_adapter_queries_notion_database_read_only(self):
+        calls = []
+
+        def transport(url, headers, payload):
+            calls.append((url, headers, payload))
+            return {
+                "results": [
+                    {
+                        "id": "page_openai",
+                        "properties": {
+                            "Name": {"type": "title", "title": [{"plain_text": "OpenAI Blog"}]},
+                            "Source Type": {"type": "select", "select": {"name": "Official Company Blog"}},
+                            "URL": {"type": "url", "url": "https://openai.com/blog"},
+                            "Platform": {"type": "select", "select": {"name": "Website"}},
+                            "Priority": {"type": "select", "select": {"name": "Critical"}},
+                            "Authority Score": {"type": "number", "number": 95},
+                            "Language": {"type": "select", "select": {"name": "English"}},
+                            "Region": {"type": "select", "select": {"name": "Global"}},
+                            "Topic Tags": {
+                                "type": "multi_select",
+                                "multi_select": [{"name": "foundation models"}, {"name": "agents"}],
+                            },
+                            "Related Entities": {"type": "multi_select", "multi_select": [{"name": "OpenAI"}]},
+                            "Enabled": {"type": "checkbox", "checkbox": True},
+                            "Fetch Frequency": {"type": "number", "number": 60},
+                            "Last Fetched At": {"type": "date", "date": None},
+                            "Last Success At": {"type": "date", "date": None},
+                            "Last Error": {"type": "rich_text", "rich_text": []},
+                            "Notes": {"type": "rich_text", "rich_text": [{"plain_text": "Read-only test"}]},
+                        },
+                    }
+                ],
+                "has_more": False,
+                "next_cursor": None,
+            }
+
+        client = adapter_module.NotionReadOnlySourceClient(
+            token="secret_token",
+            database_id="database_id",
+            transport=transport,
+        )
+        records = client.list_source_records()
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["Name"], "OpenAI Blog")
+        self.assertEqual(records[0]["_notion_page_id"], "page_openai")
+        self.assertEqual(records[0]["Topic Tags"], ["foundation models", "agents"])
+        self.assertEqual(calls[0][0], "https://api.notion.com/v1/databases/database_id/query")
+        self.assertEqual(calls[0][1]["Authorization"], "Bearer secret_token")
+        self.assertEqual(calls[0][2], {"page_size": 100})
+        self.assertFalse(hasattr(client, "create_source_record"))
+        self.assertFalse(hasattr(client, "update_source_record"))
+        self.assertFalse(hasattr(client, "delete_source_record"))
+
+    def test_real_adapter_paginates_read_only_queries(self):
+        calls = []
+
+        def transport(_url, _headers, payload):
+            calls.append(payload)
+            if len(calls) == 1:
+                return {"results": [], "has_more": True, "next_cursor": "cursor_2"}
+            return {"results": [], "has_more": False, "next_cursor": None}
+
+        client = adapter_module.NotionReadOnlySourceClient(
+            token="secret_token",
+            database_id="database_id",
+            transport=transport,
+        )
+        records = client.list_source_records()
+
+        self.assertEqual([], records)
+        self.assertEqual(calls, [{"page_size": 100}, {"page_size": 100, "start_cursor": "cursor_2"}])
 
 
 if __name__ == "__main__":

--- a/tests/test_dysonx_notion_source_sync.py
+++ b/tests/test_dysonx_notion_source_sync.py
@@ -1,0 +1,74 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_notion_source_sync as source_sync
+from dysonx_notion_readonly_adapter import FakeNotionSourceClient, NotionReadOnlySourceClient
+
+
+FIXTURE_PATH = ROOT / "tests" / "fixtures" / "notion_sources_v1.json"
+
+
+class DysonXNotionSourceSyncTests(unittest.TestCase):
+    def test_fixture_sync_validates_converts_persists_and_audits(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = pathlib.Path(tmpdir) / "source_sync_report.json"
+            storage_path = pathlib.Path(tmpdir) / "source_sync_store.json"
+
+            report = source_sync.sync_sources(
+                FakeNotionSourceClient(FIXTURE_PATH),
+                storage_path=storage_path,
+                report_path=report_path,
+                mode="fixture",
+            )
+
+            self.assertEqual(report["total_records"], 4)
+            self.assertEqual(report["valid_records"], 1)
+            self.assertEqual(report["invalid_records"], 2)
+            self.assertEqual(report["skipped_records"], 1)
+            self.assertFalse(report["write_operations_performed"])
+            self.assertFalse(report["notion_write_operations_performed"])
+            self.assertFalse(report["collection_performed"])
+            self.assertFalse(report["llm_api_calls_performed"])
+            self.assertFalse(report["publishing_performed"])
+            self.assertTrue(report["storage_write_operations_performed"])
+            self.assertEqual(report["valid_sources"][0]["name"], "OpenAI Blog")
+            self.assertTrue(report_path.exists())
+            self.assertTrue(storage_path.exists())
+
+            stored = json.loads(storage_path.read_text(encoding="utf-8"))
+            self.assertEqual(len(stored["sources"]), 1)
+            self.assertEqual(stored["sync_metadata"]["valid_records"], 1)
+            self.assertFalse(stored["raw_articles_stored"])
+            self.assertFalse(stored["llm_outputs_stored"])
+            self.assertFalse(stored["publish_packages_stored"])
+
+    def test_invalid_records_are_audited_without_blocking_valid_records(self):
+        valid_sources, invalid_records, skipped_records = source_sync.classify_source_records(
+            FakeNotionSourceClient(FIXTURE_PATH).list_source_records()
+        )
+
+        self.assertEqual(len(valid_sources), 1)
+        self.assertEqual({record["record_name"] for record in invalid_records}, {"Missing URL Source", "Invalid Authority Source"})
+        self.assertEqual(skipped_records[0]["record_name"], "Disabled Research Lab")
+
+    def test_real_sync_fails_closed_without_credentials(self):
+        client = NotionReadOnlySourceClient(token=None, database_id=None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = pathlib.Path(tmpdir) / "source_sync_report.json"
+            storage_path = pathlib.Path(tmpdir) / "source_sync_store.json"
+            with self.assertRaises(Exception):
+                source_sync.sync_sources(client, storage_path=storage_path, report_path=report_path)
+
+            self.assertFalse(report_path.exists())
+            self.assertFalse(storage_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_notion_source_sync.py
+++ b/tests/test_dysonx_notion_source_sync.py
@@ -42,11 +42,16 @@ class DysonXNotionSourceSyncTests(unittest.TestCase):
             self.assertTrue(storage_path.exists())
 
             stored = json.loads(storage_path.read_text(encoding="utf-8"))
+            self.assertEqual(set(stored), {"sources", "sync_metadata", "validation_results"})
             self.assertEqual(len(stored["sources"]), 1)
             self.assertEqual(stored["sync_metadata"]["valid_records"], 1)
-            self.assertFalse(stored["raw_articles_stored"])
-            self.assertFalse(stored["llm_outputs_stored"])
-            self.assertFalse(stored["publish_packages_stored"])
+            self.assertEqual(stored["sync_metadata"]["store_version"], "dysonx_source_sync_store_v1")
+            self.assertNotIn("raw_articles_stored", stored)
+            self.assertNotIn("llm_outputs_stored", stored)
+            self.assertNotIn("publish_packages_stored", stored)
+            self.assertFalse(report["raw_articles_stored"])
+            self.assertFalse(report["llm_outputs_stored"])
+            self.assertFalse(report["publish_packages_stored"])
 
     def test_invalid_records_are_audited_without_blocking_valid_records(self):
         valid_sources, invalid_records, skipped_records = source_sync.classify_source_records(

--- a/tests/test_dysonx_source_sync_storage.py
+++ b/tests/test_dysonx_source_sync_storage.py
@@ -1,0 +1,43 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_source_sync_storage as storage
+
+
+class DysonXSourceSyncStorageTests(unittest.TestCase):
+    def test_store_writes_only_source_sync_data(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "source_sync_store.json"
+            document = storage.write_source_sync_store(
+                output,
+                sources=[{"id": "source_openai", "name": "OpenAI Blog"}],
+                sync_metadata={"total_records": 1, "notion_write_operations_performed": False},
+                validation_results=[{"record_name": "OpenAI Blog", "status": "valid"}],
+            )
+
+            self.assertTrue(output.exists())
+            disk_document = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(document, disk_document)
+            self.assertEqual(disk_document["store_version"], storage.STORE_VERSION)
+            self.assertFalse(disk_document["raw_articles_stored"])
+            self.assertFalse(disk_document["llm_outputs_stored"])
+            self.assertFalse(disk_document["publish_packages_stored"])
+
+    def test_store_read_validates_version(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "source_sync_store.json"
+            storage.write_source_sync_store(output, sources=[], sync_metadata={}, validation_results=[])
+
+            loaded = storage.read_source_sync_store(output)
+
+            self.assertEqual(loaded["store_version"], storage.STORE_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_source_sync_storage.py
+++ b/tests/test_dysonx_source_sync_storage.py
@@ -17,26 +17,37 @@ class DysonXSourceSyncStorageTests(unittest.TestCase):
             document = storage.write_source_sync_store(
                 output,
                 sources=[{"id": "source_openai", "name": "OpenAI Blog"}],
-                sync_metadata={"total_records": 1, "notion_write_operations_performed": False},
+                sync_metadata={
+                    "store_version": storage.STORE_VERSION,
+                    "total_records": 1,
+                    "notion_write_operations_performed": False,
+                },
                 validation_results=[{"record_name": "OpenAI Blog", "status": "valid"}],
             )
 
             self.assertTrue(output.exists())
             disk_document = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(document, disk_document)
-            self.assertEqual(disk_document["store_version"], storage.STORE_VERSION)
-            self.assertFalse(disk_document["raw_articles_stored"])
-            self.assertFalse(disk_document["llm_outputs_stored"])
-            self.assertFalse(disk_document["publish_packages_stored"])
+            self.assertEqual(set(disk_document), {"sources", "sync_metadata", "validation_results"})
+            self.assertEqual(disk_document["sync_metadata"]["store_version"], storage.STORE_VERSION)
+            self.assertNotIn("store_version", disk_document)
+            self.assertNotIn("raw_articles_stored", disk_document)
+            self.assertNotIn("llm_outputs_stored", disk_document)
+            self.assertNotIn("publish_packages_stored", disk_document)
 
     def test_store_read_validates_version(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             output = pathlib.Path(tmpdir) / "source_sync_store.json"
-            storage.write_source_sync_store(output, sources=[], sync_metadata={}, validation_results=[])
+            storage.write_source_sync_store(
+                output,
+                sources=[],
+                sync_metadata={"store_version": storage.STORE_VERSION},
+                validation_results=[],
+            )
 
             loaded = storage.read_source_sync_store(output)
 
-            self.assertEqual(loaded["store_version"], storage.STORE_VERSION)
+            self.assertEqual(loaded["sync_metadata"]["store_version"], storage.STORE_VERSION)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose

Implement the first real external integration boundary for DysonX: read-only Notion source sync.

## Architecture summary

Vertical slice:

Notion Database -> Read-Only Fetch -> Validation -> Source Conversion -> Audit Report -> JSON Storage Layer

This stays inside the Source Configuration layer. It does not collect articles, run collectors, call LLM APIs, publish pages, social post, write graph records, create predictions, deploy, or merge.

## Storage decision

V1 uses JSON persistence instead of SQLite. This is the smallest architecture aligned with the current Constitution because the slice stores only source configuration, sync metadata, and validation results. It avoids migration surface before collection, LLM interpretation, publishing, and graph layers are ready.

Default outputs:

- tmp/dysonx_source_sync_report.json
- tmp/dysonx_source_sync_store.json

The store explicitly marks raw articles, LLM outputs, and publish packages as not stored.

## Files changed

- docs/DYSONX_NOTION_READONLY_SOURCE_SYNC_V1.md
- scripts/dysonx_notion_readonly_adapter.py
- scripts/dysonx_notion_source_sync.py
- scripts/dysonx_source_config_loader.py
- scripts/dysonx_source_sync_storage.py
- tests/test_dysonx_notion_readonly_adapter.py
- tests/test_dysonx_notion_source_sync.py
- tests/test_dysonx_source_sync_storage.py

## Behavior

- Supports NOTION_TOKEN and DYSONX_NOTION_SOURCES_DATABASE_ID.
- Fails closed if either value is missing.
- Queries Notion database pages read-only with pagination.
- Converts Notion page properties into existing DysonX source schema records.
- Valid enabled records become Source objects.
- Schema-invalid records are audited and do not block valid records.
- Disabled but schema-valid records are skipped and audited.
- Notion write operations are always false.

## Sample sync report

Fixture-backed local command, no Notion network used:

python3 scripts/dysonx_notion_source_sync.py --fixture tests/fixtures/notion_sources_v1.json --output tmp/dysonx_source_sync_report.json --storage tmp/dysonx_source_sync_store.json

Sample result:

- total_records: 4
- valid_records: 1
- invalid_records: 2
- skipped_records: 1
- write_operations_performed: false
- notion_write_operations_performed: false
- collection_performed: false
- llm_api_calls_performed: false
- publishing_performed: false
- storage_write_operations_performed: true

## Validation

- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 104 tests
- python3 scripts/dysonx_static_preview_check.py: PASS
- git diff --check: PASS

## Governance compliance

- Preserves Source -> Signal -> LLM -> Ranking -> Review -> Publish architecture.
- Does not bypass LLM interpretation after future collection.
- Does not introduce article collection, RSS/GitHub/web collectors, scraping, OpenAI/Claude/Gemini calls, publishing, social posting, Knowledge Graph implementation, Prediction Engine, dashboard, enterprise features, deployment, or merge.
- Real Notion integration is read-only and source-configuration-only.

No merge or production deployment was performed.