### PR TITLE
Add DysonX V1 intelligence pipeline integration

### DIFF
--- a/docs/DYSONX_V1_INTELLIGENCE_PIPELINE_INTEGRATION.md
+++ b/docs/DYSONX_V1_INTELLIGENCE_PIPELINE_INTEGRATION.md
@@ -1,0 +1,134 @@
+# DysonX V1 Intelligence Pipeline Integration
+
+Status: offline end-to-end V1 integration path
+
+## Purpose
+
+This integration composes existing DysonX V1 modules into one offline audit path
+from Source store fixture through publish-package metadata.
+
+Required flow:
+
+```text
+Source store / fixture
+-> Collector Foundation
+-> RawItem store
+-> Signal Candidate Pipeline
+-> Fake-provider LLM Intelligence Layer
+-> LLM Job / Audit
+-> Signal Ranking
+-> Quality Review
+-> Publish Package metadata
+-> End-to-end audit report
+```
+
+## Script
+
+```text
+scripts/dysonx_v1_intelligence_pipeline.py
+```
+
+Command:
+
+```bash
+python3 scripts/dysonx_v1_intelligence_pipeline.py \
+  --source-store tests/fixtures/source_sync_store_v1.json \
+  --output-dir tmp/dysonx_v1_intelligence_pipeline
+```
+
+## Reports Written
+
+The script writes JSON audit artifacts only:
+
+- `collector_report.json`
+- `raw_items_store.json`
+- `signal_candidate_report.json`
+- `llm_audit_report.json`
+- `signal_ranking_report.json`
+- `quality_review_report.json`
+- `publish_package_report.json`
+- `v1_intelligence_pipeline_report.json`
+
+It does not write website pages, public content files, social posts, graph data,
+prediction data, production data, or deployment artifacts.
+
+## Module Reuse
+
+The integration composes existing modules:
+
+- `dysonx_collector_foundation.run_collection`
+- `dysonx_rawitem_signal_pipeline.run_integration`
+- `dysonx_llm_audit.run_llm_audit`
+- `dysonx_signal_ranking.rank_signals`
+- `dysonx_publish_eligibility.run_quality_review`
+- `dysonx_publish_package.run_publish_package`
+
+It does not duplicate collector, SignalCandidate, fake-provider LLM, ranking,
+quality review, or publish-package logic.
+
+## Layer Boundaries
+
+The final audit report confirms:
+
+- RawItem remains separate from SignalCandidate
+- SignalCandidate remains separate from IntelligenceSignal
+- IntelligenceSignal remains separate from PublishPackage
+- Collector Foundation stops at RawItem persistence
+
+## Final Audit Report
+
+The final audit report includes:
+
+- `sources_seen`
+- `raw_items_created`
+- `signal_candidates_created`
+- `llm_jobs_created`
+- `intelligence_signals_created`
+- `signals_ranked`
+- `publish_ready`
+- `packages_created`
+- `rejected_or_skipped`
+- `module_reuse`
+- `layer_boundaries`
+- safety flags
+
+## Safety Flags
+
+Required safety flags remain false:
+
+- `notion_write_operations_performed`
+- `live_github_api_used`
+- `real_llm_api_used`
+- `llm_api_calls_performed`
+- `publishing_performed`
+- `website_pages_written`
+- `public_content_files_written`
+- `social_posting_performed`
+- `article_body_scraping_performed`
+- `deployment_performed`
+
+## What Is Not Implemented
+
+This integration does not implement:
+
+- real OpenAI, Claude, Gemini, or other provider calls
+- real LLM provider SDKs
+- website page generation
+- public content file writing
+- social posting
+- Knowledge Graph writes
+- Prediction Engine
+- dashboard, billing, enterprise, or multi-tenant features
+- scheduled workflows
+- deployment
+- Notion mutation
+- live GitHub API access
+- article body scraping
+- broad refactors
+
+## Next Step
+
+The next reviewed PR should decide whether to harden the fake-provider LLM
+handoff further or introduce a tightly controlled real-provider smoke boundary.
+Any real provider integration must remain separate from publishing and must keep
+quality gates blocking public output.

--- a/scripts/dysonx_v1_intelligence_pipeline.py
+++ b/scripts/dysonx_v1_intelligence_pipeline.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""DysonX V1 Intelligence Pipeline Integration.
+
+Runs the offline V1 pipeline from Source store through publish-package metadata.
+It composes existing modules and writes JSON audit reports only. It does not
+call real LLM APIs, mutate Notion, call live GitHub APIs, scrape article bodies,
+write website pages, write public content files, post to social platforms,
+schedule work, or deploy anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+import dysonx_collector_foundation
+import dysonx_llm_audit
+import dysonx_publish_eligibility
+import dysonx_publish_package
+import dysonx_rawitem_signal_pipeline
+import dysonx_signal_ranking
+
+
+SAFETY_FLAGS = {
+    "notion_write_operations_performed": False,
+    "live_github_api_used": False,
+    "real_llm_api_used": False,
+    "llm_api_calls_performed": False,
+    "publishing_performed": False,
+    "website_pages_written": False,
+    "public_content_files_written": False,
+    "social_posting_performed": False,
+    "article_body_scraping_performed": False,
+    "deployment_performed": False,
+}
+
+
+def write_json_report(report: dict[str, Any], output_path: pathlib.Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def report_paths(output_dir: str | pathlib.Path) -> dict[str, pathlib.Path]:
+    output_path = pathlib.Path(output_dir)
+    return {
+        "collector": output_path / "collector_report.json",
+        "raw_store": output_path / "raw_items_store.json",
+        "signal_candidates": output_path / "signal_candidate_report.json",
+        "llm_audit": output_path / "llm_audit_report.json",
+        "ranking": output_path / "signal_ranking_report.json",
+        "quality": output_path / "quality_review_report.json",
+        "publish_package": output_path / "publish_package_report.json",
+        "final": output_path / "v1_intelligence_pipeline_report.json",
+    }
+
+
+def rejected_or_skipped_counts(
+    candidate_report: dict[str, Any],
+    llm_audit_report: dict[str, Any],
+    quality_report: dict[str, Any],
+    package_report: dict[str, Any],
+) -> dict[str, int]:
+    status_counts = quality_report.get("status_counts", {})
+    return {
+        "candidate_rejected": len(candidate_report.get("rejected_items", [])),
+        "llm_validations_failed": int(llm_audit_report.get("validations_failed", 0)),
+        "quality_rejected": int(status_counts.get("rejected", 0)),
+        "quality_needs_review": int(status_counts.get("needs_review", 0)),
+        "publish_package_skipped": len(package_report.get("skipped", [])),
+    }
+
+
+def summarize_pipeline(
+    source_store_path: str | pathlib.Path,
+    output_dir: str | pathlib.Path,
+    collector_report: dict[str, Any],
+    raw_store: dict[str, Any],
+    candidate_report: dict[str, Any],
+    llm_audit_report: dict[str, Any],
+    ranking_report: dict[str, Any],
+    quality_report: dict[str, Any],
+    package_report: dict[str, Any],
+    generated_at: str,
+) -> dict[str, Any]:
+    module_reuse = {
+        "collector_foundation_reused": True,
+        "rawitem_signal_pipeline_reused": True,
+        "signal_candidate_pipeline_reused": bool(
+            candidate_report.get("integration", {}).get("signal_candidate_pipeline_reused")
+        ),
+        "llm_audit_reused": True,
+        "fake_provider_only": llm_audit_report.get("provider_distribution") == {"fake": llm_audit_report.get("jobs_created")},
+        "signal_ranking_reused": True,
+        "quality_review_reused": True,
+        "publish_package_reused": True,
+    }
+    layer_boundaries = {
+        "rawitem_separate_from_signal_candidate": True,
+        "signal_candidate_separate_from_intelligence_signal": True,
+        "intelligence_signal_separate_from_publish_package": True,
+        "collector_stops_at_rawitem_persistence": True,
+    }
+    return {
+        "generated_at": generated_at,
+        "source_store_path": str(source_store_path),
+        "output_dir": str(output_dir),
+        "sources_seen": int(collector_report.get("total_sources", 0)),
+        "raw_items_created": len(raw_store.get("raw_items", [])),
+        "signal_candidates_created": int(candidate_report.get("candidates_created", 0)),
+        "llm_jobs_created": int(llm_audit_report.get("jobs_created", 0)),
+        "intelligence_signals_created": int(llm_audit_report.get("signals_generated", 0)),
+        "signals_ranked": int(ranking_report.get("audit_summary", {}).get("signals_ranked", 0)),
+        "publish_ready": int(quality_report.get("status_counts", {}).get("publish_ready", 0)),
+        "packages_created": int(package_report.get("packages_created", 0)),
+        "rejected_or_skipped": rejected_or_skipped_counts(
+            candidate_report,
+            llm_audit_report,
+            quality_report,
+            package_report,
+        ),
+        "module_reuse": module_reuse,
+        "layer_boundaries": layer_boundaries,
+        **SAFETY_FLAGS,
+    }
+
+
+def run_pipeline(source_store: str | pathlib.Path, output_dir: str | pathlib.Path) -> dict[str, Any]:
+    generated_at = datetime.now(timezone.utc).isoformat()
+    paths = report_paths(output_dir)
+    pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    collector_report = dysonx_collector_foundation.run_collection(
+        source_store,
+        report_path=paths["collector"],
+        raw_store_path=paths["raw_store"],
+    )
+    raw_store = json.loads(paths["raw_store"].read_text(encoding="utf-8"))
+
+    candidate_report = dysonx_rawitem_signal_pipeline.run_integration(
+        source_store,
+        raw_store_path=paths["raw_store"],
+        collector_report_path=paths["collector"],
+        signal_output_path=paths["signal_candidates"],
+    )
+
+    candidate_records = list(candidate_report["candidates"])
+    llm_audit_report = dysonx_llm_audit.run_llm_audit(candidate_records, created_at=generated_at)
+    write_json_report(llm_audit_report, paths["llm_audit"])
+
+    ranking_result = dysonx_signal_ranking.rank_signals(llm_audit_report["signals"], top_n=10, created_at=generated_at)
+    ranking_report = dysonx_signal_ranking.ranking_result_to_report(ranking_result)
+    write_json_report(ranking_report, paths["ranking"])
+
+    quality_report = dysonx_publish_eligibility.run_quality_review(ranking_report, created_at=generated_at)
+    write_json_report(quality_report, paths["quality"])
+
+    package_report = dysonx_publish_package.run_publish_package(quality_report, created_at=generated_at)
+    write_json_report(package_report, paths["publish_package"])
+
+    final_report = summarize_pipeline(
+        source_store_path=source_store,
+        output_dir=output_dir,
+        collector_report=collector_report,
+        raw_store=raw_store,
+        candidate_report=candidate_report,
+        llm_audit_report=llm_audit_report,
+        ranking_report=ranking_report,
+        quality_report=quality_report,
+        package_report=package_report,
+        generated_at=generated_at,
+    )
+    write_json_report(final_report, paths["final"])
+    return final_report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX V1 Intelligence Pipeline Integration offline.")
+    parser.add_argument("--source-store", required=True, help="Path to Source sync store JSON.")
+    parser.add_argument("--output-dir", required=True, help="Directory to write V1 intelligence pipeline reports.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = run_pipeline(args.source_store, args.output_dir)
+    print(
+        "[v1-intelligence-pipeline] wrote reports: "
+        f"{args.output_dir} sources={report['sources_seen']} raw_items={report['raw_items_created']} "
+        f"signals={report['intelligence_signals_created']} packages={report['packages_created']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_v1_intelligence_pipeline.py
+++ b/tests/test_dysonx_v1_intelligence_pipeline.py
@@ -1,0 +1,119 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_collector_foundation
+import dysonx_llm_audit
+import dysonx_publish_eligibility
+import dysonx_publish_package
+import dysonx_rawitem_signal_pipeline
+import dysonx_signal_ranking
+import dysonx_v1_intelligence_pipeline as pipeline
+
+
+SOURCE_STORE = ROOT / "tests" / "fixtures" / "source_sync_store_v1.json"
+
+
+class DysonXV1IntelligencePipelineTests(unittest.TestCase):
+    def test_pipeline_writes_all_intermediate_reports(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = pipeline.run_pipeline(SOURCE_STORE, tmpdir)
+            output_dir = pathlib.Path(tmpdir)
+
+            for report_name in (
+                "collector_report.json",
+                "raw_items_store.json",
+                "signal_candidate_report.json",
+                "llm_audit_report.json",
+                "signal_ranking_report.json",
+                "quality_review_report.json",
+                "publish_package_report.json",
+                "v1_intelligence_pipeline_report.json",
+            ):
+                self.assertTrue((output_dir / report_name).exists(), report_name)
+
+            disk_report = json.loads((output_dir / "v1_intelligence_pipeline_report.json").read_text(encoding="utf-8"))
+            self.assertEqual(report, disk_report)
+
+    def test_counts_are_consistent_across_layers(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = pipeline.run_pipeline(SOURCE_STORE, tmpdir)
+
+            self.assertEqual(report["sources_seen"], 3)
+            self.assertEqual(report["raw_items_created"], 3)
+            self.assertEqual(report["signal_candidates_created"], 3)
+            self.assertEqual(report["llm_jobs_created"], 3)
+            self.assertEqual(report["intelligence_signals_created"], 3)
+            self.assertEqual(report["signals_ranked"], 3)
+            self.assertEqual(report["packages_created"], report["publish_ready"])
+
+    def test_existing_layers_are_reused(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with (
+                mock.patch("dysonx_collector_foundation.run_collection", wraps=dysonx_collector_foundation.run_collection) as collector_mock,
+                mock.patch("dysonx_rawitem_signal_pipeline.run_integration", wraps=dysonx_rawitem_signal_pipeline.run_integration) as rawitem_mock,
+                mock.patch("dysonx_llm_audit.run_llm_audit", wraps=dysonx_llm_audit.run_llm_audit) as llm_mock,
+                mock.patch("dysonx_signal_ranking.rank_signals", wraps=dysonx_signal_ranking.rank_signals) as ranking_mock,
+                mock.patch("dysonx_publish_eligibility.run_quality_review", wraps=dysonx_publish_eligibility.run_quality_review) as quality_mock,
+                mock.patch("dysonx_publish_package.run_publish_package", wraps=dysonx_publish_package.run_publish_package) as package_mock,
+            ):
+                report = pipeline.run_pipeline(SOURCE_STORE, tmpdir)
+
+            collector_mock.assert_called_once()
+            rawitem_mock.assert_called_once()
+            llm_mock.assert_called_once()
+            ranking_mock.assert_called_once()
+            quality_mock.assert_called_once()
+            package_mock.assert_called_once()
+            self.assertTrue(all(report["module_reuse"].values()))
+
+    def test_layer_boundaries_are_not_bypassed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = pipeline.run_pipeline(SOURCE_STORE, tmpdir)
+
+            self.assertTrue(report["layer_boundaries"]["rawitem_separate_from_signal_candidate"])
+            self.assertTrue(report["layer_boundaries"]["signal_candidate_separate_from_intelligence_signal"])
+            self.assertTrue(report["layer_boundaries"]["intelligence_signal_separate_from_publish_package"])
+            self.assertTrue(report["layer_boundaries"]["collector_stops_at_rawitem_persistence"])
+            self.assertEqual(report["rejected_or_skipped"]["candidate_rejected"], 0)
+
+    def test_fake_provider_only_and_safety_flags_false(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report = pipeline.run_pipeline(SOURCE_STORE, tmpdir)
+
+            self.assertTrue(report["module_reuse"]["fake_provider_only"])
+            self.assertFalse(report["notion_write_operations_performed"])
+            self.assertFalse(report["live_github_api_used"])
+            self.assertFalse(report["real_llm_api_used"])
+            self.assertFalse(report["llm_api_calls_performed"])
+            self.assertFalse(report["publishing_performed"])
+            self.assertFalse(report["website_pages_written"])
+            self.assertFalse(report["public_content_files_written"])
+            self.assertFalse(report["social_posting_performed"])
+            self.assertFalse(report["article_body_scraping_performed"])
+            self.assertFalse(report["deployment_performed"])
+
+    def test_no_prohibited_integrations_are_present(self):
+        module_source = pathlib.Path(pipeline.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertNotIn("import openai", module_source)
+        self.assertNotIn("from openai", module_source)
+        self.assertNotIn("import anthropic", module_source)
+        self.assertNotIn("import google.generativeai", module_source)
+        self.assertNotIn("api.github.com", module_source)
+        self.assertNotIn("api.notion.com", module_source)
+        self.assertNotIn("requests", module_source)
+        self.assertNotIn("urllib.request", module_source)
+        self.assertNotIn("import schedule", module_source)
+        self.assertNotIn("from schedule", module_source)
+        self.assertNotIn(".every(", module_source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Create a single offline end-to-end V1 integration path that composes existing modules from Source store through publish-package metadata and final audit reporting.

## Architecture Summary

Source store / fixture -> Collector Foundation -> RawItem store -> Signal Candidate Pipeline -> Fake-provider LLM Intelligence / LLM Job Audit -> Signal Ranking -> Quality Review -> Publish Package metadata -> End-to-end audit report.

## Files Changed

- docs/DYSONX_V1_INTELLIGENCE_PIPELINE_INTEGRATION.md
- scripts/dysonx_v1_intelligence_pipeline.py
- tests/test_dysonx_v1_intelligence_pipeline.py

## Pipeline Behavior

- Writes collector_report.json
- Writes raw_items_store.json
- Writes signal_candidate_report.json
- Writes llm_audit_report.json
- Writes signal_ranking_report.json
- Writes quality_review_report.json
- Writes publish_package_report.json
- Writes v1_intelligence_pipeline_report.json
- Reuses existing modules directly rather than duplicating logic
- Uses fake-provider LLM audit only
- Writes JSON audit artifacts only

## Sample Final Audit Summary

Latest fixture run:

- sources_seen: 3
- raw_items_created: 3
- signal_candidates_created: 3
- llm_jobs_created: 3
- intelligence_signals_created: 3
- signals_ranked: 3
- publish_ready: 0
- packages_created: 0
- quality_needs_review: 3
- publish_package_skipped: 3

Module reuse confirmations are true for collector, RawItem-to-SignalCandidate integration, existing Signal Candidate Pipeline, LLM audit, fake provider only, ranking, quality review, and publish package.

## Safety Flags

All required flags are false:

- notion_write_operations_performed
- live_github_api_used
- real_llm_api_used
- llm_api_calls_performed
- publishing_performed
- website_pages_written
- public_content_files_written
- social_posting_performed
- article_body_scraping_performed
- deployment_performed

## Validation

- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS (124 tests)
- python3 scripts/dysonx_static_preview_check.py: PASS
- python3 scripts/dysonx_v1_intelligence_pipeline.py --source-store tests/fixtures/source_sync_store_v1.json --output-dir tmp/dysonx_v1_intelligence_pipeline: PASS
- git diff --check: PASS

## Governance Compliance

- No real OpenAI / Claude / Gemini calls
- No real LLM provider SDK
- No website page generation
- No public content file writing
- No social posting
- No Knowledge Graph implementation
- No Prediction Engine
- No dashboard, billing, enterprise, or multi-tenant features
- No scheduled workflow
- No deployment
- No Notion mutation
- No live GitHub API
- No article body scraping
- No broad refactor
- Existing module logic is composed, not duplicated

No production deployment was performed.