### PR TITLE
Add DysonX Notion live smoke test

### DIFF
--- a/.github/workflows/dysonx-notion-smoke-test.yml
+++ b/.github/workflows/dysonx-notion-smoke-test.yml
@@ -1,0 +1,87 @@
+name: DysonX Notion Read-Only Smoke Test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  notion-readonly-smoke:
+    name: Notion read-only source sync smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      DYSONX_NOTION_SOURCES_DATABASE_ID: ${{ secrets.DYSONX_NOTION_SOURCES_DATABASE_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run Notion read-only source sync
+        run: |
+          python3 scripts/dysonx_notion_source_sync.py \
+            --notion-readonly \
+            --output tmp/dysonx_source_sync_report.json \
+            --storage tmp/dysonx_source_sync_store.json
+
+      - name: Assert smoke-test safety boundary
+        run: |
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          report_path = pathlib.Path("tmp/dysonx_source_sync_report.json")
+          store_path = pathlib.Path("tmp/dysonx_source_sync_store.json")
+
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          store = json.loads(store_path.read_text(encoding="utf-8"))
+
+          expected_store_keys = {"sources", "sync_metadata", "validation_results"}
+          if set(store) != expected_store_keys:
+              print(f"[notion-smoke] FAIL: unexpected store keys: {sorted(store)}")
+              sys.exit(1)
+
+          expected_false_flags = {
+              "write_operations_performed": "Notion writes",
+              "notion_write_operations_performed": "Notion writes",
+              "collection_performed": "collection",
+              "llm_api_calls_performed": "LLM calls",
+              "publishing_performed": "publishing",
+              "social_posting_performed": "social posting",
+              "raw_articles_stored": "raw article storage",
+              "llm_outputs_stored": "LLM output storage",
+              "publish_packages_stored": "publish package storage",
+          }
+          for key, label in expected_false_flags.items():
+              if report.get(key) is not False:
+                  print(f"[notion-smoke] FAIL: {label} flag is not false: {key}={report.get(key)!r}")
+                  sys.exit(1)
+
+          print("[notion-smoke] PASS: read-only sync boundary confirmed")
+          print(
+              "[notion-smoke] records: "
+              f"total={report.get('total_records')} "
+              f"valid={report.get('valid_records')} "
+              f"invalid={report.get('invalid_records')} "
+              f"skipped={report.get('skipped_records')}"
+          )
+          PY
+
+      - name: Upload Notion sync report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dysonx-notion-source-sync-report
+          path: |
+            tmp/dysonx_source_sync_report.json
+            tmp/dysonx_source_sync_store.json
+          if-no-files-found: warn

--- a/docs/DYSONX_NOTION_LIVE_SMOKE_TEST.md
+++ b/docs/DYSONX_NOTION_LIVE_SMOKE_TEST.md
@@ -1,0 +1,95 @@
+# DysonX Notion Live Smoke Test
+
+Status: manual GitHub Actions smoke test for read-only source sync
+
+This document describes the safe live Notion smoke test workflow:
+
+```text
+.github/workflows/dysonx-notion-smoke-test.yml
+```
+
+## Purpose
+
+The workflow verifies that the configured Notion source database can be read by
+the DysonX read-only source sync without adding any downstream product behavior.
+
+It tests only:
+
+```text
+Notion Source Registry
+-> Read-Only Fetch
+-> Validation
+-> Source Conversion
+-> Audit Report
+-> JSON Source Persistence
+```
+
+## Trigger
+
+The workflow uses `workflow_dispatch` only.
+
+There is no schedule, push trigger, pull request trigger, production deployment
+trigger, or automatic run path.
+
+## Secrets
+
+The workflow reads these GitHub Secrets:
+
+- `NOTION_TOKEN`
+- `DYSONX_NOTION_SOURCES_DATABASE_ID`
+
+The sync client fails closed if either value is missing.
+
+## Command
+
+The workflow runs:
+
+```bash
+python3 scripts/dysonx_notion_source_sync.py \
+  --notion-readonly \
+  --output tmp/dysonx_source_sync_report.json \
+  --storage tmp/dysonx_source_sync_store.json
+```
+
+## Safety Assertions
+
+After the sync command, the workflow checks the report and store to confirm:
+
+- no Notion writes
+- no collection
+- no LLM calls
+- no publishing
+- no social posting
+- no raw article storage
+- no LLM output storage
+- no publish package storage
+- persisted store top-level keys are only `sources`, `sync_metadata`, and
+  `validation_results`
+
+## Artifacts
+
+The workflow uploads:
+
+- `tmp/dysonx_source_sync_report.json`
+- `tmp/dysonx_source_sync_store.json`
+
+These artifacts exist for manual review of source sync health. They are not
+published pages and are not deployed.
+
+## Out of Scope
+
+This smoke test does not add:
+
+- scheduled source sync
+- collector layer
+- RSS collector
+- GitHub collector
+- web scraping
+- real LLM provider calls
+- publishing
+- social posting
+- Knowledge Graph implementation
+- Prediction Engine
+- dashboard
+- deployment
+- merge automation


### PR DESCRIPTION
## Purpose

Add a safe manual GitHub Actions workflow to run the DysonX Notion read-only source sync as a live smoke test.

## Scope

- Adds .github/workflows/dysonx-notion-smoke-test.yml
- Adds docs/DYSONX_NOTION_LIVE_SMOKE_TEST.md
- Manual workflow_dispatch only
- Uses GitHub Secrets: NOTION_TOKEN and DYSONX_NOTION_SOURCES_DATABASE_ID
- Uploads source sync report and source sync store artifacts

## Workflow summary

The workflow runs:

python3 scripts/dysonx_notion_source_sync.py --notion-readonly --output tmp/dysonx_source_sync_report.json --storage tmp/dysonx_source_sync_store.json

Then it checks the generated report and store to confirm:

- no Notion writes
- no collection
- no LLM calls
- no publishing
- no social posting
- no raw article storage
- no LLM output storage
- no publish package storage
- persisted store top-level keys are only sources, sync_metadata, validation_results

## Safety boundaries

- No scheduled trigger
- No automatic production run
- No collector
- No LLM provider call
- No publishing
- No social posting
- No deployment
- No merge automation

## Validation

- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 104 tests
- python3 scripts/dysonx_static_preview_check.py: PASS
- git diff --check: PASS

No merge or production deployment was performed.