### PR TITLE
Add DysonX V1 OpenAI orchestrator smoke test

### DIFF
--- a/.github/workflows/dysonx-v1-openai-orchestrator-smoke.yml
+++ b/.github/workflows/dysonx-v1-openai-orchestrator-smoke.yml
@@ -1,0 +1,123 @@
+name: DysonX V1 OpenAI Orchestrator Smoke Test
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  v1-openai-orchestrator-smoke:
+    name: V1 OpenAI orchestrator smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      DYSONX_OPENAI_ORCHESTRATOR_SMOKE_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      DYSONX_OPENAI_ORCHESTRATOR_OUTPUT_DIR: tmp/dysonx_v1_openai_orchestrator_smoke
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run V1 OpenAI orchestrator smoke test
+        run: |
+          python3 - <<'PY'
+          import os
+          import subprocess
+
+          env = os.environ.copy()
+          env["OPENAI_API_KEY"] = env["DYSONX_OPENAI_ORCHESTRATOR_SMOKE_API_KEY"]
+          subprocess.check_call(
+              [
+                  "python3",
+                  "scripts/dysonx_v1_intelligence_pipeline.py",
+                  "--source-store",
+                  "tests/fixtures/source_sync_store_v1.json",
+                  "--output-dir",
+                  env["DYSONX_OPENAI_ORCHESTRATOR_OUTPUT_DIR"],
+                  "--provider",
+                  "openai",
+                  "--allow-real-llm",
+                  "--max-items",
+                  "1",
+              ],
+              env=env,
+          )
+          PY
+
+      - name: Assert V1 OpenAI orchestrator safety boundary
+        run: |
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          output_dir = pathlib.Path("tmp/dysonx_v1_openai_orchestrator_smoke")
+          final_report = json.loads((output_dir / "v1_intelligence_pipeline_report.json").read_text(encoding="utf-8"))
+
+          expected_values = {
+              "provider": "openai",
+              "real_llm_api_used": True,
+              "llm_api_calls_performed": True,
+              "publishing_performed": False,
+              "website_pages_written": False,
+              "public_content_files_written": False,
+              "social_posting_performed": False,
+              "deployment_performed": False,
+              "notion_write_operations_performed": False,
+              "live_github_api_used": False,
+              "article_body_scraping_performed": False,
+              "raw_provider_response_stored": False,
+          }
+
+          for key, expected in expected_values.items():
+              actual = final_report.get(key)
+              if actual is not expected and actual != expected:
+                  print(f"[v1-openai-orchestrator-smoke] FAIL: {key}={actual!r}, expected {expected!r}")
+                  sys.exit(1)
+
+          if int(final_report.get("items_requested", 0)) > 1:
+              print(f"[v1-openai-orchestrator-smoke] FAIL: items_requested={final_report.get('items_requested')!r}")
+              sys.exit(1)
+
+          if int(final_report.get("items_processed", 0)) > 1:
+              print(f"[v1-openai-orchestrator-smoke] FAIL: items_processed={final_report.get('items_processed')!r}")
+              sys.exit(1)
+
+          required_reports = (
+              output_dir / "v1_intelligence_pipeline_report.json",
+              output_dir / "llm_audit_report.json",
+              output_dir / "signal_candidate_report.json",
+          )
+          for report_path in required_reports:
+              if not report_path.exists():
+                  print(f"[v1-openai-orchestrator-smoke] FAIL: missing {report_path}")
+                  sys.exit(1)
+
+          print("[v1-openai-orchestrator-smoke] PASS: full orchestrator OpenAI boundary confirmed")
+          print(
+              "[v1-openai-orchestrator-smoke] summary: "
+              f"provider={final_report.get('provider')} "
+              f"items_requested={final_report.get('items_requested')} "
+              f"items_processed={final_report.get('items_processed')} "
+              f"signals={final_report.get('intelligence_signals_created')} "
+              f"packages={final_report.get('packages_created')}"
+          )
+          PY
+
+      - name: Upload safe V1 OpenAI orchestrator smoke artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: dysonx-v1-openai-orchestrator-smoke-report
+          path: |
+            tmp/dysonx_v1_openai_orchestrator_smoke/v1_intelligence_pipeline_report.json
+            tmp/dysonx_v1_openai_orchestrator_smoke/llm_audit_report.json
+            tmp/dysonx_v1_openai_orchestrator_smoke/signal_candidate_report.json
+          if-no-files-found: warn

--- a/docs/DYSONX_V1_OPENAI_ORCHESTRATOR_SMOKE_TEST.md
+++ b/docs/DYSONX_V1_OPENAI_ORCHESTRATOR_SMOKE_TEST.md
@@ -1,0 +1,190 @@
+# DysonX V1 OpenAI Orchestrator Smoke Test
+
+Status: manual full-orchestrator smoke-test documentation
+
+## Purpose
+
+The DysonX V1 OpenAI Orchestrator Smoke Test verifies that the full V1
+Intelligence Pipeline orchestrator can run with the already-gated OpenAI
+provider.
+
+This is not a publishing workflow. It exists only to confirm that the full V1
+pipeline can carry one manually gated OpenAI IntelligenceSignal through ranking,
+quality review, publish-package metadata, and final audit reporting.
+
+## Workflow
+
+Workflow file:
+
+```text
+.github/workflows/dysonx-v1-openai-orchestrator-smoke.yml
+```
+
+Trigger:
+
+```text
+workflow_dispatch only
+```
+
+There is no schedule trigger, push trigger, pull request trigger, deployment
+trigger, or automatic production run.
+
+## Required Secret
+
+The workflow requires this GitHub Secret:
+
+```text
+OPENAI_API_KEY
+```
+
+The workflow passes the secret to the existing gated provider path through the
+orchestrator process environment. It must not be printed, echoed, uploaded, or
+written to artifacts.
+
+## Full Orchestrator Path Tested
+
+The workflow runs this full path:
+
+```text
+Source store fixture
+-> Collector
+-> RawItem
+-> SignalCandidate
+-> OpenAI IntelligenceSignal
+-> Ranking
+-> QualityReview
+-> PublishPackage metadata
+-> Final audit report
+```
+
+The orchestrator command is:
+
+```bash
+python3 scripts/dysonx_v1_intelligence_pipeline.py \
+  --source-store tests/fixtures/source_sync_store_v1.json \
+  --output-dir tmp/dysonx_v1_openai_orchestrator_smoke \
+  --provider openai \
+  --allow-real-llm \
+  --max-items 1
+```
+
+## Cost Boundary
+
+The workflow uses:
+
+```text
+--max-items 1
+```
+
+This keeps the smoke test to at most one SignalCandidate. The final audit report
+must show:
+
+- `items_requested` less than or equal to `1`
+- `items_processed` less than or equal to `1`
+
+The run still invokes the real OpenAI provider when manually dispatched, so it
+can incur a small API cost. It must remain manual until a separate scheduling
+and cost-control review is approved.
+
+## Safety Assertions
+
+The workflow fails unless the final orchestrator audit report confirms:
+
+- `provider`: `openai`
+- `real_llm_api_used`: true
+- `llm_api_calls_performed`: true
+- `items_requested` less than or equal to `1`
+- `items_processed` less than or equal to `1`
+- `publishing_performed`: false
+- `website_pages_written`: false
+- `public_content_files_written`: false
+- `social_posting_performed`: false
+- `deployment_performed`: false
+- `notion_write_operations_performed`: false
+- `live_github_api_used`: false
+- `article_body_scraping_performed`: false
+- `raw_provider_response_stored`: false
+
+## Safe Artifacts
+
+The workflow uploads only:
+
+- `tmp/dysonx_v1_openai_orchestrator_smoke/v1_intelligence_pipeline_report.json`
+- `tmp/dysonx_v1_openai_orchestrator_smoke/llm_audit_report.json`
+- `tmp/dysonx_v1_openai_orchestrator_smoke/signal_candidate_report.json`
+
+The workflow does not upload:
+
+- raw provider responses
+- secrets
+- RawItem stores
+- publish packages
+- website pages
+- public content files
+
+## Difference From PR #50 Provider Smoke
+
+PR #50 added a provider-boundary smoke test. That workflow first creates a
+SignalCandidate fixture output, then calls `dysonx_real_llm_provider.py`
+directly.
+
+This workflow tests the larger orchestrator boundary. It calls
+`dysonx_v1_intelligence_pipeline.py` once and verifies the full chain from
+Source store fixture through final V1 audit report.
+
+## How To Read Success
+
+A successful run means:
+
+- GitHub Actions could invoke the full V1 orchestrator manually.
+- The orchestrator reused the gated OpenAI provider path.
+- The run was limited to at most one SignalCandidate.
+- Ranking, QualityReview, and PublishPackage metadata stages completed.
+- Final safety assertions passed.
+- No publishing, website writing, social posting, deployment, Notion mutation,
+  live GitHub API usage, article body scraping, or raw provider response storage
+  occurred.
+
+## How To Read Failure
+
+A failure may mean:
+
+- `OPENAI_API_KEY` is missing or invalid.
+- The provider API returned an error.
+- The provider output failed strict JSON validation.
+- The downstream ranking, quality review, or publish-package metadata stage
+  rejected or could not process the generated IntelligenceSignal.
+- The final audit report safety flags did not match the required boundary.
+- More than one item was requested or processed.
+- Expected safe artifacts were not created.
+
+Failure does not publish content. It should be treated as an integration signal
+for the orchestrator boundary only.
+
+## What This Does Not Validate
+
+This smoke test does not validate:
+
+- production publishing
+- website page generation
+- public content writing
+- social posting
+- Knowledge Graph writes
+- Prediction Engine behavior
+- dashboard, billing, enterprise, or multi-tenant features
+- scheduled operation
+- production deployment
+- live Notion mutation
+- live GitHub API usage
+- article body scraping
+- large-volume cost behavior
+- final editorial quality for public release
+
+## Next Step After Success
+
+After one successful manual orchestrator smoke test, the next recommended PR
+should document the result and review the real-provider output quality across
+the final orchestrator audit report.
+
+Do not proceed directly to publishing, social distribution, Knowledge Graph
+writes, scheduled LLM runs, or deployment from this smoke-test milestone.

--- a/scripts/dysonx_v1_intelligence_pipeline.py
+++ b/scripts/dysonx_v1_intelligence_pipeline.py
@@ -190,6 +190,7 @@ def summarize_pipeline(
             **SAFETY_FLAGS,
             "real_llm_api_used": bool(llm_audit_report.get("real_llm_api_used", False)),
             "llm_api_calls_performed": bool(llm_audit_report.get("llm_api_calls_performed", False)),
+            "raw_provider_response_stored": bool(llm_audit_report.get("raw_provider_response_stored", False)),
         },
     }
 

--- a/tests/test_dysonx_v1_intelligence_pipeline.py
+++ b/tests/test_dysonx_v1_intelligence_pipeline.py
@@ -179,6 +179,7 @@ class DysonXV1IntelligencePipelineTests(unittest.TestCase):
                 "items_processed",
                 "prompt_version",
                 "publish_package_created",
+                "raw_provider_response_stored",
             ):
                 self.assertIn(field_name, report)
 

--- a/tests/test_dysonx_v1_openai_orchestrator_smoke_workflow.py
+++ b/tests/test_dysonx_v1_openai_orchestrator_smoke_workflow.py
@@ -1,0 +1,81 @@
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "dysonx-v1-openai-orchestrator-smoke.yml"
+
+
+class DysonXV1OpenAIOrchestratorSmokeWorkflowTests(unittest.TestCase):
+    def workflow_text(self) -> str:
+        return WORKFLOW.read_text(encoding="utf-8")
+
+    def test_workflow_dispatch_only(self):
+        text = self.workflow_text()
+
+        self.assertIn("workflow_dispatch:", text)
+        self.assertNotRegex(text, re.compile(r"^\s+push:", re.MULTILINE))
+        self.assertNotRegex(text, re.compile(r"^\s+pull_request:", re.MULTILINE))
+        self.assertNotRegex(text, re.compile(r"^\s+schedule:", re.MULTILINE))
+        self.assertNotIn("deployment_status:", text)
+
+    def test_openai_secret_is_referenced_but_not_printed(self):
+        text = self.workflow_text()
+
+        self.assertIn("DYSONX_OPENAI_ORCHESTRATOR_SMOKE_API_KEY: ${{ secrets.OPENAI_API_KEY }}", text)
+        self.assertIn('env["OPENAI_API_KEY"] = env["DYSONX_OPENAI_ORCHESTRATOR_SMOKE_API_KEY"]', text)
+        self.assertNotIn("echo $OPENAI_API_KEY", text)
+        self.assertNotIn("printenv OPENAI_API_KEY", text)
+        self.assertNotIn("OPENAI_API_KEY" + "=", text)
+
+    def test_orchestrator_provider_gate_is_manual_and_capped(self):
+        text = self.workflow_text()
+
+        self.assertIn("scripts/dysonx_v1_intelligence_pipeline.py", text)
+        self.assertIn('"--source-store"', text)
+        self.assertIn('"tests/fixtures/source_sync_store_v1.json"', text)
+        self.assertIn('"--provider"', text)
+        self.assertIn('"openai"', text)
+        self.assertIn('"--allow-real-llm"', text)
+        self.assertIn('"--max-items"', text)
+        self.assertIn('"1"', text)
+        self.assertIn("tmp/dysonx_v1_openai_orchestrator_smoke", text)
+
+    def test_safety_assertions_cover_required_final_report_flags(self):
+        text = self.workflow_text()
+
+        for token in (
+            '"provider": "openai"',
+            '"real_llm_api_used": True',
+            '"llm_api_calls_performed": True',
+            '"publishing_performed": False',
+            '"website_pages_written": False',
+            '"public_content_files_written": False',
+            '"social_posting_performed": False',
+            '"deployment_performed": False',
+            '"notion_write_operations_performed": False',
+            '"live_github_api_used": False',
+            '"article_body_scraping_performed": False',
+            '"raw_provider_response_stored": False',
+            'final_report.get("items_requested"',
+            'final_report.get("items_processed"',
+        ):
+            self.assertIn(token, text)
+
+    def test_uploaded_artifacts_are_limited_to_safe_reports(self):
+        text = self.workflow_text()
+        artifact_block = text.split("path:")[-1]
+
+        self.assertIn("actions/upload-artifact@v4", text)
+        self.assertIn("tmp/dysonx_v1_openai_orchestrator_smoke/v1_intelligence_pipeline_report.json", artifact_block)
+        self.assertIn("tmp/dysonx_v1_openai_orchestrator_smoke/llm_audit_report.json", artifact_block)
+        self.assertIn("tmp/dysonx_v1_openai_orchestrator_smoke/signal_candidate_report.json", artifact_block)
+        self.assertNotIn("raw_items_store.json", artifact_block)
+        self.assertNotIn("raw_provider_response", artifact_block)
+        self.assertNotIn("publish_package_report.json", artifact_block)
+        self.assertNotIn("OPENAI_API_KEY", artifact_block)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Adds a manual-only GitHub Actions smoke test for the full V1 Intelligence Pipeline orchestrator running with the existing gated OpenAI provider.

## Scope

- Adds `.github/workflows/dysonx-v1-openai-orchestrator-smoke.yml`.
- Adds `docs/DYSONX_V1_OPENAI_ORCHESTRATOR_SMOKE_TEST.md`.
- Adds workflow-structure and safety-boundary tests.
- Extends the final orchestrator audit report with `raw_provider_response_stored`, sourced from the existing gated provider report.

## Full Orchestrator Path

```text
Source store
-> Collector
-> RawItem
-> SignalCandidate
-> OpenAI IntelligenceSignal
-> Ranking
-> QualityReview
-> PublishPackage metadata
-> Final audit report
```

## Workflow Boundary

- `workflow_dispatch` only.
- No schedule, push, pull request, or deployment trigger.
- Uses `OPENAI_API_KEY` from GitHub Secrets without printing or uploading it.
- Runs the existing orchestrator with `--provider openai --allow-real-llm --max-items 1`.
- Uploads only the final orchestrator audit report, OpenAI LLM report, and SignalCandidate report.

## Safety Boundary

The workflow asserts:

- `provider=openai`
- `real_llm_api_used=true`
- `llm_api_calls_performed=true`
- `items_requested <= 1`
- `items_processed <= 1`
- publishing, website/public content writing, social posting, deployment, Notion mutation, live GitHub API, article body scraping, and raw provider response storage are all false

## Validation

- `python3 scripts/constitution_guard.py`
- `python3 scripts/architecture_guard.py`
- `python3 scripts/release_guard.py`
- `python3 -m py_compile scripts/*.py`
- `python3 -m unittest discover -s tests`
- `python3 scripts/dysonx_static_preview_check.py`
- `python3 scripts/dysonx_v1_intelligence_pipeline.py --source-store tests/fixtures/source_sync_store_v1.json --output-dir tmp/dysonx_v1_intelligence_pipeline`
- `git diff --check`

No real OpenAI call was run during PR creation. No workflow was dispatched. No merge or deployment was performed.
