### PR TITLE
Add DysonX SignalQualityScore V1

### DIFF
--- a/docs/DYSONX_SIGNAL_QUALITY_SCORE_V1.md
+++ b/docs/DYSONX_SIGNAL_QUALITY_SCORE_V1.md
@@ -1,0 +1,237 @@
+# DysonX SignalQualityScore V1
+
+## Purpose
+
+SignalQualityScore V1 turns DysonX OpenAI Output Quality Audit V1 results into a stable score report that future Confidence Calibration, Multi-source Correlation, Human Approval, and Publish Readiness Gate work can consume.
+
+This is an offline score object derived from an existing audit report. It does not call OpenAI, dispatch workflows, publish content, write website pages, mutate Notion, use live GitHub API collection, scrape article bodies, write Knowledge Graph records, implement Prediction Engine work, deploy, or merge.
+
+SignalQualityScore V1 does not enable publishing. It creates structured score records so DysonX can review quality consistently before any future approval or publish-readiness path exists.
+
+## Relationship To Signal Quality Framework V1
+
+SignalQualityScore V1 uses the 13 dimensions defined by:
+
+`docs/DYSONX_SIGNAL_QUALITY_FRAMEWORK_V1.md`
+
+The score dimensions are:
+
+- Information Density
+- Source Attribution
+- Source Authority
+- Reasoning Depth
+- Novelty
+- AGI Capability Relevance
+- Entity / Relationship Value
+- Tracker Reuse Value
+- Actionability
+- Watch Next Specificity
+- Prediction / Future Review Value
+- Confidence Support
+- Anti-Garbage Risk
+
+The score does not redefine these dimensions. It preserves the audit's dimension scores and normalizes them into a first-class score record.
+
+## Relationship To OpenAI Output Quality Audit V1
+
+SignalQualityScore V1 consumes:
+
+`docs/DYSONX_OPENAI_OUTPUT_QUALITY_AUDIT_V1.md`
+
+It reads only an existing OpenAI Output Quality Audit V1 JSON report. It does not read raw provider responses, raw articles, workflow logs, secrets, Notion data, live GitHub data, or website output.
+
+V1 does not rescore raw text unless a future reviewed change requires it. The score is derived from audit output so audit behavior and score behavior remain separable.
+
+## Input Audit Report
+
+CLI:
+
+```bash
+python3 scripts/dysonx_signal_quality_score.py \
+  --audit-report tmp/dysonx_openai_output_quality_audit.json \
+  --output tmp/dysonx_signal_quality_score.json
+```
+
+The input audit report must include:
+
+- `audit_version`
+- `framework_reference`
+- `quality_dimensions`
+- `signal_reviews`
+- `tier_counts`
+- `safety_flags`
+
+Malformed or incomplete input fails closed.
+
+## Output Score Report Schema
+
+The score report contains:
+
+- `score_version`
+- `created_at`
+- `input_audit_report`
+- `framework_reference`
+- `audit_reference`
+- `signals_scored`
+- `score_dimensions`
+- `score_records`
+- `tier_counts`
+- `blocking_risk_counts`
+- `recommended_next_actions`
+- `safety_flags`
+
+Each score record contains:
+
+- `signal_id`
+- `candidate_id`
+- `title`
+- `source_url`
+- `quality_score_total`
+- `quality_score_max`
+- `quality_score_percent`
+- `quality_tier`
+- `dimension_scores`
+- `critical_risk_flags`
+- `noncritical_risk_flags`
+- `missing_fields`
+- `publish_readiness_candidate`
+- `recommended_action`
+- `score_explanation`
+- `confidence_input_available`
+- `requires_confidence_calibration`
+- `requires_human_review`
+- `correlation_recommended`
+- `score_source`
+
+`quality_score_percent` is normalized as:
+
+`quality_score_total / 65`
+
+## Tier And Action Mapping
+
+SignalQualityScore V1 preserves audit tiers when the audit report is valid.
+
+Recommended action mapping:
+
+- Tier A with no critical risk: `candidate_for_human_approval`
+- Tier B with no critical risk: `needs_human_review`
+- Tier C: `improve_or_regenerate`
+- Tier D: `reject_or_regenerate`
+- Any critical risk: `blocked_by_quality_risk`
+
+Tier A can become a candidate for future human approval, but it is not publish-ready by itself. Tier B requires human review. Tier C requires improved analysis or regeneration. Tier D should be rejected or regenerated.
+
+## Critical Risk Handling
+
+Critical risks include:
+
+- `missing_source_url`
+- `missing_why_it_matters`
+- `missing_watch_next`
+- `missing_agi_capability`
+- `unsupported_publish_readiness`
+- `article_like_output`
+- `generic_summary`
+- `raw_provider_response_present`
+- `network_or_live_operation_attempted`
+
+Any critical risk blocks `publish_readiness_candidate`.
+
+This PR does not implement a Publish Readiness Gate. The field is a future-facing score attribute only, and the output safety flag `publish_readiness_enabled` remains false.
+
+## Confidence Calibration Boundary
+
+SignalQualityScore V1 records whether confidence input is available from the audit report. It does not calibrate confidence.
+
+`requires_confidence_calibration` is true by default because future calibration must consider source authority, evidence completeness, claim specificity, cross-source support, contradiction risk, uncertainty labeling, freshness, and whether claims are directly supported or inferred.
+
+## Correlation Boundary
+
+SignalQualityScore V1 may recommend future correlation for Tier A or Tier B signals, or for signals with strong entity / relationship value.
+
+It does not perform correlation. It does not merge sources, compare evidence across sources, or create Knowledge Graph edges.
+
+## Human Approval Boundary
+
+SignalQualityScore V1 does not approve Signals.
+
+Tier A still requires future human approval before any publish-readiness path. Tier B and Tier C require human review or improved analysis. Signals with critical risks are blocked until those risks are resolved.
+
+## Publish-Readiness Boundary
+
+This PR does not enable publish readiness.
+
+Publishing remains blocked until Confidence Calibration V1, Multi-source Correlation V1, Human Approval Gate V1, and Publish Readiness Gate V1 are reviewed and stable.
+
+## Safety Flags
+
+The output safety flags are all false:
+
+- `openai_call_performed`
+- `workflow_dispatched`
+- `publishing_performed`
+- `publish_readiness_enabled`
+- `website_pages_written`
+- `social_posting_performed`
+- `notion_mutation_performed`
+- `live_github_api_used`
+- `article_body_scraping_performed`
+- `raw_provider_response_stored`
+- `knowledge_graph_write_performed`
+- `prediction_engine_performed`
+- `deployment_performed`
+
+## Non-Goals
+
+This PR does not:
+
+- call OpenAI
+- require `OPENAI_API_KEY`
+- dispatch workflows
+- change workflows
+- publish content
+- enable publish readiness
+- generate website pages
+- write public content files
+- social post
+- mutate Notion
+- use live GitHub API collection
+- scrape article bodies
+- require or store raw provider responses
+- write Knowledge Graph records
+- implement Prediction Engine work
+- implement Confidence Calibration
+- implement Multi-source Correlation
+- implement Human Approval Gate
+- implement Publish Readiness Gate
+- deploy
+- merge itself
+
+## How To Run Locally
+
+Generate the audit fixture from existing safe reports:
+
+```bash
+python3 scripts/dysonx_openai_output_quality_audit.py \
+  --llm-audit-report tests/fixtures/openai_output_quality_audit_v1/llm_audit_report.json \
+  --signal-candidate-report tests/fixtures/openai_output_quality_audit_v1/signal_candidate_report.json \
+  --pipeline-report tests/fixtures/openai_output_quality_audit_v1/pipeline_report.json \
+  --output tmp/dysonx_openai_output_quality_audit.json
+```
+
+Then generate SignalQualityScore V1:
+
+```bash
+python3 scripts/dysonx_signal_quality_score.py \
+  --audit-report tmp/dysonx_openai_output_quality_audit.json \
+  --output tmp/dysonx_signal_quality_score.json
+```
+
+## Next Recommended PR
+
+The next recommended PR should be selected after review of score outputs:
+
+- Confidence Calibration V1 if reviewers need better confidence support before using scores.
+- Multi-source Correlation V1 if reviewers need cross-source evidence comparison for Tier A/B Signals.
+
+Publishing should remain blocked until both the confidence and correlation boundaries are understood and a separate Human Approval Gate and Publish Readiness Gate exist.

--- a/scripts/dysonx_signal_quality_score.py
+++ b/scripts/dysonx_signal_quality_score.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""DysonX SignalQualityScore V1.
+
+Builds first-class score records from an existing OpenAI Output Quality Audit
+V1 report. This script is offline and deterministic. It does not call OpenAI,
+dispatch workflows, publish, write website pages, mutate Notion, call GitHub,
+scrape article bodies, write Knowledge Graph records, run Prediction Engine
+work, enable publish readiness, or deploy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+
+SCORE_VERSION = "signal_quality_score_v1"
+FRAMEWORK_REFERENCE = "docs/DYSONX_SIGNAL_QUALITY_FRAMEWORK_V1.md"
+AUDIT_REFERENCE = "docs/DYSONX_OPENAI_OUTPUT_QUALITY_AUDIT_V1.md"
+QUALITY_SCORE_MAX = 65
+
+SCORE_DIMENSIONS = (
+    "Information Density",
+    "Source Attribution",
+    "Source Authority",
+    "Reasoning Depth",
+    "Novelty",
+    "AGI Capability Relevance",
+    "Entity / Relationship Value",
+    "Tracker Reuse Value",
+    "Actionability",
+    "Watch Next Specificity",
+    "Prediction / Future Review Value",
+    "Confidence Support",
+    "Anti-Garbage Risk",
+)
+
+CRITICAL_RISK_FLAGS = {
+    "missing_source_url",
+    "missing_why_it_matters",
+    "missing_watch_next",
+    "missing_agi_capability",
+    "unsupported_publish_readiness",
+    "article_like_output",
+    "generic_summary",
+    "raw_provider_response_present",
+    "network_or_live_operation_attempted",
+}
+
+SAFETY_FLAGS = {
+    "openai_call_performed": False,
+    "workflow_dispatched": False,
+    "publishing_performed": False,
+    "publish_readiness_enabled": False,
+    "website_pages_written": False,
+    "social_posting_performed": False,
+    "notion_mutation_performed": False,
+    "live_github_api_used": False,
+    "article_body_scraping_performed": False,
+    "raw_provider_response_stored": False,
+    "knowledge_graph_write_performed": False,
+    "prediction_engine_performed": False,
+    "deployment_performed": False,
+}
+
+
+class ScoreInputError(ValueError):
+    """Raised when an audit report cannot safely produce score records."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json_object(path: str | pathlib.Path, label: str) -> dict[str, Any]:
+    report_path = pathlib.Path(path)
+    try:
+        data = json.loads(report_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI should fail closed on malformed JSON.
+        raise ScoreInputError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ScoreInputError(f"{label} must be a JSON object")
+    return data
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def normalize_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, tuple):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    return []
+
+
+def require_fields(report: dict[str, Any]) -> None:
+    required_fields = (
+        "audit_version",
+        "framework_reference",
+        "quality_dimensions",
+        "signal_reviews",
+        "tier_counts",
+        "safety_flags",
+    )
+    missing = [field for field in required_fields if field not in report]
+    if missing:
+        raise ScoreInputError(f"Audit report missing required fields: {', '.join(missing)}")
+    if report.get("audit_version") != "openai_output_quality_audit_v1":
+        raise ScoreInputError("Audit report must be OpenAI Output Quality Audit V1")
+    if report.get("quality_dimensions") != list(SCORE_DIMENSIONS):
+        raise ScoreInputError("Audit quality dimensions do not match SignalQualityScore V1")
+    signal_reviews = report.get("signal_reviews")
+    if not isinstance(signal_reviews, list) or not all(isinstance(review, dict) for review in signal_reviews):
+        raise ScoreInputError("Audit report signal_reviews must be a list of objects")
+
+
+def critical_and_noncritical_risks(risk_flags: list[str]) -> tuple[list[str], list[str]]:
+    critical = sorted(flag for flag in risk_flags if flag in CRITICAL_RISK_FLAGS)
+    noncritical = sorted(flag for flag in risk_flags if flag not in CRITICAL_RISK_FLAGS)
+    return critical, noncritical
+
+
+def action_for_tier(quality_tier: str, critical_risk_flags: list[str]) -> str:
+    if critical_risk_flags:
+        return "blocked_by_quality_risk"
+    if quality_tier.startswith("Tier A"):
+        return "candidate_for_human_approval"
+    if quality_tier.startswith("Tier B"):
+        return "needs_human_review"
+    if quality_tier.startswith("Tier C"):
+        return "improve_or_regenerate"
+    return "reject_or_regenerate"
+
+
+def confidence_input_available(review: dict[str, Any]) -> bool:
+    notes = normalize_list(review.get("confidence_notes"))
+    if not notes:
+        return False
+    return any(note.startswith("model_confidence=") or note == "source_url_present" for note in notes)
+
+
+def requires_human_review(quality_tier: str, critical_risk_flags: list[str]) -> bool:
+    if critical_risk_flags:
+        return True
+    if quality_tier.startswith("Tier A"):
+        return True
+    if quality_tier.startswith("Tier B") or quality_tier.startswith("Tier C"):
+        return True
+    return False
+
+
+def correlation_recommended(quality_tier: str, dimension_scores: dict[str, int]) -> bool:
+    entity_score = int(dimension_scores.get("Entity / Relationship Value", 0))
+    return quality_tier.startswith("Tier A") or quality_tier.startswith("Tier B") or entity_score >= 3
+
+
+def score_explanation(total: int, tier: str, critical_risk_flags: list[str]) -> str:
+    percent = total / QUALITY_SCORE_MAX
+    if critical_risk_flags:
+        return (
+            f"Score {total}/{QUALITY_SCORE_MAX} ({percent:.2%}) is blocked by "
+            f"critical risks: {', '.join(critical_risk_flags)}."
+        )
+    return f"Score {total}/{QUALITY_SCORE_MAX} ({percent:.2%}) maps to {tier}."
+
+
+def validate_review(review: dict[str, Any], index: int) -> None:
+    required_fields = (
+        "signal_id",
+        "candidate_id",
+        "title",
+        "source_url",
+        "quality_scores",
+        "total_score",
+        "quality_tier",
+        "risk_flags",
+        "missing_fields",
+    )
+    missing = [field for field in required_fields if field not in review]
+    if missing:
+        raise ScoreInputError(f"Signal review {index} missing required fields: {', '.join(missing)}")
+    scores = review.get("quality_scores")
+    if not isinstance(scores, dict):
+        raise ScoreInputError(f"Signal review {index} quality_scores must be an object")
+    if set(scores.keys()) != set(SCORE_DIMENSIONS):
+        raise ScoreInputError(f"Signal review {index} quality score dimensions do not match framework")
+    for dimension, score in scores.items():
+        if not isinstance(score, int) or score < 0 or score > 5:
+            raise ScoreInputError(f"Signal review {index} dimension {dimension} must be an integer from 0 to 5")
+    total = review.get("total_score")
+    if not isinstance(total, int) or total < 0 or total > QUALITY_SCORE_MAX:
+        raise ScoreInputError(f"Signal review {index} total_score must be an integer from 0 to {QUALITY_SCORE_MAX}")
+
+
+def build_score_record(review: dict[str, Any], index: int) -> dict[str, Any]:
+    validate_review(review, index)
+    dimension_scores = {dimension: int(review["quality_scores"][dimension]) for dimension in SCORE_DIMENSIONS}
+    total = int(review["total_score"])
+    quality_tier = normalize_text(review.get("quality_tier"))
+    risk_flags = normalize_list(review.get("risk_flags"))
+    critical, noncritical = critical_and_noncritical_risks(risk_flags)
+    action = action_for_tier(quality_tier, critical)
+    publish_candidate = action == "candidate_for_human_approval" and not critical
+    confidence_available = confidence_input_available(review)
+    return {
+        "signal_id": normalize_text(review.get("signal_id")),
+        "candidate_id": normalize_text(review.get("candidate_id")),
+        "title": normalize_text(review.get("title")),
+        "source_url": normalize_text(review.get("source_url")),
+        "quality_score_total": total,
+        "quality_score_max": QUALITY_SCORE_MAX,
+        "quality_score_percent": total / QUALITY_SCORE_MAX,
+        "quality_tier": quality_tier,
+        "dimension_scores": dimension_scores,
+        "critical_risk_flags": critical,
+        "noncritical_risk_flags": noncritical,
+        "missing_fields": normalize_list(review.get("missing_fields")),
+        "publish_readiness_candidate": publish_candidate,
+        "recommended_action": action,
+        "score_explanation": score_explanation(total, quality_tier, critical),
+        "confidence_input_available": confidence_available,
+        "requires_confidence_calibration": True,
+        "requires_human_review": requires_human_review(quality_tier, critical),
+        "correlation_recommended": correlation_recommended(quality_tier, dimension_scores),
+        "score_source": "openai_output_quality_audit_v1",
+    }
+
+
+def summarize_tiers(score_records: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {
+        "Tier A: Decision-grade Signal": 0,
+        "Tier B: Useful Signal": 0,
+        "Tier C: Needs Review": 0,
+        "Tier D: Reject / Low-value": 0,
+    }
+    for record in score_records:
+        tier = str(record.get("quality_tier"))
+        counts[tier] = counts.get(tier, 0) + 1
+    return counts
+
+
+def summarize_blocking_risks(score_records: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {flag: 0 for flag in sorted(CRITICAL_RISK_FLAGS)}
+    for record in score_records:
+        for flag in record.get("critical_risk_flags", []):
+            counts[flag] = counts.get(flag, 0) + 1
+    return {flag: count for flag, count in counts.items() if count > 0}
+
+
+def recommended_next_actions(score_records: list[dict[str, Any]]) -> list[str]:
+    actions = [
+        "Review SignalQualityScore V1 output against real and fixture audit reports.",
+        "Implement Confidence Calibration V1 before publish-readiness decisions.",
+        "Implement Multi-source Correlation V1 for high-value or entity-rich signals.",
+        "Keep publishing blocked until Human Approval Gate and Publish Readiness Gate exist.",
+    ]
+    if any(record.get("critical_risk_flags") for record in score_records):
+        actions.insert(0, "Resolve records blocked by critical quality risks.")
+    return actions
+
+
+def run_score(
+    audit_report_path: str | pathlib.Path,
+    output_path: str | pathlib.Path | None = None,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    audit_report = read_json_object(audit_report_path, "OpenAI Output Quality Audit V1 report")
+    require_fields(audit_report)
+    score_records = [
+        build_score_record(review, index)
+        for index, review in enumerate(audit_report["signal_reviews"])
+    ]
+    report = {
+        "score_version": SCORE_VERSION,
+        "created_at": created_at or utc_now(),
+        "input_audit_report": str(audit_report_path),
+        "framework_reference": FRAMEWORK_REFERENCE,
+        "audit_reference": AUDIT_REFERENCE,
+        "signals_scored": len(score_records),
+        "score_dimensions": list(SCORE_DIMENSIONS),
+        "score_records": score_records,
+        "tier_counts": summarize_tiers(score_records),
+        "blocking_risk_counts": summarize_blocking_risks(score_records),
+        "recommended_next_actions": recommended_next_actions(score_records),
+        "safety_flags": dict(SAFETY_FLAGS),
+    }
+    if output_path is not None:
+        write_report(report, output_path)
+    return report
+
+
+def write_report(report: dict[str, Any], output_path: str | pathlib.Path) -> None:
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX SignalQualityScore V1.")
+    parser.add_argument("--audit-report", required=True, help="Path to OpenAI Output Quality Audit V1 JSON.")
+    parser.add_argument("--output", required=True, help="Path to write SignalQualityScore V1 report JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_score(args.audit_report, output_path=args.output)
+    except ScoreInputError as exc:
+        print(f"[signal-quality-score] failed: {exc}")
+        return 1
+    print(
+        "[signal-quality-score] wrote report: "
+        f"{args.output} signals_scored={report['signals_scored']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/signal_quality_score_v1/openai_output_quality_audit.json
+++ b/tests/fixtures/signal_quality_score_v1/openai_output_quality_audit.json
@@ -1,0 +1,207 @@
+{
+  "audit_version": "openai_output_quality_audit_v1",
+  "created_at": "2026-06-19T00:00:00+00:00",
+  "findings": [
+    "Fixture audit for SignalQualityScore V1."
+  ],
+  "framework_reference": "docs/DYSONX_SIGNAL_QUALITY_FRAMEWORK_V1.md",
+  "input_paths": {
+    "llm_audit_report": "fixture/llm_audit_report.json",
+    "pipeline_report": "fixture/pipeline_report.json",
+    "signal_candidate_report": "fixture/signal_candidate_report.json"
+  },
+  "milestone_reference": "docs/DYSONX_V1_OPENAI_ORCHESTRATOR_SMOKE_MILESTONE.md",
+  "quality_dimensions": [
+    "Information Density",
+    "Source Attribution",
+    "Source Authority",
+    "Reasoning Depth",
+    "Novelty",
+    "AGI Capability Relevance",
+    "Entity / Relationship Value",
+    "Tracker Reuse Value",
+    "Actionability",
+    "Watch Next Specificity",
+    "Prediction / Future Review Value",
+    "Confidence Support",
+    "Anti-Garbage Risk"
+  ],
+  "recommended_next_actions": [
+    "Use audit results to design SignalQualityScore V1 integration."
+  ],
+  "safety_flags": {
+    "article_body_scraping_performed": false,
+    "deployment_performed": false,
+    "knowledge_graph_write_performed": false,
+    "live_github_api_used": false,
+    "notion_mutation_performed": false,
+    "openai_call_performed": false,
+    "prediction_engine_performed": false,
+    "publishing_performed": false,
+    "raw_provider_response_stored": false,
+    "social_posting_performed": false,
+    "website_pages_written": false,
+    "workflow_dispatched": false
+  },
+  "signal_reviews": [
+    {
+      "candidate_id": "candidate_tier_a",
+      "confidence_notes": [
+        "model_confidence=0.82",
+        "source_url_present"
+      ],
+      "missing_fields": [],
+      "pass_publish_readiness_candidate": true,
+      "prompt_version": "real_llm_provider_gated_v1",
+      "provider": "openai",
+      "quality_scores": {
+        "AGI Capability Relevance": 5,
+        "Actionability": 5,
+        "Anti-Garbage Risk": 5,
+        "Confidence Support": 4,
+        "Entity / Relationship Value": 4,
+        "Information Density": 4,
+        "Novelty": 4,
+        "Prediction / Future Review Value": 4,
+        "Reasoning Depth": 4,
+        "Source Attribution": 5,
+        "Source Authority": 4,
+        "Tracker Reuse Value": 4,
+        "Watch Next Specificity": 5
+      },
+      "quality_tier": "Tier A: Decision-grade Signal",
+      "recommended_action": "Eligible for future human review as a publish-readiness candidate.",
+      "risk_flags": [],
+      "signal_id": "signal_tier_a",
+      "source_url": "https://openai.com/example-agent-update",
+      "strengths": [],
+      "title": "OpenAI releases agent infrastructure update",
+      "total_score": 57,
+      "weaknesses": []
+    },
+    {
+      "candidate_id": "candidate_tier_b",
+      "confidence_notes": [
+        "model_confidence=0.7",
+        "source_url_present"
+      ],
+      "missing_fields": [],
+      "pass_publish_readiness_candidate": false,
+      "prompt_version": "real_llm_provider_gated_v1",
+      "provider": "openai",
+      "quality_scores": {
+        "AGI Capability Relevance": 4,
+        "Actionability": 3,
+        "Anti-Garbage Risk": 4,
+        "Confidence Support": 3,
+        "Entity / Relationship Value": 3,
+        "Information Density": 3,
+        "Novelty": 3,
+        "Prediction / Future Review Value": 3,
+        "Reasoning Depth": 3,
+        "Source Attribution": 4,
+        "Source Authority": 3,
+        "Tracker Reuse Value": 3,
+        "Watch Next Specificity": 4
+      },
+      "quality_tier": "Tier B: Useful Signal",
+      "recommended_action": "Useful signal; validate correlation and confidence before approval.",
+      "risk_flags": [],
+      "signal_id": "signal_tier_b",
+      "source_url": "https://example.com/tier-b",
+      "strengths": [],
+      "title": "Useful model evaluation update",
+      "total_score": 43,
+      "weaknesses": []
+    },
+    {
+      "candidate_id": "candidate_tier_c",
+      "confidence_notes": [
+        "model_confidence=0.55"
+      ],
+      "missing_fields": [
+        "related_entities"
+      ],
+      "pass_publish_readiness_candidate": false,
+      "prompt_version": "real_llm_provider_gated_v1",
+      "provider": "openai",
+      "quality_scores": {
+        "AGI Capability Relevance": 3,
+        "Actionability": 2,
+        "Anti-Garbage Risk": 3,
+        "Confidence Support": 2,
+        "Entity / Relationship Value": 0,
+        "Information Density": 3,
+        "Novelty": 3,
+        "Prediction / Future Review Value": 2,
+        "Reasoning Depth": 2,
+        "Source Attribution": 4,
+        "Source Authority": 3,
+        "Tracker Reuse Value": 1,
+        "Watch Next Specificity": 3
+      },
+      "quality_tier": "Tier C: Needs Review",
+      "recommended_action": "Needs stronger analysis, attribution, or capability mapping.",
+      "risk_flags": [],
+      "signal_id": "signal_tier_c",
+      "source_url": "https://example.com/tier-c",
+      "strengths": [],
+      "title": "Potentially relevant research update",
+      "total_score": 31,
+      "weaknesses": []
+    },
+    {
+      "candidate_id": "candidate_tier_d",
+      "confidence_notes": [
+        "model_confidence=0.95"
+      ],
+      "missing_fields": [
+        "source_url",
+        "why_it_matters",
+        "agi_capability",
+        "related_entities",
+        "watch_next"
+      ],
+      "pass_publish_readiness_candidate": false,
+      "prompt_version": "real_llm_provider_gated_v1",
+      "provider": "openai",
+      "quality_scores": {
+        "AGI Capability Relevance": 0,
+        "Actionability": 0,
+        "Anti-Garbage Risk": 2,
+        "Confidence Support": 2,
+        "Entity / Relationship Value": 0,
+        "Information Density": 1,
+        "Novelty": 4,
+        "Prediction / Future Review Value": 0,
+        "Reasoning Depth": 0,
+        "Source Attribution": 0,
+        "Source Authority": 0,
+        "Tracker Reuse Value": 0,
+        "Watch Next Specificity": 0
+      },
+      "quality_tier": "Tier D: Reject / Low-value",
+      "recommended_action": "Fix critical risks before any publish-readiness consideration.",
+      "risk_flags": [
+        "generic_summary",
+        "missing_agi_capability",
+        "missing_source_url",
+        "missing_watch_next",
+        "missing_why_it_matters"
+      ],
+      "signal_id": "signal_tier_d",
+      "source_url": "",
+      "strengths": [],
+      "title": "AI changes everything",
+      "total_score": 9,
+      "weaknesses": []
+    }
+  ],
+  "signals_reviewed": 4,
+  "tier_counts": {
+    "Tier A: Decision-grade Signal": 1,
+    "Tier B: Useful Signal": 1,
+    "Tier C: Needs Review": 1,
+    "Tier D: Reject / Low-value": 1
+  }
+}

--- a/tests/test_dysonx_signal_quality_score.py
+++ b/tests/test_dysonx_signal_quality_score.py
@@ -1,0 +1,184 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_signal_quality_score as score
+
+
+FIXTURE = ROOT / "tests" / "fixtures" / "signal_quality_score_v1" / "openai_output_quality_audit.json"
+FIXED_TIME = "2026-06-19T00:00:00+00:00"
+
+
+class DysonXSignalQualityScoreTests(unittest.TestCase):
+    def run_fixture_score(self) -> dict:
+        return score.run_score(FIXTURE, created_at=FIXED_TIME)
+
+    def records_by_candidate(self) -> dict[str, dict]:
+        report = self.run_fixture_score()
+        return {record["candidate_id"]: record for record in report["score_records"]}
+
+    def test_script_reads_audit_fixture_and_writes_score_report(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "signal_quality_score.json"
+
+            exit_code = score.main(["--audit-report", str(FIXTURE), "--output", str(output)])
+
+            self.assertEqual(exit_code, 0)
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(report["score_version"], score.SCORE_VERSION)
+            self.assertEqual(report["signals_scored"], 4)
+            self.assertEqual(len(report["score_records"]), 4)
+
+    def test_score_dimensions_exactly_match_framework_dimensions(self):
+        report = self.run_fixture_score()
+
+        self.assertEqual(report["score_dimensions"], list(score.SCORE_DIMENSIONS))
+        for record in report["score_records"]:
+            self.assertEqual(list(record["dimension_scores"].keys()), list(score.SCORE_DIMENSIONS))
+
+    def test_score_percentage_is_total_score_divided_by_65(self):
+        records = self.records_by_candidate()
+        tier_a = records["candidate_tier_a"]
+
+        self.assertEqual(tier_a["quality_score_total"], 57)
+        self.assertEqual(tier_a["quality_score_max"], 65)
+        self.assertAlmostEqual(tier_a["quality_score_percent"], 57 / 65)
+
+    def test_critical_risks_block_publish_readiness_candidate(self):
+        records = self.records_by_candidate()
+        tier_d = records["candidate_tier_d"]
+
+        self.assertIn("missing_source_url", tier_d["critical_risk_flags"])
+        self.assertFalse(tier_d["publish_readiness_candidate"])
+
+    def test_tier_a_without_critical_risks_maps_to_human_approval_not_publish_ready(self):
+        records = self.records_by_candidate()
+        tier_a = records["candidate_tier_a"]
+
+        self.assertEqual(tier_a["recommended_action"], "candidate_for_human_approval")
+        self.assertTrue(tier_a["publish_readiness_candidate"])
+        self.assertTrue(tier_a["requires_human_review"])
+
+    def test_tier_b_maps_to_needs_human_review(self):
+        records = self.records_by_candidate()
+
+        self.assertEqual(records["candidate_tier_b"]["recommended_action"], "needs_human_review")
+        self.assertTrue(records["candidate_tier_b"]["requires_human_review"])
+
+    def test_tier_c_maps_to_improve_or_regenerate(self):
+        records = self.records_by_candidate()
+
+        self.assertEqual(records["candidate_tier_c"]["recommended_action"], "improve_or_regenerate")
+
+    def test_tier_d_maps_to_reject_or_regenerate_without_critical_risk(self):
+        review = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        tier_d = next(item for item in review["signal_reviews"] if item["candidate_id"] == "candidate_tier_d")
+        tier_d["risk_flags"] = []
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = pathlib.Path(tmpdir) / "audit.json"
+            audit_path.write_text(json.dumps(review), encoding="utf-8")
+            report = score.run_score(audit_path, created_at=FIXED_TIME)
+
+        record = next(item for item in report["score_records"] if item["candidate_id"] == "candidate_tier_d")
+        self.assertEqual(record["recommended_action"], "reject_or_regenerate")
+
+    def test_tier_d_maps_to_blocked_by_quality_risk_when_critical(self):
+        records = self.records_by_candidate()
+
+        self.assertEqual(records["candidate_tier_d"]["recommended_action"], "blocked_by_quality_risk")
+
+    def test_any_critical_risk_maps_to_blocked_by_quality_risk(self):
+        review = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        tier_b = next(item for item in review["signal_reviews"] if item["candidate_id"] == "candidate_tier_b")
+        tier_b["risk_flags"] = ["missing_watch_next"]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = pathlib.Path(tmpdir) / "audit.json"
+            audit_path.write_text(json.dumps(review), encoding="utf-8")
+            report = score.run_score(audit_path, created_at=FIXED_TIME)
+
+        record = next(item for item in report["score_records"] if item["candidate_id"] == "candidate_tier_b")
+        self.assertEqual(record["recommended_action"], "blocked_by_quality_risk")
+        self.assertFalse(record["publish_readiness_candidate"])
+
+    def test_safety_flags_are_all_false_including_publish_readiness_enabled(self):
+        report = self.run_fixture_score()
+
+        self.assertIn("publish_readiness_enabled", report["safety_flags"])
+        for flag_name, value in report["safety_flags"].items():
+            self.assertFalse(value, flag_name)
+
+    def test_no_openai_api_key_is_required(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            report = self.run_fixture_score()
+
+        self.assertEqual(report["signals_scored"], 4)
+
+    def test_malformed_audit_report_exits_nonzero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            malformed = pathlib.Path(tmpdir) / "malformed.json"
+            malformed.write_text("{not json", encoding="utf-8")
+            output = pathlib.Path(tmpdir) / "score.json"
+
+            exit_code = score.main(["--audit-report", str(malformed), "--output", str(output)])
+
+            self.assertEqual(exit_code, 1)
+            self.assertFalse(output.exists())
+
+    def test_missing_required_audit_fields_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audit_path = pathlib.Path(tmpdir) / "audit.json"
+            audit_path.write_text(json.dumps({"audit_version": "openai_output_quality_audit_v1"}), encoding="utf-8")
+
+            with self.assertRaises(score.ScoreInputError):
+                score.run_score(audit_path, created_at=FIXED_TIME)
+
+    def test_output_includes_framework_and_audit_references(self):
+        report = self.run_fixture_score()
+
+        self.assertEqual(report["framework_reference"], "docs/DYSONX_SIGNAL_QUALITY_FRAMEWORK_V1.md")
+        self.assertEqual(report["audit_reference"], "docs/DYSONX_OPENAI_OUTPUT_QUALITY_AUDIT_V1.md")
+
+    def test_confidence_calibration_is_required_but_not_implemented(self):
+        report = self.run_fixture_score()
+
+        for record in report["score_records"]:
+            self.assertTrue(record["requires_confidence_calibration"])
+        self.assertNotIn("calibrated_confidence", json.dumps(report))
+
+    def test_correlation_is_recommended_only_as_future_action_not_performed(self):
+        records = self.records_by_candidate()
+
+        self.assertTrue(records["candidate_tier_a"]["correlation_recommended"])
+        self.assertTrue(records["candidate_tier_b"]["correlation_recommended"])
+        serialized = json.dumps(self.run_fixture_score())
+        self.assertNotIn("correlation_performed", serialized)
+        self.assertNotIn("correlation_results", serialized)
+
+    def test_no_raw_provider_response_is_required_or_stored(self):
+        report = self.run_fixture_score()
+        serialized = json.dumps(report)
+
+        self.assertFalse(report["safety_flags"]["raw_provider_response_stored"])
+        self.assertNotIn('"raw_provider_response":', serialized)
+
+    def test_score_script_has_no_live_network_or_provider_dependency(self):
+        source = pathlib.Path(score.__file__).read_text(encoding="utf-8").lower()
+
+        self.assertNotIn("http.client", source)
+        self.assertNotIn("urllib", source)
+        self.assertNotIn("requests", source)
+        self.assertNotIn("import openai", source)
+        self.assertNotIn("dysonx_real_llm_provider", source)
+        self.assertNotIn("api.github.com", source)
+        self.assertNotIn("api.notion.com", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add SignalQualityScore V1 as an offline score object derived from OpenAI Output Quality Audit V1 reports.
- Add deterministic score report generation with framework dimensions, tier/action mapping, critical risk preservation, confidence/correlation placeholders, and safety flags.
- Add documentation, fixture coverage, and unit tests.

## Safety boundaries
- No OpenAI call.
- No OPENAI_API_KEY required.
- No workflow dispatch or workflow changes.
- No publishing, website/public content writing, social posting, Notion mutation, live GitHub API usage, article scraping, Knowledge Graph writes, Prediction Engine work, deployment, or merge.

## Validation
- python3 scripts/constitution_guard.py PASS
- python3 scripts/architecture_guard.py PASS
- python3 scripts/release_guard.py PASS
- python3 -m py_compile scripts/*.py PASS
- python3 -m unittest discover -s tests PASS
- python3 scripts/dysonx_openai_output_quality_audit.py --llm-audit-report tests/fixtures/openai_output_quality_audit_v1/llm_audit_report.json --signal-candidate-report tests/fixtures/openai_output_quality_audit_v1/signal_candidate_report.json --pipeline-report tests/fixtures/openai_output_quality_audit_v1/pipeline_report.json --output tmp/dysonx_openai_output_quality_audit.json PASS
- python3 scripts/dysonx_signal_quality_score.py --audit-report tmp/dysonx_openai_output_quality_audit.json --output tmp/dysonx_signal_quality_score.json PASS
- git diff --check origin/main...HEAD PASS