### PR TITLE
Add DysonX Collector Foundation V1

### DIFF
--- a/docs/DYSONX_COLLECTOR_FOUNDATION_V1.md
+++ b/docs/DYSONX_COLLECTOR_FOUNDATION_V1.md
@@ -1,0 +1,167 @@
+# DysonX Collector Foundation V1
+
+Status: first collection-layer foundation after the live Notion Source Registry milestone
+
+## Purpose
+
+Collector Foundation V1 establishes the first controlled path from DysonX Source
+objects to persisted RawItem records.
+
+It implements this vertical slice:
+
+```text
+Source Registry / Source objects
+-> Collector selection
+-> RSS collector
+-> Manual URL collector skeleton
+-> GitHub release collector skeleton
+-> RawItem creation
+-> Normalization
+-> Deduplication
+-> RawItem JSON persistence
+-> Audit report
+```
+
+## Architecture Boundary
+
+This PR introduces the Collection and Raw Data foundation only. It does not
+advance collected RawItems into SignalCandidates, LLM jobs, Signals, publishing,
+social distribution, trackers, or the Knowledge Graph.
+
+The protected architecture remains:
+
+```text
+Source
+-> RawItem
+-> SignalCandidate
+-> LLM Intelligence
+-> Ranking
+-> Review
+-> Publish Package
+```
+
+Collector Foundation V1 stops at RawItem persistence.
+
+## Collector Behavior
+
+Collector selection is based on Source fields from the source sync store:
+
+- RSS sources use the RSS collector.
+- Manual URL sources use a metadata-only manual collector skeleton.
+- GitHub release sources use a fixture-only GitHub release collector skeleton.
+- Unknown sources fall back to the manual URL skeleton.
+
+### RSS Collector
+
+The RSS collector parses local XML fixture data with Python standard library XML
+parsing. It extracts item title, link, description, publication date, and source
+metadata into RawItem candidates.
+
+This foundation does not schedule RSS collection and does not publish RSS-derived
+items.
+
+### Manual URL Skeleton
+
+The manual URL collector creates RawItem metadata only. It preserves source URL
+and source attribution but does not scrape article bodies.
+
+### GitHub Release Skeleton
+
+The GitHub release collector parses fixture JSON only. It does not call the live
+GitHub API.
+
+## Normalization
+
+Normalization:
+
+- trims repeated title whitespace
+- canonicalizes URL scheme and host casing
+- strips query strings and fragments
+- creates deterministic RawItem IDs from source, canonical URL, and title
+- computes content hashes
+- preserves source attribution
+- preserves raw excerpt separately from raw content
+
+Normalization must not rewrite source material into a publishable article.
+
+## Deduplication
+
+Deduplication is deterministic and local to the collection run.
+
+RawItems are considered duplicates when they share:
+
+- source ID
+- canonical URL
+- normalized lower-case title
+
+Duplicate records are reported in `deduplication_results` and excluded from the
+persisted `raw_items` list.
+
+## RawItem Persistence Shape
+
+RawItems are stored in JSON with exactly these top-level keys:
+
+```text
+raw_items
+collection_metadata
+deduplication_results
+```
+
+The store is a raw-data cache and audit artifact. It is not a Knowledge Graph,
+not a publish package, and not a website data store.
+
+## Audit Report
+
+The collector audit report includes:
+
+- collection timestamp
+- source count
+- raw item count before deduplication
+- persisted raw item count
+- duplicates removed
+- per-source collector results
+- raw store path
+- safety flags
+
+Required safety flags are always false:
+
+- `notion_write_operations_performed`
+- `live_github_api_used`
+- `llm_api_calls_performed`
+- `publishing_performed`
+- `social_posting_performed`
+- `article_body_scraping_performed`
+
+## What Is Not Implemented
+
+Collector Foundation V1 does not implement:
+
+- scheduled collectors
+- live GitHub API access
+- full article scraping
+- Notion mutation or writeback
+- LLM provider calls
+- SignalCandidate generation from collected data
+- Signal publishing
+- social posting
+- Knowledge Graph writes
+- Prediction Engine
+- dashboard, billing, enterprise, or multi-tenant features
+- deployment
+
+## Command
+
+Fixture-safe command:
+
+```bash
+python3 scripts/dysonx_collector_foundation.py \
+  --source-store tests/fixtures/source_sync_store_v1.json \
+  --output tmp/dysonx_collector_report.json \
+  --raw-store tmp/dysonx_raw_items_store.json
+```
+
+## Next Step
+
+The next product step after this foundation should be a separate reviewed PR for
+converting RawItems into SignalCandidates without bypassing the LLM-first
+interpretation architecture.

--- a/scripts/dysonx_collector_foundation.py
+++ b/scripts/dysonx_collector_foundation.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""DysonX Collector Foundation V1.
+
+Collects fixture-safe Source records into RawItem JSON records. This script does
+not mutate Notion, call live GitHub APIs, scrape article bodies, call LLM APIs,
+publish pages, post to social platforms, or deploy anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from dysonx_raw_item_storage import STORE_VERSION, write_raw_item_store
+
+
+DEFAULT_REPORT_PATH = pathlib.Path("tmp/dysonx_collector_report.json")
+DEFAULT_RAW_STORE_PATH = pathlib.Path("tmp/dysonx_raw_items_store.json")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def write_json(path: str | pathlib.Path, data: dict[str, Any]) -> None:
+    output_path = pathlib.Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_source_store(path: str | pathlib.Path) -> list[dict[str, Any]]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Source store must be a JSON object")
+    sources = data.get("sources")
+    if not isinstance(sources, list) or not all(isinstance(source, dict) for source in sources):
+        raise ValueError("Source store must contain a sources list")
+    return sources
+
+
+def fixture_path(value: str, base_dir: pathlib.Path) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        path = base_dir / path
+    return path
+
+
+def normalize_space(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def canonicalize_url(url: str) -> str:
+    parsed = urlsplit(url.strip())
+    scheme = parsed.scheme.lower()
+    netloc = parsed.netloc.lower()
+    path = re.sub(r"/+", "/", parsed.path or "/")
+    if path != "/":
+        path = path.rstrip("/")
+    return urlunsplit((scheme, netloc, path, "", ""))
+
+
+def raw_item_id(source_id: str, canonical_url: str, title: str) -> str:
+    digest = hashlib.sha256(f"{source_id}|{canonical_url}|{title}".encode("utf-8")).hexdigest()[:16]
+    return f"raw_{digest}"
+
+
+def source_fixture(source: dict[str, Any], base_dir: pathlib.Path) -> pathlib.Path | None:
+    fixture = source.get("collector_fixture") or source.get("fixture_path")
+    if fixture:
+        return fixture_path(str(fixture), base_dir)
+    url = str(source.get("url") or "")
+    if url and not url.startswith(("http://", "https://")):
+        return fixture_path(url, base_dir)
+    return None
+
+
+def select_collector(source: dict[str, Any]) -> str:
+    source_type = str(source.get("source_type") or "").lower()
+    platform = str(source.get("platform") or "").lower()
+    url = str(source.get("url") or "").lower()
+
+    if "github" in platform or "github" in source_type or source.get("github_releases_fixture"):
+        return "github_release_fixture"
+    if "manual" in platform or "manual" in source_type:
+        return "manual_url"
+    if "rss" in platform or "rss" in source_type or url.endswith((".rss", ".xml")):
+        return "rss"
+    return "manual_url"
+
+
+def normalize_raw_item(source: dict[str, Any], item: dict[str, Any], collected_at: str) -> dict[str, Any]:
+    title = normalize_space(str(item.get("raw_title") or item.get("title") or ""))
+    original_url = str(item.get("original_url") or item.get("url") or source.get("url") or "")
+    canonical_url = canonicalize_url(original_url)
+    source_id = str(source["id"])
+    raw_content = item.get("raw_content")
+    raw_excerpt = item.get("raw_excerpt")
+    content_hash = hashlib.sha256(
+        f"{title}|{canonical_url}|{raw_content or raw_excerpt or ''}".encode("utf-8")
+    ).hexdigest()
+    return {
+        "id": raw_item_id(source_id, canonical_url, title),
+        "source_id": source_id,
+        "source_name": str(source.get("name") or ""),
+        "source_type": str(source.get("source_type") or ""),
+        "original_url": original_url,
+        "canonical_url": canonical_url,
+        "raw_title": title,
+        "raw_content": raw_content,
+        "raw_excerpt": raw_excerpt,
+        "raw_author": item.get("raw_author"),
+        "raw_published_at": item.get("raw_published_at"),
+        "fetched_at": collected_at,
+        "content_hash": content_hash,
+        "fetch_status": str(item.get("fetch_status") or "collected"),
+        "detected_language": item.get("detected_language") or source.get("language") or "English",
+        "error": item.get("error"),
+        "metadata": dict(item.get("metadata") or {}),
+    }
+
+
+def collect_rss(source: dict[str, Any], base_dir: pathlib.Path) -> list[dict[str, Any]]:
+    path = source_fixture(source, base_dir)
+    if path is None:
+        return [
+            {
+                "title": "",
+                "url": str(source.get("url") or ""),
+                "fetch_status": "skipped",
+                "error": "RSS collector V1 requires a local fixture path",
+            }
+        ]
+    root = ET.fromstring(path.read_text(encoding="utf-8"))
+    items: list[dict[str, Any]] = []
+    for item in root.findall(".//item"):
+        title = item.findtext("title") or ""
+        link = item.findtext("link") or ""
+        description = item.findtext("description") or ""
+        published = item.findtext("pubDate") or item.findtext("published") or ""
+        items.append(
+            {
+                "title": title,
+                "url": link,
+                "raw_excerpt": normalize_space(description),
+                "raw_published_at": published,
+                "metadata": {"collector": "rss", "fixture_path": str(path)},
+            }
+        )
+    return items
+
+
+def collect_manual_url(source: dict[str, Any], _base_dir: pathlib.Path) -> list[dict[str, Any]]:
+    title = f"Manual URL placeholder: {source.get('name')}"
+    return [
+        {
+            "title": title,
+            "url": str(source.get("url") or ""),
+            "raw_excerpt": "",
+            "raw_content": None,
+            "raw_published_at": None,
+            "metadata": {"collector": "manual_url", "metadata_only": True},
+        }
+    ]
+
+
+def collect_github_release_fixture(source: dict[str, Any], base_dir: pathlib.Path) -> list[dict[str, Any]]:
+    fixture = source.get("github_releases_fixture") or source.get("collector_fixture")
+    if not fixture:
+        return [
+            {
+                "title": "",
+                "url": str(source.get("url") or ""),
+                "fetch_status": "skipped",
+                "error": "GitHub release collector V1 requires fixture data",
+            }
+        ]
+    path = fixture_path(str(fixture), base_dir)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("GitHub release fixture must contain a list")
+    items: list[dict[str, Any]] = []
+    for release in data:
+        if not isinstance(release, dict):
+            continue
+        items.append(
+            {
+                "title": str(release.get("name") or release.get("tag_name") or ""),
+                "url": str(release.get("html_url") or source.get("url") or ""),
+                "raw_excerpt": normalize_space(str(release.get("body") or "")),
+                "raw_published_at": release.get("published_at"),
+                "metadata": {
+                    "collector": "github_release_fixture",
+                    "tag_name": release.get("tag_name"),
+                    "fixture_path": str(path),
+                },
+            }
+        )
+    return items
+
+
+COLLECTORS = {
+    "rss": collect_rss,
+    "manual_url": collect_manual_url,
+    "github_release_fixture": collect_github_release_fixture,
+}
+
+
+def deduplicate_raw_items(raw_items: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    seen: dict[tuple[str, str, str], dict[str, Any]] = {}
+    unique_items: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    for item in raw_items:
+        key = (
+            str(item["source_id"]),
+            str(item["canonical_url"]),
+            str(item["raw_title"]).lower(),
+        )
+        if key in seen:
+            results.append(
+                {
+                    "status": "duplicate",
+                    "raw_item_id": item["id"],
+                    "duplicate_of": seen[key]["id"],
+                    "canonical_url": item["canonical_url"],
+                    "source_id": item["source_id"],
+                }
+            )
+            continue
+        seen[key] = item
+        unique_items.append(item)
+        results.append(
+            {
+                "status": "unique",
+                "raw_item_id": item["id"],
+                "canonical_url": item["canonical_url"],
+                "source_id": item["source_id"],
+            }
+        )
+    return unique_items, results
+
+
+def run_collection(
+    source_store_path: str | pathlib.Path,
+    report_path: str | pathlib.Path = DEFAULT_REPORT_PATH,
+    raw_store_path: str | pathlib.Path = DEFAULT_RAW_STORE_PATH,
+) -> dict[str, Any]:
+    collected_at = utc_now()
+    base_dir = pathlib.Path(source_store_path).resolve().parents[2]
+    sources = load_source_store(source_store_path)
+    raw_items: list[dict[str, Any]] = []
+    source_results: list[dict[str, Any]] = []
+
+    for source in sources:
+        if source.get("enabled") is False:
+            source_results.append(
+                {
+                    "source_id": source.get("id"),
+                    "source_name": source.get("name"),
+                    "collector": "none",
+                    "status": "skipped",
+                    "items_collected": 0,
+                    "error": "source disabled",
+                }
+            )
+            continue
+        collector_name = select_collector(source)
+        collector = COLLECTORS[collector_name]
+        try:
+            collected = collector(source, base_dir)
+            normalized = [normalize_raw_item(source, item, collected_at) for item in collected]
+            raw_items.extend(normalized)
+            source_results.append(
+                {
+                    "source_id": source.get("id"),
+                    "source_name": source.get("name"),
+                    "collector": collector_name,
+                    "status": "collected",
+                    "items_collected": len(normalized),
+                    "error": None,
+                }
+            )
+        except Exception as exc:  # pragma: no cover - exercised by integration failures
+            source_results.append(
+                {
+                    "source_id": source.get("id"),
+                    "source_name": source.get("name"),
+                    "collector": collector_name,
+                    "status": "failed",
+                    "items_collected": 0,
+                    "error": str(exc),
+                }
+            )
+
+    unique_items, deduplication_results = deduplicate_raw_items(raw_items)
+    collection_metadata = {
+        "store_version": STORE_VERSION,
+        "collected_at": collected_at,
+        "total_sources": len(sources),
+        "total_raw_items_before_deduplication": len(raw_items),
+        "total_raw_items": len(unique_items),
+        "duplicates_removed": len(raw_items) - len(unique_items),
+    }
+    store_document = write_raw_item_store(
+        raw_store_path,
+        raw_items=unique_items,
+        collection_metadata=collection_metadata,
+        deduplication_results=deduplication_results,
+    )
+    report = {
+        **collection_metadata,
+        "source_results": source_results,
+        "raw_store_path": str(raw_store_path),
+        "stored_raw_item_count": len(store_document["raw_items"]),
+        "notion_write_operations_performed": False,
+        "live_github_api_used": False,
+        "llm_api_calls_performed": False,
+        "publishing_performed": False,
+        "social_posting_performed": False,
+        "article_body_scraping_performed": False,
+    }
+    write_json(report_path, report)
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Collector Foundation V1.")
+    parser.add_argument("--source-store", required=True, help="Path to source sync store JSON.")
+    parser.add_argument("--output", default=str(DEFAULT_REPORT_PATH), help="Path to collector audit report JSON.")
+    parser.add_argument("--raw-store", default=str(DEFAULT_RAW_STORE_PATH), help="Path to raw item JSON store.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = run_collection(args.source_store, report_path=args.output, raw_store_path=args.raw_store)
+    print(
+        "[collector-foundation] wrote report: "
+        f"{args.output} sources={report['total_sources']} raw_items={report['total_raw_items']} "
+        f"duplicates_removed={report['duplicates_removed']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_raw_item_storage.py
+++ b/scripts/dysonx_raw_item_storage.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""JSON persistence for DysonX RawItem collection V1."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Any
+
+
+STORE_VERSION = "dysonx_raw_items_store_v1"
+
+
+def build_raw_item_store(
+    raw_items: list[dict[str, Any]],
+    collection_metadata: dict[str, Any],
+    deduplication_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "raw_items": raw_items,
+        "collection_metadata": collection_metadata,
+        "deduplication_results": deduplication_results,
+    }
+
+
+def write_raw_item_store(
+    output_path: str | pathlib.Path,
+    raw_items: list[dict[str, Any]],
+    collection_metadata: dict[str, Any],
+    deduplication_results: list[dict[str, Any]],
+) -> dict[str, Any]:
+    document = build_raw_item_store(raw_items, collection_metadata, deduplication_results)
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return document
+
+
+def read_raw_item_store(path: str | pathlib.Path) -> dict[str, Any]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("DysonX raw item store must be a JSON object")
+    metadata = data.get("collection_metadata")
+    if not isinstance(metadata, dict) or metadata.get("store_version") != STORE_VERSION:
+        raise ValueError("Unsupported DysonX raw item store version")
+    return data

--- a/tests/fixtures/collector_rss_feed_v1.xml
+++ b/tests/fixtures/collector_rss_feed_v1.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>DysonX Fixture Feed</title>
+    <item>
+      <title>OpenAI announces agent reliability update</title>
+      <link>https://openai.com/blog/agent-reliability?utm_source=test</link>
+      <description>OpenAI describes an update to agent reliability.</description>
+      <pubDate>Thu, 18 Jun 2026 10:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>OpenAI announces agent reliability update</title>
+      <link>https://openai.com/blog/agent-reliability</link>
+      <description>Duplicate fixture item for deduplication.</description>
+      <pubDate>Thu, 18 Jun 2026 10:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/github_releases_v1.json
+++ b/tests/fixtures/github_releases_v1.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "v1.2.0 agent runtime",
+    "tag_name": "v1.2.0",
+    "html_url": "https://github.com/example/agent-runtime/releases/tag/v1.2.0",
+    "body": "Fixture release notes for an agent runtime update.",
+    "published_at": "2026-06-18T12:00:00Z"
+  }
+]

--- a/tests/fixtures/source_sync_store_v1.json
+++ b/tests/fixtures/source_sync_store_v1.json
@@ -1,0 +1,76 @@
+{
+  "sources": [
+    {
+      "id": "source_openai_rss",
+      "notion_page_id": "fixture_openai_rss",
+      "name": "OpenAI RSS Fixture",
+      "source_type": "RSS",
+      "url": "tests/fixtures/collector_rss_feed_v1.xml",
+      "authority_score": 95.0,
+      "enabled": true,
+      "platform": "RSS",
+      "language": "English",
+      "region": "Global",
+      "priority": "Critical",
+      "notes": "Collector foundation RSS fixture."
+    },
+    {
+      "id": "source_manual_policy",
+      "notion_page_id": "fixture_manual_policy",
+      "name": "Manual Policy URL",
+      "source_type": "Manual URL",
+      "url": "https://example.gov/ai-policy-update",
+      "authority_score": 85.0,
+      "enabled": true,
+      "platform": "Manual",
+      "language": "English",
+      "region": "US",
+      "priority": "High",
+      "notes": "Manual URL skeleton fixture."
+    },
+    {
+      "id": "source_github_release",
+      "notion_page_id": "fixture_github_release",
+      "name": "Agent Runtime Releases",
+      "source_type": "GitHub Releases",
+      "url": "https://github.com/example/agent-runtime",
+      "authority_score": 80.0,
+      "enabled": true,
+      "platform": "GitHub",
+      "language": "English",
+      "region": "Global",
+      "priority": "Medium",
+      "github_releases_fixture": "tests/fixtures/github_releases_v1.json",
+      "notes": "GitHub release fixture only; no live API."
+    }
+  ],
+  "sync_metadata": {
+    "store_version": "dysonx_source_sync_store_v1",
+    "mode": "fixture",
+    "total_records": 3,
+    "valid_records": 3,
+    "invalid_records": 0,
+    "skipped_records": 0,
+    "notion_write_operations_performed": false
+  },
+  "validation_results": [
+    {
+      "record_name": "OpenAI RSS Fixture",
+      "notion_page_id": "fixture_openai_rss",
+      "status": "valid",
+      "errors": []
+    },
+    {
+      "record_name": "Manual Policy URL",
+      "notion_page_id": "fixture_manual_policy",
+      "status": "valid",
+      "errors": []
+    },
+    {
+      "record_name": "Agent Runtime Releases",
+      "notion_page_id": "fixture_github_release",
+      "status": "valid",
+      "errors": []
+    }
+  ]
+}

--- a/tests/test_dysonx_collector_foundation.py
+++ b/tests/test_dysonx_collector_foundation.py
@@ -1,0 +1,111 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_collector_foundation as collector
+
+
+SOURCE_STORE = ROOT / "tests" / "fixtures" / "source_sync_store_v1.json"
+
+
+class DysonXCollectorFoundationTests(unittest.TestCase):
+    def setUp(self):
+        self.sources = collector.load_source_store(SOURCE_STORE)
+        self.base_dir = ROOT
+
+    def test_collector_selection(self):
+        selected = {source["id"]: collector.select_collector(source) for source in self.sources}
+
+        self.assertEqual(selected["source_openai_rss"], "rss")
+        self.assertEqual(selected["source_manual_policy"], "manual_url")
+        self.assertEqual(selected["source_github_release"], "github_release_fixture")
+
+    def test_rss_fixture_parsing(self):
+        source = self.sources[0]
+        items = collector.collect_rss(source, self.base_dir)
+
+        self.assertEqual(len(items), 2)
+        self.assertEqual(items[0]["title"], "OpenAI announces agent reliability update")
+        self.assertEqual(items[0]["metadata"]["collector"], "rss")
+
+    def test_manual_url_skeleton_is_metadata_only(self):
+        source = self.sources[1]
+        items = collector.collect_manual_url(source, self.base_dir)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["url"], "https://example.gov/ai-policy-update")
+        self.assertIsNone(items[0]["raw_content"])
+        self.assertTrue(items[0]["metadata"]["metadata_only"])
+
+    def test_github_release_fixture_parsing(self):
+        source = self.sources[2]
+        items = collector.collect_github_release_fixture(source, self.base_dir)
+
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["title"], "v1.2.0 agent runtime")
+        self.assertEqual(items[0]["metadata"]["collector"], "github_release_fixture")
+
+    def test_normalization_canonicalizes_url_and_preserves_raw_boundary(self):
+        source = self.sources[0]
+        raw = {
+            "title": "  OpenAI   Update  ",
+            "url": "HTTPS://OPENAI.COM/blog/update/?utm_source=test",
+            "raw_excerpt": "Short excerpt",
+            "metadata": {"collector": "rss"},
+        }
+
+        item = collector.normalize_raw_item(source, raw, "2026-06-19T00:00:00+00:00")
+
+        self.assertEqual(item["raw_title"], "OpenAI Update")
+        self.assertEqual(item["canonical_url"], "https://openai.com/blog/update")
+        self.assertEqual(item["raw_excerpt"], "Short excerpt")
+        self.assertIsNone(item["raw_content"])
+
+    def test_deduplication_by_source_url_and_title(self):
+        source = self.sources[0]
+        first = collector.normalize_raw_item(
+            source,
+            {"title": "Same", "url": "https://example.com/a?utm=1", "raw_excerpt": "one"},
+            "2026-06-19T00:00:00+00:00",
+        )
+        second = collector.normalize_raw_item(
+            source,
+            {"title": "Same", "url": "https://example.com/a", "raw_excerpt": "two"},
+            "2026-06-19T00:00:00+00:00",
+        )
+
+        unique, results = collector.deduplicate_raw_items([first, second])
+
+        self.assertEqual(len(unique), 1)
+        self.assertEqual(results[0]["status"], "unique")
+        self.assertEqual(results[1]["status"], "duplicate")
+
+    def test_run_collection_writes_report_and_store_with_safety_flags(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = pathlib.Path(tmpdir) / "collector_report.json"
+            store_path = pathlib.Path(tmpdir) / "raw_items_store.json"
+
+            report = collector.run_collection(SOURCE_STORE, report_path=report_path, raw_store_path=store_path)
+
+            store = json.loads(store_path.read_text(encoding="utf-8"))
+            self.assertEqual(set(store), {"raw_items", "collection_metadata", "deduplication_results"})
+            self.assertEqual(report["total_sources"], 3)
+            self.assertEqual(report["total_raw_items_before_deduplication"], 4)
+            self.assertEqual(report["total_raw_items"], 3)
+            self.assertEqual(report["duplicates_removed"], 1)
+            self.assertFalse(report["notion_write_operations_performed"])
+            self.assertFalse(report["live_github_api_used"])
+            self.assertFalse(report["llm_api_calls_performed"])
+            self.assertFalse(report["publishing_performed"])
+            self.assertFalse(report["social_posting_performed"])
+            self.assertFalse(report["article_body_scraping_performed"])
+            self.assertTrue(report_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_raw_item_storage.py
+++ b/tests/test_dysonx_raw_item_storage.py
@@ -1,0 +1,46 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_raw_item_storage as storage
+
+
+class DysonXRawItemStorageTests(unittest.TestCase):
+    def test_raw_item_store_shape(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "raw_items_store.json"
+            document = storage.write_raw_item_store(
+                output,
+                raw_items=[{"id": "raw_1", "raw_title": "Fixture"}],
+                collection_metadata={"store_version": storage.STORE_VERSION, "total_raw_items": 1},
+                deduplication_results=[{"status": "unique", "raw_item_id": "raw_1"}],
+            )
+
+            disk_document = json.loads(output.read_text(encoding="utf-8"))
+
+            self.assertEqual(document, disk_document)
+            self.assertEqual(set(disk_document), {"raw_items", "collection_metadata", "deduplication_results"})
+            self.assertEqual(disk_document["collection_metadata"]["store_version"], storage.STORE_VERSION)
+
+    def test_raw_item_store_read_validates_version(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "raw_items_store.json"
+            storage.write_raw_item_store(
+                output,
+                raw_items=[],
+                collection_metadata={"store_version": storage.STORE_VERSION},
+                deduplication_results=[],
+            )
+
+            loaded = storage.read_raw_item_store(output)
+
+            self.assertEqual(loaded["collection_metadata"]["store_version"], storage.STORE_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Implement the first controlled Collection Layer foundation after the Notion Live Source Registry milestone.

This PR completes a fixture-safe vertical slice:

Source Registry / Source objects -> Collector selection -> RSS collector -> Manual URL skeleton -> GitHub release fixture skeleton -> RawItem creation -> Normalization -> Deduplication -> RawItem JSON persistence -> Audit report.

## Scope

- Adds scripts/dysonx_collector_foundation.py
- Adds scripts/dysonx_raw_item_storage.py
- Adds fixture source store, RSS XML fixture, and GitHub release JSON fixture
- Adds collector, normalization, deduplication, persistence, and audit tests
- Adds docs/DYSONX_COLLECTOR_FOUNDATION_V1.md

## Collector Behavior

- RSS collector parses local XML fixture data with Python standard library XML parsing.
- Manual URL collector creates metadata-only RawItems and does not scrape article bodies.
- GitHub release collector parses fixture JSON only and does not call the live GitHub API.
- Deduplication uses source ID, canonical URL, and normalized lower-case title.

## RawItem Persistence Shape

RawItem JSON store top-level keys are:

- raw_items
- collection_metadata
- deduplication_results

## Safety Flags

Collector audit report confirms false:

- notion_write_operations_performed
- live_github_api_used
- llm_api_calls_performed
- publishing_performed
- social_posting_performed
- article_body_scraping_performed

## Validation

- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS (113 tests)
- python3 scripts/dysonx_static_preview_check.py: PASS
- python3 scripts/dysonx_collector_foundation.py --source-store tests/fixtures/source_sync_store_v1.json --output tmp/dysonx_collector_report.json --raw-store tmp/dysonx_raw_items_store.json: PASS
- git diff --check: PASS

## Governance Compliance

- Preserves Source -> RawItem -> SignalCandidate architecture
- Does not call real LLM APIs
- Does not publish pages
- Does not social post
- Does not implement Knowledge Graph or Prediction Engine
- Does not schedule collectors
- Does not scrape article bodies
- Does not mutate Notion or write back to Notion
- Does not use live GitHub API
- Does not deploy

No production deployment was performed.