### PR TITLE
Add DysonX OpenAI gated smoke test

### DIFF
--- a/.github/workflows/dysonx-openai-gated-smoke-test.yml
+++ b/.github/workflows/dysonx-openai-gated-smoke-test.yml
@@ -1,0 +1,119 @@
+name: DysonX OpenAI Gated Smoke Test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  openai-gated-smoke:
+    name: OpenAI gated provider smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      DYSONX_OPENAI_SMOKE_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run V1 intelligence pipeline fixture
+        run: |
+          python3 scripts/dysonx_v1_intelligence_pipeline.py \
+            --source-store tests/fixtures/source_sync_store_v1.json \
+            --output-dir tmp/dysonx_v1_intelligence_pipeline
+          cp \
+            tmp/dysonx_v1_intelligence_pipeline/signal_candidate_report.json \
+            tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json
+
+      - name: Run gated OpenAI provider smoke test
+        run: |
+          python3 - <<'PY'
+          import os
+          import subprocess
+
+          env = os.environ.copy()
+          env["OPENAI_API_KEY"] = env["DYSONX_OPENAI_SMOKE_API_KEY"]
+          subprocess.check_call(
+              [
+                  "python3",
+                  "scripts/dysonx_real_llm_provider.py",
+                  "--signal-candidates",
+                  "tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json",
+                  "--provider",
+                  "openai",
+                  "--allow-real-llm",
+                  "--max-items",
+                  "1",
+                  "--output",
+                  "tmp/dysonx_openai_smoke_report.json",
+              ],
+              env=env,
+          )
+          PY
+
+      - name: Assert OpenAI smoke-test safety boundary
+        run: |
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          report_path = pathlib.Path("tmp/dysonx_openai_smoke_report.json")
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+
+          expected_values = {
+              "provider": "openai",
+              "real_llm_api_used": True,
+              "llm_api_calls_performed": True,
+              "publishing_performed": False,
+              "website_pages_written": False,
+              "public_content_files_written": False,
+              "social_posting_performed": False,
+              "deployment_performed": False,
+              "notion_write_operations_performed": False,
+              "live_github_api_used": False,
+              "article_body_scraping_performed": False,
+              "raw_provider_response_stored": False,
+          }
+
+          for key, expected in expected_values.items():
+              actual = report.get(key)
+              if actual is not expected and actual != expected:
+                  print(f"[openai-smoke] FAIL: {key}={actual!r}, expected {expected!r}")
+                  sys.exit(1)
+
+          if int(report.get("items_requested", 0)) > 1:
+              print(f"[openai-smoke] FAIL: items_requested={report.get('items_requested')!r}")
+              sys.exit(1)
+
+          if int(report.get("items_processed", 0)) > 1:
+              print(f"[openai-smoke] FAIL: items_processed={report.get('items_processed')!r}")
+              sys.exit(1)
+
+          print("[openai-smoke] PASS: gated OpenAI boundary confirmed")
+          print(
+              "[openai-smoke] summary: "
+              f"provider={report.get('provider')} "
+              f"items_requested={report.get('items_requested')} "
+              f"items_processed={report.get('items_processed')} "
+              f"signals={report.get('intelligence_signals_created')}"
+          )
+          PY
+
+      - name: Upload safe OpenAI smoke artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dysonx-openai-gated-smoke-report
+          path: |
+            tmp/dysonx_openai_smoke_report.json
+            tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json
+          if-no-files-found: warn

--- a/docs/DYSONX_OPENAI_GATED_SMOKE_TEST.md
+++ b/docs/DYSONX_OPENAI_GATED_SMOKE_TEST.md
@@ -1,0 +1,171 @@
+# DysonX OpenAI Gated Smoke Test
+
+Status: manual smoke-test workflow documentation
+
+## Purpose
+
+The DysonX OpenAI Gated Smoke Test verifies that the already merged gated
+OpenAI provider path can be invoked manually with strict limits.
+
+This smoke test is not a publishing workflow. It exists only to confirm that the
+real provider boundary can process one existing SignalCandidate into a validated
+IntelligenceSignal audit report.
+
+## Workflow
+
+Workflow file:
+
+```text
+.github/workflows/dysonx-openai-gated-smoke-test.yml
+```
+
+Trigger:
+
+```text
+workflow_dispatch only
+```
+
+There is no schedule trigger, push trigger, pull request trigger, deployment
+trigger, or automatic production run.
+
+## Required Secret
+
+The workflow requires this GitHub Secret:
+
+```text
+OPENAI_API_KEY
+```
+
+The workflow passes the secret as an environment variable to the gated provider
+CLI. It must not be printed, echoed, uploaded, or written to artifacts.
+
+## Smoke-Test Flow
+
+The workflow performs these steps:
+
+```text
+Checkout repository
+-> Set up Python
+-> Run V1 intelligence pipeline against fixture source store
+-> Run dysonx_real_llm_provider.py with OpenAI gate enabled
+-> Assert safety flags and item limits
+-> Upload safe JSON artifacts
+```
+
+The real provider command is:
+
+```bash
+python3 scripts/dysonx_real_llm_provider.py \
+  --signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json \
+  --provider openai \
+  --allow-real-llm \
+  --max-items 1 \
+  --output tmp/dysonx_openai_smoke_report.json
+```
+
+## Cost Boundary
+
+The workflow uses:
+
+```text
+--max-items 1
+```
+
+This keeps the smoke test to a single candidate. The report should show:
+
+- `items_requested` less than or equal to `1`
+- `items_processed` less than or equal to `1`
+
+The workflow is still a real provider call when run manually, so it can incur a
+small OpenAI API cost. It must remain manual until a separate scheduling and
+cost-control review is approved.
+
+## Safety Assertions
+
+The workflow fails unless the OpenAI smoke report confirms:
+
+- `provider`: `openai`
+- `items_requested` less than or equal to `1`
+- `items_processed` less than or equal to `1`
+- `real_llm_api_used`: true
+- `llm_api_calls_performed`: true
+- `publishing_performed`: false
+- `website_pages_written`: false
+- `public_content_files_written`: false
+- `social_posting_performed`: false
+- `deployment_performed`: false
+- `notion_write_operations_performed`: false
+- `live_github_api_used`: false
+- `article_body_scraping_performed`: false
+- `raw_provider_response_stored`: false
+
+## Safe Artifacts
+
+The workflow uploads only:
+
+- `tmp/dysonx_openai_smoke_report.json`
+- `tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json`
+
+The workflow does not upload:
+
+- raw provider responses
+- secrets
+- full raw article content
+- RawItem stores
+- publish packages
+- website pages
+- public content files
+
+## How To Read Success
+
+A successful run means:
+
+- GitHub Actions could invoke the OpenAI-gated provider path manually.
+- The provider gate accepted the explicit manual command.
+- The run was limited to at most one SignalCandidate.
+- The provider report passed strict safety assertions.
+- No publishing, website writing, social posting, deployment, Notion mutation,
+  live GitHub API usage, article body scraping, or raw provider response storage
+  occurred.
+
+## How To Read Failure
+
+A failure may mean:
+
+- `OPENAI_API_KEY` is missing or invalid.
+- The provider API returned an error.
+- The provider output failed strict JSON validation.
+- The report safety flags did not match the required boundary.
+- More than one item was requested or processed.
+- Expected safe artifacts were not created.
+
+Failure does not publish content. It should be treated as an integration signal
+for the provider boundary only.
+
+## What This Does Not Validate
+
+This smoke test does not validate:
+
+- production publishing
+- website page generation
+- public content writing
+- social posting
+- Knowledge Graph writes
+- Prediction Engine behavior
+- dashboard, billing, enterprise, or multi-tenant features
+- scheduled operation
+- production deployment
+- full source collection
+- live Notion mutation
+- live GitHub API usage
+- article body scraping
+- large-volume cost behavior
+- final editorial quality for public release
+
+## Next Step After Successful Smoke Test
+
+After one successful manual smoke test, the next recommended PR should document
+the result and decide whether to add a narrow real-provider audit review step.
+
+Do not proceed directly to publishing, social distribution, Knowledge Graph
+writes, scheduled LLM runs, or deployment from this smoke-test milestone.

--- a/tests/test_dysonx_openai_smoke_workflow.py
+++ b/tests/test_dysonx_openai_smoke_workflow.py
@@ -1,0 +1,76 @@
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "dysonx-openai-gated-smoke-test.yml"
+
+
+class DysonXOpenAIGatedSmokeWorkflowTests(unittest.TestCase):
+    def workflow_text(self) -> str:
+        return WORKFLOW.read_text(encoding="utf-8")
+
+    def test_workflow_dispatch_only(self):
+        text = self.workflow_text()
+
+        self.assertIn("workflow_dispatch:", text)
+        self.assertNotRegex(text, re.compile(r"^\s+push:", re.MULTILINE))
+        self.assertNotRegex(text, re.compile(r"^\s+pull_request:", re.MULTILINE))
+        self.assertNotRegex(text, re.compile(r"^\s+schedule:", re.MULTILINE))
+        self.assertNotIn("deployment_status:", text)
+
+    def test_openai_secret_is_referenced_but_not_printed(self):
+        text = self.workflow_text()
+
+        self.assertIn("DYSONX_OPENAI_SMOKE_API_KEY: ${{ secrets.OPENAI_API_KEY }}", text)
+        self.assertIn('env["OPENAI_API_KEY"] = env["DYSONX_OPENAI_SMOKE_API_KEY"]', text)
+        self.assertNotIn("echo $OPENAI_API_KEY", text)
+        self.assertNotIn("printenv OPENAI_API_KEY", text)
+        self.assertNotIn("OPENAI_API_KEY" + "=", text)
+
+    def test_openai_provider_gate_is_manual_and_capped(self):
+        text = self.workflow_text()
+
+        self.assertIn("scripts/dysonx_real_llm_provider.py", text)
+        self.assertIn('"--provider"', text)
+        self.assertIn('"openai"', text)
+        self.assertIn("--allow-real-llm", text)
+        self.assertIn('"--max-items"', text)
+        self.assertIn('"1"', text)
+        self.assertIn("tmp/dysonx_openai_smoke_report.json", text)
+
+    def test_safety_assertions_cover_required_flags(self):
+        text = self.workflow_text()
+
+        for token in (
+            '"provider": "openai"',
+            '"real_llm_api_used": True',
+            '"llm_api_calls_performed": True',
+            '"publishing_performed": False',
+            '"website_pages_written": False',
+            '"public_content_files_written": False',
+            '"social_posting_performed": False',
+            '"deployment_performed": False',
+            '"notion_write_operations_performed": False',
+            '"live_github_api_used": False',
+            '"article_body_scraping_performed": False',
+            '"raw_provider_response_stored": False',
+            'report.get("items_requested"',
+            'report.get("items_processed"',
+        ):
+            self.assertIn(token, text)
+
+    def test_uploaded_artifacts_are_limited_to_safe_reports(self):
+        text = self.workflow_text()
+
+        self.assertIn("actions/upload-artifact@v4", text)
+        self.assertIn("tmp/dysonx_openai_smoke_report.json", text)
+        self.assertIn("tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json", text)
+        self.assertNotIn("raw_items_store.json", text)
+        self.assertNotIn("raw_provider_response", text.split("path:")[-1])
+        self.assertNotIn("publish_package_report.json", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add a manual-only GitHub Actions smoke test for the already merged gated OpenAI provider path.

This verifies the real provider path can be invoked manually with strict limits while preserving no-publishing and no-deployment boundaries.

## Files Changed

- `.github/workflows/dysonx-openai-gated-smoke-test.yml`
- `docs/DYSONX_OPENAI_GATED_SMOKE_TEST.md`
- `tests/test_dysonx_openai_smoke_workflow.py`

## Workflow Behavior

- Trigger is `workflow_dispatch` only.
- No `schedule`, `push`, `pull_request`, or deployment trigger.
- Uses GitHub Secret `OPENAI_API_KEY` through a non-legacy workflow env binding.
- Runs the V1 intelligence pipeline against `tests/fixtures/source_sync_store_v1.json`.
- Runs `scripts/dysonx_real_llm_provider.py` with:
  - `--provider openai`
  - `--allow-real-llm`
  - `--max-items 1`
  - `--signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json`
  - `--output tmp/dysonx_openai_smoke_report.json`

## Safety Boundary

The workflow asserts:

- `provider = openai`
- `items_requested <= 1`
- `items_processed <= 1`
- `real_llm_api_used = true`
- `llm_api_calls_performed = true`
- `publishing_performed = false`
- `website_pages_written = false`
- `public_content_files_written = false`
- `social_posting_performed = false`
- `deployment_performed = false`
- `notion_write_operations_performed = false`
- `live_github_api_used = false`
- `article_body_scraping_performed = false`
- `raw_provider_response_stored = false`

Uploaded artifacts are limited to:

- `tmp/dysonx_openai_smoke_report.json`
- `tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json`

## Documentation

The new doc explains:

- manual-only trigger
- required `OPENAI_API_KEY` GitHub Secret
- `--max-items 1`
- cost boundary
- expected artifacts
- no publishing, deployment, or social posting
- how to read success/failure
- what the smoke test does not validate
- recommended next step after a successful smoke test

## Validation

- `python3 scripts/constitution_guard.py` - PASS
- `python3 scripts/architecture_guard.py` - PASS
- `python3 scripts/release_guard.py` - PASS
- `python3 -m py_compile scripts/*.py` - PASS
- `python3 -m unittest discover -s tests` - PASS
- `python3 scripts/dysonx_static_preview_check.py` - PASS
- `python3 scripts/dysonx_v1_intelligence_pipeline.py --source-store tests/fixtures/source_sync_store_v1.json --output-dir tmp/dysonx_v1_intelligence_pipeline` - PASS
- `python3 scripts/dysonx_real_llm_provider.py --signal-candidates tmp/dysonx_v1_intelligence_pipeline/signal_candidates_report.json --provider fake --output tmp/dysonx_real_llm_report.json` - PASS
- `git diff --check` - PASS

## Deployment Impact

No deployment path is introduced. The workflow is manual-only and was not run during PR creation.

No real OpenAI call was run during PR creation. No production deployment was performed.
