### PR TITLE
Connect DysonX RawItems to SignalCandidates

### DIFF
--- a/docs/DYSONX_RAWITEM_TO_SIGNAL_CANDIDATE_INTEGRATION_V1.md
+++ b/docs/DYSONX_RAWITEM_TO_SIGNAL_CANDIDATE_INTEGRATION_V1.md
@@ -1,0 +1,139 @@
+# DysonX RawItem to SignalCandidate Integration V1
+
+Status: first integration from Collector Foundation V1 output into the existing
+Signal Candidate Pipeline
+
+## Purpose
+
+This integration connects collected RawItems to the existing deterministic Signal
+Candidate Pipeline without adding LLM calls, publishing, social posting, graph
+writes, deployment, scheduled collection, article body scraping, Notion
+mutation, or live GitHub API access.
+
+Required flow:
+
+```text
+Source Registry / Source store
+-> Collector Foundation
+-> RawItem store
+-> Signal Candidate Pipeline
+-> Signal Candidate audit report
+```
+
+## Architecture Boundary
+
+This PR introduces a handoff between the Raw Data layer and the existing
+SignalCandidate layer. It does not merge SignalCandidate generation into the
+collector itself.
+
+The collector still stops at RawItem persistence. The integration script reads
+that RawItem store, adapts records into the existing pipeline input shape, and
+then calls the existing `dysonx_signal_candidate_pipeline.run_pipeline` function.
+
+## Script
+
+Integration script:
+
+```text
+scripts/dysonx_rawitem_signal_pipeline.py
+```
+
+Command:
+
+```bash
+python3 scripts/dysonx_rawitem_signal_pipeline.py \
+  --source-store tests/fixtures/source_sync_store_v1.json \
+  --raw-store tmp/dysonx_raw_items_store.json \
+  --collector-report tmp/dysonx_collector_report.json \
+  --signal-output tmp/dysonx_signal_candidates_report.json
+```
+
+If `--raw-store` does not exist, the script runs Collector Foundation V1 first
+with the provided fixture source store and writes the collector report.
+
+## RawItem Store Input
+
+The RawItem store must keep the Collector Foundation V1 shape:
+
+```text
+raw_items
+collection_metadata
+deduplication_results
+```
+
+Each persisted RawItem is adapted into the existing Signal Candidate Pipeline
+fixture shape:
+
+- `source_id`
+- `source_name`
+- `title`
+- `url`
+- `published_at`
+- `language`
+- `collected_at`
+- `raw_content`
+- `metadata`
+
+The adapter preserves RawItem metadata, original URL, content hash, source type,
+and RawItem ID in the pipeline metadata object.
+
+## Signal Candidate Pipeline Reuse
+
+The integration reuses:
+
+```text
+dysonx_signal_candidate_pipeline.run_pipeline
+```
+
+It does not add a new candidate classifier outside the existing pipeline and
+does not bypass the SignalCandidate layer.
+
+## Audit Report
+
+The signal candidate audit report includes the existing candidate pipeline
+fields plus an `integration` object:
+
+- source store path
+- raw store path
+- collector report path
+- whether Collector Foundation ran in this invocation
+- RawItems read
+- confirmation that the existing Signal Candidate Pipeline was reused
+- confirmation that the SignalCandidate layer was not bypassed
+
+Required safety flags remain false:
+
+- `notion_write_operations_performed`
+- `live_github_api_used`
+- `llm_api_calls_performed`
+- `publishing_performed`
+- `social_posting_performed`
+- `article_body_scraping_performed`
+
+The existing candidate pipeline flags also remain false:
+
+- `llm_used`
+- `network_requests_performed`
+- `publishing_performed`
+
+## What Is Not Implemented
+
+This integration does not implement:
+
+- real LLM API calls
+- publishing
+- social posting
+- Knowledge Graph writes
+- Prediction Engine
+- dashboard, billing, enterprise, or multi-tenant features
+- deployment
+- Notion mutation
+- live GitHub API access
+- scheduled collectors
+- article body scraping
+
+## Next Step
+
+The next reviewed PR should move from deterministic SignalCandidate creation
+toward the LLM Intelligence layer while preserving the rule that LLM analysis is
+the first major interpretation step after collection.

--- a/scripts/dysonx_rawitem_signal_pipeline.py
+++ b/scripts/dysonx_rawitem_signal_pipeline.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""DysonX RawItem to SignalCandidate Integration V1.
+
+Connects Collector Foundation V1 RawItem JSON output to the existing Signal
+Candidate Pipeline. This script does not call LLM APIs, publish pages, post to
+social platforms, mutate Notion, call live GitHub APIs, scrape article bodies,
+implement graph writes, schedule collectors, or deploy anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from typing import Any
+
+import dysonx_collector_foundation
+import dysonx_signal_candidate_pipeline
+
+
+DEFAULT_SIGNAL_OUTPUT = pathlib.Path("tmp/dysonx_signal_candidates_report.json")
+
+
+SAFETY_FLAGS = {
+    "notion_write_operations_performed": False,
+    "live_github_api_used": False,
+    "llm_api_calls_performed": False,
+    "publishing_performed": False,
+    "social_posting_performed": False,
+    "article_body_scraping_performed": False,
+}
+
+
+def write_json(path: str | pathlib.Path, data: dict[str, Any]) -> None:
+    output_path = pathlib.Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def ensure_raw_store(
+    source_store_path: str | pathlib.Path,
+    raw_store_path: str | pathlib.Path,
+    collector_report_path: str | pathlib.Path,
+) -> dict[str, Any]:
+    raw_path = pathlib.Path(raw_store_path)
+    if raw_path.exists():
+        return {
+            "collector_ran": False,
+            "collector_report_path": str(collector_report_path),
+            "raw_store_path": str(raw_store_path),
+        }
+    report = dysonx_collector_foundation.run_collection(
+        source_store_path,
+        report_path=collector_report_path,
+        raw_store_path=raw_store_path,
+    )
+    return {
+        "collector_ran": True,
+        "collector_report_path": str(collector_report_path),
+        "raw_store_path": str(raw_store_path),
+        "collector_report": report,
+    }
+
+
+def load_raw_item_store(path: str | pathlib.Path) -> dict[str, Any]:
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("RawItem store must be a JSON object")
+    if set(data) != {"raw_items", "collection_metadata", "deduplication_results"}:
+        raise ValueError("RawItem store must contain raw_items, collection_metadata, and deduplication_results")
+    raw_items = data.get("raw_items")
+    if not isinstance(raw_items, list) or not all(isinstance(item, dict) for item in raw_items):
+        raise ValueError("RawItem store raw_items must be a list of objects")
+    return data
+
+
+def raw_store_item_to_pipeline_record(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source_id": item.get("source_id"),
+        "source_name": item.get("source_name"),
+        "title": item.get("raw_title"),
+        "url": item.get("canonical_url") or item.get("original_url"),
+        "published_at": item.get("raw_published_at") or "",
+        "language": item.get("detected_language") or "English",
+        "collected_at": item.get("fetched_at"),
+        "raw_content": item.get("raw_content") or item.get("raw_excerpt") or "",
+        "metadata": {
+            **dict(item.get("metadata") or {}),
+            "raw_item_id": item.get("id"),
+            "original_url": item.get("original_url"),
+            "content_hash": item.get("content_hash"),
+            "source_type": item.get("source_type"),
+        },
+    }
+
+
+def raw_store_to_pipeline_records(raw_store: dict[str, Any]) -> list[dict[str, Any]]:
+    return [raw_store_item_to_pipeline_record(item) for item in raw_store["raw_items"]]
+
+
+def run_integration(
+    source_store_path: str | pathlib.Path,
+    raw_store_path: str | pathlib.Path,
+    collector_report_path: str | pathlib.Path,
+    signal_output_path: str | pathlib.Path = DEFAULT_SIGNAL_OUTPUT,
+) -> dict[str, Any]:
+    collector_context = ensure_raw_store(source_store_path, raw_store_path, collector_report_path)
+    raw_store = load_raw_item_store(raw_store_path)
+    records = raw_store_to_pipeline_records(raw_store)
+    candidate_report = dysonx_signal_candidate_pipeline.run_pipeline(records)
+    report = {
+        **candidate_report,
+        "integration": {
+            "source_store_path": str(source_store_path),
+            "raw_store_path": str(raw_store_path),
+            "collector_report_path": str(collector_report_path),
+            "collector_ran": collector_context["collector_ran"],
+            "raw_items_read": len(records),
+            "signal_candidate_pipeline_reused": True,
+            "signal_candidate_layer_bypassed": False,
+        },
+        **SAFETY_FLAGS,
+    }
+    write_json(signal_output_path, report)
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX RawItem to SignalCandidate Integration V1.")
+    parser.add_argument("--source-store", required=True, help="Path to source sync store JSON.")
+    parser.add_argument("--raw-store", required=True, help="Path to RawItem store JSON.")
+    parser.add_argument("--collector-report", required=True, help="Path to collector audit report JSON.")
+    parser.add_argument("--signal-output", default=str(DEFAULT_SIGNAL_OUTPUT), help="Path to SignalCandidate report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = run_integration(
+        args.source_store,
+        raw_store_path=args.raw_store,
+        collector_report_path=args.collector_report,
+        signal_output_path=args.signal_output,
+    )
+    print(
+        "[rawitem-signal-pipeline] wrote report: "
+        f"{args.signal_output} raw_items={report['integration']['raw_items_read']} "
+        f"candidates={report['candidates_created']} rejected={len(report['rejected_items'])}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_rawitem_signal_pipeline.py
+++ b/tests/test_dysonx_rawitem_signal_pipeline.py
@@ -1,0 +1,119 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_collector_foundation
+import dysonx_rawitem_signal_pipeline as integration
+
+
+SOURCE_STORE = ROOT / "tests" / "fixtures" / "source_sync_store_v1.json"
+
+
+class DysonXRawItemSignalPipelineTests(unittest.TestCase):
+    def test_raw_item_store_is_read_correctly(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_store = pathlib.Path(tmpdir) / "raw_items_store.json"
+            collector_report = pathlib.Path(tmpdir) / "collector_report.json"
+            dysonx_collector_foundation.run_collection(
+                SOURCE_STORE,
+                report_path=collector_report,
+                raw_store_path=raw_store,
+            )
+
+            loaded = integration.load_raw_item_store(raw_store)
+            records = integration.raw_store_to_pipeline_records(loaded)
+
+            self.assertEqual(set(loaded), {"raw_items", "collection_metadata", "deduplication_results"})
+            self.assertEqual(len(records), 3)
+            self.assertIn("title", records[0])
+            self.assertIn("raw_content", records[0])
+            self.assertIn("raw_item_id", records[0]["metadata"])
+
+    def test_missing_raw_store_runs_collector_foundation_first(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_store = pathlib.Path(tmpdir) / "raw_items_store.json"
+            collector_report = pathlib.Path(tmpdir) / "collector_report.json"
+            signal_output = pathlib.Path(tmpdir) / "signal_candidates.json"
+
+            report = integration.run_integration(
+                SOURCE_STORE,
+                raw_store_path=raw_store,
+                collector_report_path=collector_report,
+                signal_output_path=signal_output,
+            )
+
+            self.assertTrue(raw_store.exists())
+            self.assertTrue(collector_report.exists())
+            self.assertTrue(report["integration"]["collector_ran"])
+            self.assertEqual(report["integration"]["raw_items_read"], 3)
+
+    def test_raw_items_are_transformed_through_existing_pipeline(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_store = pathlib.Path(tmpdir) / "raw_items_store.json"
+            collector_report = pathlib.Path(tmpdir) / "collector_report.json"
+            signal_output = pathlib.Path(tmpdir) / "signal_candidates.json"
+            dysonx_collector_foundation.run_collection(
+                SOURCE_STORE,
+                report_path=collector_report,
+                raw_store_path=raw_store,
+            )
+
+            with mock.patch("dysonx_signal_candidate_pipeline.run_pipeline", wraps=integration.dysonx_signal_candidate_pipeline.run_pipeline) as run_mock:
+                report = integration.run_integration(
+                    SOURCE_STORE,
+                    raw_store_path=raw_store,
+                    collector_report_path=collector_report,
+                    signal_output_path=signal_output,
+                )
+
+            run_mock.assert_called_once()
+            self.assertFalse(report["integration"]["signal_candidate_layer_bypassed"])
+            self.assertTrue(report["integration"]["signal_candidate_pipeline_reused"])
+            self.assertEqual(report["candidates_created"], 3)
+            self.assertEqual(len(report["candidates"]), 3)
+
+    def test_audit_flags_remain_false(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            signal_output = pathlib.Path(tmpdir) / "signal_candidates.json"
+            report = integration.run_integration(
+                SOURCE_STORE,
+                raw_store_path=pathlib.Path(tmpdir) / "raw_items_store.json",
+                collector_report_path=pathlib.Path(tmpdir) / "collector_report.json",
+                signal_output_path=signal_output,
+            )
+
+            self.assertFalse(report["notion_write_operations_performed"])
+            self.assertFalse(report["live_github_api_used"])
+            self.assertFalse(report["llm_api_calls_performed"])
+            self.assertFalse(report["publishing_performed"])
+            self.assertFalse(report["social_posting_performed"])
+            self.assertFalse(report["article_body_scraping_performed"])
+            self.assertFalse(report["llm_used"])
+            self.assertFalse(report["network_requests_performed"])
+
+            disk_report = json.loads(signal_output.read_text(encoding="utf-8"))
+            self.assertEqual(report, disk_report)
+
+    def test_no_prohibited_integrations_are_present(self):
+        module_source = pathlib.Path(integration.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("api.github.com", module_source)
+        self.assertNotIn("api.notion.com", module_source)
+        self.assertNotIn("requests", module_source)
+        self.assertNotIn("urllib.request", module_source)
+        self.assertNotIn("import schedule", module_source)
+        self.assertNotIn("from schedule", module_source)
+        self.assertNotIn(".every(", module_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Connect Collector Foundation V1 RawItem JSON output to the existing Signal Candidate Pipeline without adding LLM calls, publishing, social posting, Notion mutation, live GitHub API access, scheduling, scraping, graph writes, prediction features, or deployment.

## Architecture Summary

Source Registry / Source store -> Collector Foundation -> RawItem store -> existing Signal Candidate Pipeline -> Signal Candidate audit report.

The collector still stops at RawItem persistence. The new integration script adapts RawItem store records into the existing signal candidate pipeline input shape and calls dysonx_signal_candidate_pipeline.run_pipeline.

## Files Changed

- docs/DYSONX_RAWITEM_TO_SIGNAL_CANDIDATE_INTEGRATION_V1.md
- scripts/dysonx_rawitem_signal_pipeline.py
- tests/test_dysonx_rawitem_signal_pipeline.py

## Integration Behavior

- Accepts --source-store, --raw-store, --collector-report, and --signal-output.
- Runs Collector Foundation first if the requested raw store does not exist.
- Reads RawItem store top-level keys: raw_items, collection_metadata, deduplication_results.
- Converts RawItems into the existing Signal Candidate Pipeline record shape.
- Reuses dysonx_signal_candidate_pipeline.run_pipeline.
- Reports that SignalCandidate layer was not bypassed.

## Sample SignalCandidate Report

Latest fixture run:

- raw_items_read: 3
- candidates_created: 3
- rejected_items: 0
- candidate_types: general_signal=3
- signal_candidate_pipeline_reused: true
- signal_candidate_layer_bypassed: false

Safety flags are false:

- notion_write_operations_performed
- live_github_api_used
- llm_api_calls_performed
- publishing_performed
- social_posting_performed
- article_body_scraping_performed

## Validation

- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS (118 tests)
- python3 scripts/dysonx_static_preview_check.py: PASS
- python3 scripts/dysonx_rawitem_signal_pipeline.py --source-store tests/fixtures/source_sync_store_v1.json --raw-store tmp/dysonx_raw_items_store.json --collector-report tmp/dysonx_collector_report.json --signal-output tmp/dysonx_signal_candidates_report.json: PASS
- git diff --check: PASS

## Governance Compliance

- No real LLM API
- No publishing
- No social posting
- No Knowledge Graph
- No Prediction Engine
- No dashboard, billing, enterprise, or multi-tenant features
- No deployment
- No Notion mutation
- No live GitHub API
- No scheduled collectors
- No article body scraping
- No merge performed by this PR

No production deployment was performed.