### PR TITLE
docs: add DysonX Phase 2 usability milestone review

### DIFF
--- a/docs/DYSONX_PHASE_2_USABILITY_MILESTONE_REVIEW.md
+++ b/docs/DYSONX_PHASE_2_USABILITY_MILESTONE_REVIEW.md
@@ -1,0 +1,190 @@
+# DysonX Phase 2 Usability Milestone Review
+
+## 1. Status
+
+This is a documentation-only milestone review after PR #58.
+
+Phase 2 has shifted from building internal quality layers only to building the minimal usable Owner intelligence loop.
+
+The current strategic priority is not to keep adding complex backend intelligence layers before the Owner can read, judge, and give feedback on internal intelligence briefs. DysonX should now move toward an internal brief and internal frontend that the Owner can actually use.
+
+## 2. Milestones Completed
+
+- PR #54: V1 OpenAI orchestrator smoke milestone
+- PR #55: Signal Quality Framework V1
+- PR #56: OpenAI Output Quality Audit V1
+- PR #57: SignalQualityScore V1
+- PR #58: Internal Intelligence Brief V1
+
+Together, these milestones created the first governed path from safe pipeline artifacts through quality audit, quality scoring, and an internal owner-readable brief.
+
+## 3. Current Internal Loop
+
+The current internal loop is:
+
+```text
+Source / Safe Artifacts
+-> IntelligenceSignal
+-> Output Quality Audit
+-> SignalQualityScore
+-> Internal Intelligence Brief
+-> Owner reads and reviews manually
+```
+
+This loop is internal only.
+
+It does not publish content, generate website pages, create public posts, write Knowledge Graph records, run the Prediction Engine, mutate Notion, dispatch workflows, or deploy.
+
+## 4. What The Owner Can Read Today
+
+Internal Intelligence Brief V1 can now show:
+
+- executive summary
+- tier counts
+- blocked count
+- human review count
+- correlation recommended count
+- decision-grade candidates
+- useful signals requiring review
+- blocked / low-value signals
+- owner review queue placeholders
+- next actions
+- safety boundary
+
+This gives the Owner a first internal reading surface for deciding whether generated Signals are useful, thin, blocked, or worth improving.
+
+## 5. What The Owner Can Decide Today
+
+The Owner can manually review each Signal and choose one of these decision placeholders:
+
+- `approve_for_future_publish_readiness_review`
+- `request_more_sources`
+- `request_regeneration`
+- `reject`
+- `hold`
+
+No decision is auto-approved.
+
+No Signal becomes publish-ready yet.
+
+The placeholder `approve_for_future_publish_readiness_review` means only that the Owner may later route a Signal into a future reviewed publish-readiness process after missing gates exist.
+
+## 6. What The Owner Cannot Do Yet
+
+The current loop is useful but still incomplete. Missing usability pieces include:
+
+- no internal frontend yet
+- no clickable review UI
+- no persisted Owner feedback record
+- no feedback-to-score loop
+- `why_it_matters` / `watch_next` may not flow fully from earlier reports into the brief
+- no confidence calibration
+- no correlation execution
+- no publish readiness
+- no public publishing
+
+The Owner can read and judge the brief, but feedback is not yet captured as structured data that the next iteration can use.
+
+## 7. Business / Product Risk
+
+The main risk is no longer only architecture drift.
+
+The new risk is overbuilding backend intelligence layers before the Owner can use the product.
+
+DysonX must avoid becoming an impressive but unused backend system. If internal scores, audits, and future gates continue to expand without an Owner-facing review loop, the product may become technically coherent but practically unvalidated.
+
+The immediate product question is:
+
+```text
+Can the Owner read a brief, make decisions, and feed those decisions back into the next iteration?
+```
+
+## 8. Strategic Direction
+
+The current strategic direction is:
+
+Build the minimal usable Owner intelligence loop before adding complex intelligence layers.
+
+Priority order:
+
+1. Owner-readable brief
+2. Owner feedback capture
+3. Improved brief field completeness
+4. Minimal internal frontend / preview
+5. Then only add Confidence / Correlation where actual Owner review reveals need
+
+This keeps Phase 2 focused on usability and decision value instead of abstract backend completeness.
+
+## 9. Recommended Next PR
+
+Two practical next PR options are available.
+
+### Option A: Owner Review Feedback V1
+
+Purpose:
+
+Allow Owner feedback decisions to be captured as structured JSON against brief items.
+
+This would let the Owner record decisions such as:
+
+- `approve_for_future_publish_readiness_review`
+- `request_more_sources`
+- `request_regeneration`
+- `reject`
+- `hold`
+
+It would create the first persistent feedback artifact for future iteration.
+
+### Option B: Brief Field Completeness V1
+
+Purpose:
+
+Pass `why_it_matters`, `watch_next`, and source/context fields from audit/score into the brief more completely.
+
+This would improve the readability and decision usefulness of each brief item, especially when the Owner cannot judge a Signal from score and title alone.
+
+### Recommendation
+
+Default recommendation: Owner Review Feedback V1 first, unless review shows the brief is too thin to judge.
+
+Reason:
+
+A feedback loop is the fastest path toward product usefulness.
+
+Without structured Owner feedback, DysonX cannot know whether the brief is good enough, which fields are missing, which Signals are useful, or which quality dimensions need improvement.
+
+If the Owner cannot make decisions from the current brief at all, then Brief Field Completeness V1 should come first. Otherwise, capture feedback first and use real feedback to prioritize field-completeness work.
+
+## 10. Explicit Non-Goals
+
+This milestone review does not authorize:
+
+- public publishing
+- website generation
+- social posting
+- Knowledge Graph writes
+- Prediction Engine
+- complex Confidence Calibration
+- complex Multi-source Correlation
+- deployment automation
+- workflow automation
+- OpenAI calls
+- Notion mutation
+- live GitHub API collection
+- article scraping
+
+Any future work in those areas requires a separate reviewed PR and explicit authorization.
+
+## 11. Completion Standard For The Next Stage
+
+The next stage is complete when:
+
+- Owner can read an internal brief
+- Owner can record decisions on each Signal
+- feedback is saved as structured data
+- brief quality gaps are visible
+- next iteration can improve based on actual Owner feedback
+
+At that point, DysonX will have the start of a usable internal intelligence loop rather than only a backend scoring pipeline.
+
+No production deployment is authorized by this milestone review.


### PR DESCRIPTION
## Purpose

Add a documentation-only Phase 2 usability milestone review after PR #58 Internal Intelligence Brief V1.

This review records the current strategic priority: DysonX should build the minimal usable Owner intelligence loop before adding more complex backend intelligence layers.

## Scope

Documentation-only.

Files changed:

- docs/DYSONX_PHASE_2_USABILITY_MILESTONE_REVIEW.md

## Summary

The review documents:

- completed Phase 2 milestones from PR #54 through PR #58
- the current internal loop from safe artifacts through Internal Intelligence Brief
- what the Owner can read today
- what the Owner can decide today
- what the Owner cannot do yet
- the product risk of overbuilding backend layers before usability
- the strategic direction toward Owner feedback and internal frontend usability
- recommended next PR options

## Recommended Next PR

Default recommendation: Owner Review Feedback V1 first, unless review shows the current brief is too thin to judge.

Reason: a structured feedback loop is the fastest path toward product usefulness.

## Safety / Non-Goals

This PR does not authorize or implement:

- code changes
- workflow changes
- public publishing
- website generation
- social posting
- Knowledge Graph writes
- Prediction Engine work
- complex Confidence Calibration
- complex Multi-source Correlation
- deployment automation
- workflow automation
- OpenAI calls
- Notion mutation
- live GitHub API collection
- article scraping

## Validation

Passed locally:

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- git diff --check origin/main...HEAD
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests

## Deployment Impact

No deployment. No production deployment was performed.
