### PR TITLE
feat: add DysonX Owner Review Feedback V1

### DIFF
--- a/docs/DYSONX_OWNER_REVIEW_FEEDBACK_V1.md
+++ b/docs/DYSONX_OWNER_REVIEW_FEEDBACK_V1.md
@@ -1,0 +1,246 @@
+# DysonX Owner Review Feedback V1
+
+## Purpose
+
+Owner Review Feedback V1 captures Owner decisions on Internal Intelligence Brief V1 items as a structured JSON report.
+
+It is an offline deterministic review artifact. It helps DysonX close the minimal usable Owner intelligence loop:
+
+```text
+SignalQualityScore
+-> Internal Intelligence Brief
+-> Owner Review
+-> Owner Feedback
+-> Improved Brief / Usable Internal Frontend
+```
+
+This is internal only. It is not publishing, public content generation, website generation, social distribution, Knowledge Graph writing, Prediction Engine work, Confidence Calibration, Correlation, workflow automation, or deployment.
+
+## Why This Exists Now
+
+Internal Intelligence Brief V1 made scored Signals readable by the Owner.
+
+The Phase 2 Usability Milestone Review identified the next practical missing piece: the Owner can read and judge a brief, but feedback is not yet saved as structured data.
+
+Owner Review Feedback V1 creates that first persistent feedback artifact. It lets the Owner record whether each brief item should be held, rejected, regenerated, supported by more sources, or considered later for a future publish-readiness review.
+
+The goal is product usefulness, not backend layer expansion.
+
+## Relationship To SignalQualityScore V1
+
+SignalQualityScore V1 creates quality score records and tier/action mappings from an existing OpenAI Output Quality Audit V1 report.
+
+Owner Review Feedback V1 does not rescore Signals. It does not change score records. It consumes the downstream Internal Intelligence Brief V1 queue that was derived from SignalQualityScore V1.
+
+An Owner decision can disagree with or refine a score-driven recommendation, but it does not alter the original score report.
+
+## Relationship To Internal Intelligence Brief V1
+
+Internal Intelligence Brief V1 creates an owner-readable brief and an `owner_review_queue`.
+
+Owner Review Feedback V1 reads that existing brief JSON and validates every Owner decision against the brief's `owner_review_queue`.
+
+Every decision `signal_id` must exist in the brief. Unknown Signals fail closed.
+
+## Input Brief JSON
+
+CLI:
+
+```bash
+python3 scripts/dysonx_owner_review_feedback.py \
+  --brief-json tmp/dysonx_internal_intelligence_brief.json \
+  --feedback-input tmp/owner_feedback_input.json \
+  --output tmp/dysonx_owner_review_feedback.json
+```
+
+The brief input must be an existing Internal Intelligence Brief V1 JSON report with:
+
+- `brief_version`
+- `source_score_report`
+- `signals_reviewed`
+- `owner_review_queue`
+- `safety_flags`
+
+The script reads the brief JSON only from the explicit `--brief-json` path.
+
+## Input Owner Feedback JSON
+
+The Owner feedback input contains:
+
+- `reviewer`
+- `review_session_id`
+- `reviewed_at`
+- `brief_version`
+- `brief_source`
+- `decisions`
+
+Each decision contains:
+
+- `signal_id`
+- `owner_decision`
+- `owner_comment`
+- `priority`
+- `follow_up_required`
+- `follow_up_note`
+
+Validation rules:
+
+- `reviewer` is required.
+- `review_session_id` is required.
+- `reviewed_at` is required.
+- `brief_version` must match the brief JSON `brief_version`.
+- `brief_source` must match or reference the source brief path.
+- `decisions` must be a non-empty list.
+- Every decision `signal_id` must exist in the brief `owner_review_queue`.
+- `owner_decision` must be an allowed value.
+- `priority` must be an allowed value.
+- `owner_comment` may be empty but must exist.
+- `follow_up_required` must be boolean.
+- `follow_up_note` may be empty but must exist.
+
+Malformed or incomplete input fails closed.
+
+## Output Feedback Report Schema
+
+The output JSON contains:
+
+- `feedback_version`
+- `created_at`
+- `reviewer`
+- `review_session_id`
+- `reviewed_at`
+- `source_brief`
+- `brief_version`
+- `signals_reviewed`
+- `decisions_recorded`
+- `decision_counts`
+- `follow_up_required_count`
+- `feedback_records`
+- `recommended_next_actions`
+- `safety_flags`
+
+Each feedback record contains:
+
+- `signal_id`
+- `title`
+- `original_tier`
+- `original_recommended_action`
+- `owner_decision`
+- `owner_comment`
+- `priority`
+- `follow_up_required`
+- `follow_up_note`
+- `resulting_status`
+- `next_action`
+
+## Allowed Decisions
+
+Allowed `owner_decision` values:
+
+- `approve_for_future_publish_readiness_review`
+- `request_more_sources`
+- `request_regeneration`
+- `reject`
+- `hold`
+
+Allowed `priority` values:
+
+- `high`
+- `medium`
+- `low`
+
+No decision is treated as publication permission.
+
+`approve_for_future_publish_readiness_review` means only that the Signal may later enter a separate reviewed publish-readiness process after missing gates exist. It does not make the Signal publish-ready.
+
+## Resulting Status Mapping
+
+- `approve_for_future_publish_readiness_review` -> `owner_approved_for_later_publish_readiness_review_only`
+- `request_more_sources` -> `needs_more_sources`
+- `request_regeneration` -> `needs_regeneration`
+- `reject` -> `owner_rejected`
+- `hold` -> `owner_hold`
+
+## Next Action Mapping
+
+- `approve_for_future_publish_readiness_review` -> `later_publish_readiness_review_required`
+- `request_more_sources` -> `collect_or_attach_more_sources`
+- `request_regeneration` -> `regenerate_or_improve_signal_analysis`
+- `reject` -> `remove_from_current_review_queue`
+- `hold` -> `keep_for_later_review`
+
+## Safety Boundaries
+
+The output safety flags are all false:
+
+- `openai_call_performed`
+- `workflow_dispatched`
+- `publishing_performed`
+- `publish_readiness_enabled`
+- `public_content_generated`
+- `website_pages_written`
+- `social_posting_performed`
+- `notion_mutation_performed`
+- `live_github_api_used`
+- `article_body_scraping_performed`
+- `raw_provider_response_stored`
+- `knowledge_graph_write_performed`
+- `prediction_engine_performed`
+- `confidence_calibration_performed`
+- `correlation_performed`
+- `deployment_performed`
+
+The tool does not require `OPENAI_API_KEY`.
+
+It reads only explicit local JSON inputs and writes only the requested output JSON report.
+
+## Non-Goals
+
+This PR does not:
+
+- call OpenAI
+- require `OPENAI_API_KEY`
+- dispatch workflows
+- change workflows
+- publish content
+- enable publish readiness
+- generate public content
+- generate website pages
+- generate SEO metadata
+- generate social post drafts
+- mutate Notion
+- use live GitHub API collection
+- scrape article bodies
+- require or store raw provider responses
+- write Knowledge Graph records
+- implement Prediction Engine work
+- implement Confidence Calibration
+- implement Multi-source Correlation
+- implement Human Approval Gate
+- implement Publish Readiness Gate
+- deploy
+- merge itself
+
+## How To Run Locally
+
+Run the tool against fixture inputs:
+
+```bash
+python3 scripts/dysonx_owner_review_feedback.py \
+  --brief-json tests/fixtures/owner_review_feedback_v1/internal_intelligence_brief.json \
+  --feedback-input tests/fixtures/owner_review_feedback_v1/owner_feedback_input.json \
+  --output tmp/dysonx_owner_review_feedback.json
+```
+
+The output is a local internal JSON report for audit and reuse.
+
+## Next Recommended Step
+
+After reviewing Owner Review Feedback V1 output, choose the next practical PR based on actual usefulness:
+
+- Brief Field Completeness V1 if the brief is too thin for good Owner decisions.
+- Minimal Internal Frontend Preview V1 if the brief and feedback artifacts are sufficient and the next bottleneck is usability.
+
+Default recommendation: Brief Field Completeness V1 if the Owner cannot judge Signals from the current brief; otherwise Minimal Internal Frontend Preview V1.
+
+Publishing, correlation, confidence calibration, Knowledge Graph writes, Prediction Engine work, and deployment remain blocked unless separately authorized.

--- a/docs/DYSONX_WEEKLY_HANDOFF_2026_06_20.md
+++ b/docs/DYSONX_WEEKLY_HANDOFF_2026_06_20.md
@@ -1,0 +1,72 @@
+# DysonX Weekly Handoff 2026-06-20
+
+## 1. Current Project Status
+
+DysonX is in Phase 2 and has shifted from internal backend quality layering toward a minimal usable Owner intelligence loop.
+
+The current objective is to make the Owner able to read internal intelligence, make decisions, record feedback, and use that feedback to drive the next iteration.
+
+This handoff captures the closing point for the week of 2026-06-20.
+
+## 2. PRs Merged This Phase
+
+- PR #54: V1 OpenAI orchestrator smoke milestone
+- PR #55: Signal Quality Framework V1
+- PR #56: OpenAI Output Quality Audit V1
+- PR #57: SignalQualityScore V1
+- PR #58: Internal Intelligence Brief V1
+- PR #59: Phase 2 Usability Milestone Review
+- PR #60 if this PR becomes PR #60: Owner Review Feedback V1
+
+## 3. Strategic Shift
+
+The strategic shift is from backend intelligence layering to the minimal usable Owner intelligence loop.
+
+DysonX should not keep adding complex intelligence layers before the Owner can use the product. The immediate question is:
+
+```text
+Can the Owner read a brief, make decisions, and feed those decisions back into the next iteration?
+```
+
+## 4. Current Loop
+
+The current loop is:
+
+```text
+SignalQualityScore
+-> Internal Intelligence Brief
+-> Owner Review Feedback
+```
+
+This remains internal only.
+
+## 5. Explicit Current Non-Goals
+
+Current non-goals:
+
+- no complex Confidence Calibration
+- no complex Correlation
+- no Knowledge Graph writes
+- no Prediction Engine work
+- no Publishing
+- no Website generation
+- no Social distribution
+- no Deployment
+
+These areas require separate explicit authorization and reviewed PRs.
+
+## 6. Recommended Next Week
+
+Recommended next week:
+
+- Review Owner Review Feedback V1 output.
+- Decide whether to do Brief Field Completeness V1 first or Minimal Internal Frontend Preview V1 first.
+- Default recommendation: Brief Field Completeness V1 if the brief is too thin for Owner judgment; otherwise Minimal Internal Frontend Preview V1.
+
+The practical next step should be chosen from actual Owner review friction, not abstract backend completeness.
+
+## 7. Safety Boundary
+
+No production deployment was performed.
+
+This week did not authorize publishing, public content generation, website generation, social posting, Knowledge Graph writes, Prediction Engine work, Notion mutation, live GitHub API collection, article scraping, workflow automation, confidence calibration, correlation, human approval gate, publish readiness gate, OpenAI calls, deployment, or production changes.

--- a/scripts/dysonx_owner_review_feedback.py
+++ b/scripts/dysonx_owner_review_feedback.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""DysonX Owner Review Feedback V1.
+
+Captures Owner decisions on Internal Intelligence Brief V1 review items as a
+structured offline JSON report. This script is deterministic. It does not call
+OpenAI, dispatch workflows, publish, write public content, mutate Notion, call
+live GitHub APIs, scrape article bodies, store raw provider responses, write
+Knowledge Graph records, run Prediction Engine work, perform confidence
+calibration or correlation, enable publish readiness, or deploy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+
+FEEDBACK_VERSION = "owner_review_feedback_v1"
+BRIEF_VERSION = "internal_intelligence_brief_v1"
+
+ALLOWED_OWNER_DECISIONS = (
+    "approve_for_future_publish_readiness_review",
+    "request_more_sources",
+    "request_regeneration",
+    "reject",
+    "hold",
+)
+
+ALLOWED_PRIORITIES = ("high", "medium", "low")
+
+RESULTING_STATUS_BY_DECISION = {
+    "approve_for_future_publish_readiness_review": "owner_approved_for_later_publish_readiness_review_only",
+    "request_more_sources": "needs_more_sources",
+    "request_regeneration": "needs_regeneration",
+    "reject": "owner_rejected",
+    "hold": "owner_hold",
+}
+
+NEXT_ACTION_BY_DECISION = {
+    "approve_for_future_publish_readiness_review": "later_publish_readiness_review_required",
+    "request_more_sources": "collect_or_attach_more_sources",
+    "request_regeneration": "regenerate_or_improve_signal_analysis",
+    "reject": "remove_from_current_review_queue",
+    "hold": "keep_for_later_review",
+}
+
+SAFETY_FLAGS = {
+    "openai_call_performed": False,
+    "workflow_dispatched": False,
+    "publishing_performed": False,
+    "publish_readiness_enabled": False,
+    "public_content_generated": False,
+    "website_pages_written": False,
+    "social_posting_performed": False,
+    "notion_mutation_performed": False,
+    "live_github_api_used": False,
+    "article_body_scraping_performed": False,
+    "raw_provider_response_stored": False,
+    "knowledge_graph_write_performed": False,
+    "prediction_engine_performed": False,
+    "confidence_calibration_performed": False,
+    "correlation_performed": False,
+    "deployment_performed": False,
+}
+
+
+class FeedbackInputError(ValueError):
+    """Raised when owner feedback cannot safely produce a report."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json_object(path: str | pathlib.Path, label: str) -> dict[str, Any]:
+    input_path = pathlib.Path(path)
+    try:
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI should fail closed on malformed JSON.
+        raise FeedbackInputError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise FeedbackInputError(f"{label} must be a JSON object")
+    return data
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def require_brief_fields(brief: dict[str, Any]) -> None:
+    required_fields = (
+        "brief_version",
+        "source_score_report",
+        "signals_reviewed",
+        "owner_review_queue",
+        "safety_flags",
+    )
+    missing = [field for field in required_fields if field not in brief]
+    if missing:
+        raise FeedbackInputError(f"Internal Intelligence Brief missing required fields: {', '.join(missing)}")
+    if brief.get("brief_version") != BRIEF_VERSION:
+        raise FeedbackInputError("Brief report must be Internal Intelligence Brief V1")
+    queue = brief.get("owner_review_queue")
+    if not isinstance(queue, list) or not queue or not all(isinstance(item, dict) for item in queue):
+        raise FeedbackInputError("Brief owner_review_queue must be a non-empty list of objects")
+
+
+def require_queue_item_fields(item: dict[str, Any], index: int) -> None:
+    required_fields = ("signal_id", "title", "tier", "action")
+    missing = [field for field in required_fields if field not in item]
+    if missing:
+        raise FeedbackInputError(f"Brief owner_review_queue item {index} missing required fields: {', '.join(missing)}")
+    if not normalize_text(item.get("signal_id")):
+        raise FeedbackInputError(f"Brief owner_review_queue item {index} signal_id is required")
+
+
+def owner_review_items_by_signal_id(brief: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    require_brief_fields(brief)
+    items: dict[str, dict[str, Any]] = {}
+    for index, item in enumerate(brief["owner_review_queue"]):
+        require_queue_item_fields(item, index)
+        signal_id = normalize_text(item.get("signal_id"))
+        if signal_id in items:
+            raise FeedbackInputError(f"Brief owner_review_queue contains duplicate signal_id: {signal_id}")
+        items[signal_id] = item
+    return items
+
+
+def require_feedback_fields(feedback: dict[str, Any], brief: dict[str, Any], brief_path: str | pathlib.Path) -> None:
+    required_fields = (
+        "reviewer",
+        "review_session_id",
+        "reviewed_at",
+        "brief_version",
+        "brief_source",
+        "decisions",
+    )
+    missing = [field for field in required_fields if field not in feedback]
+    if missing:
+        raise FeedbackInputError(f"Owner feedback input missing required fields: {', '.join(missing)}")
+    for field in ("reviewer", "review_session_id", "reviewed_at", "brief_version", "brief_source"):
+        if not normalize_text(feedback.get(field)):
+            raise FeedbackInputError(f"Owner feedback input field {field} is required")
+    if feedback.get("brief_version") != brief.get("brief_version"):
+        raise FeedbackInputError("Owner feedback input brief_version must match the brief JSON brief_version")
+    brief_source = normalize_text(feedback.get("brief_source"))
+    valid_sources = {str(brief_path), pathlib.Path(brief_path).name}
+    if brief_source not in valid_sources and brief_source != normalize_text(brief.get("source_score_report")):
+        raise FeedbackInputError("Owner feedback input brief_source must match or reference the source brief path")
+    decisions = feedback.get("decisions")
+    if not isinstance(decisions, list) or not decisions:
+        raise FeedbackInputError("Owner feedback input decisions must be a non-empty list")
+    if not all(isinstance(decision, dict) for decision in decisions):
+        raise FeedbackInputError("Owner feedback input decisions must be objects")
+
+
+def validate_decision(decision: dict[str, Any], index: int, known_signal_ids: set[str]) -> None:
+    required_fields = (
+        "signal_id",
+        "owner_decision",
+        "owner_comment",
+        "priority",
+        "follow_up_required",
+        "follow_up_note",
+    )
+    missing = [field for field in required_fields if field not in decision]
+    if missing:
+        raise FeedbackInputError(f"Owner feedback decision {index} missing required fields: {', '.join(missing)}")
+    signal_id = normalize_text(decision.get("signal_id"))
+    if signal_id not in known_signal_ids:
+        raise FeedbackInputError(f"Owner feedback decision {index} references unknown signal_id: {signal_id}")
+    owner_decision = normalize_text(decision.get("owner_decision"))
+    if owner_decision not in ALLOWED_OWNER_DECISIONS:
+        raise FeedbackInputError(f"Owner feedback decision {index} has unsupported owner_decision: {owner_decision}")
+    priority = normalize_text(decision.get("priority"))
+    if priority not in ALLOWED_PRIORITIES:
+        raise FeedbackInputError(f"Owner feedback decision {index} has unsupported priority: {priority}")
+    if not isinstance(decision.get("follow_up_required"), bool):
+        raise FeedbackInputError(f"Owner feedback decision {index} follow_up_required must be boolean")
+    if not isinstance(decision.get("owner_comment"), str):
+        raise FeedbackInputError(f"Owner feedback decision {index} owner_comment must be a string")
+    if not isinstance(decision.get("follow_up_note"), str):
+        raise FeedbackInputError(f"Owner feedback decision {index} follow_up_note must be a string")
+
+
+def validate_decisions(feedback: dict[str, Any], known_signal_ids: set[str]) -> None:
+    seen: set[str] = set()
+    for index, decision in enumerate(feedback["decisions"]):
+        validate_decision(decision, index, known_signal_ids)
+        signal_id = normalize_text(decision.get("signal_id"))
+        if signal_id in seen:
+            raise FeedbackInputError(f"Owner feedback input contains duplicate decision for signal_id: {signal_id}")
+        seen.add(signal_id)
+
+
+def build_feedback_record(decision: dict[str, Any], brief_item: dict[str, Any]) -> dict[str, Any]:
+    owner_decision = normalize_text(decision.get("owner_decision"))
+    return {
+        "signal_id": normalize_text(decision.get("signal_id")),
+        "title": normalize_text(brief_item.get("title")),
+        "original_tier": normalize_text(brief_item.get("tier")),
+        "original_recommended_action": normalize_text(brief_item.get("action")),
+        "owner_decision": owner_decision,
+        "owner_comment": decision.get("owner_comment", ""),
+        "priority": normalize_text(decision.get("priority")),
+        "follow_up_required": bool(decision.get("follow_up_required")),
+        "follow_up_note": decision.get("follow_up_note", ""),
+        "resulting_status": RESULTING_STATUS_BY_DECISION[owner_decision],
+        "next_action": NEXT_ACTION_BY_DECISION[owner_decision],
+    }
+
+
+def decision_counts(records: list[dict[str, Any]]) -> dict[str, int]:
+    counts = {decision: 0 for decision in ALLOWED_OWNER_DECISIONS}
+    for record in records:
+        counts[record["owner_decision"]] += 1
+    return counts
+
+
+def recommended_next_actions(records: list[dict[str, Any]]) -> list[str]:
+    decisions = {record["owner_decision"] for record in records}
+    actions: list[str] = []
+    if "request_more_sources" in decisions:
+        actions.append("Prepare better source evidence for Signals marked request_more_sources.")
+    if "request_regeneration" in decisions:
+        actions.append("Improve Signal analysis prompt or regenerate selected Signals offline.")
+    if "hold" in decisions:
+        actions.append("Keep held Signals in the next internal brief or owner review queue.")
+    if "approve_for_future_publish_readiness_review" in decisions:
+        actions.append("Future publish-readiness review is required; do not publish automatically.")
+    if "reject" in decisions:
+        actions.append("Remove rejected Signals from the current owner review queue.")
+    actions.append("Do not publish yet.")
+    return actions
+
+
+def build_feedback_report(
+    brief_json_path: str | pathlib.Path,
+    feedback_input_path: str | pathlib.Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    brief = read_json_object(brief_json_path, "Internal Intelligence Brief V1 report")
+    feedback = read_json_object(feedback_input_path, "Owner feedback input")
+    review_items = owner_review_items_by_signal_id(brief)
+    require_feedback_fields(feedback, brief, brief_json_path)
+    validate_decisions(feedback, set(review_items.keys()))
+    records = [
+        build_feedback_record(decision, review_items[normalize_text(decision.get("signal_id"))])
+        for decision in feedback["decisions"]
+    ]
+    return {
+        "feedback_version": FEEDBACK_VERSION,
+        "created_at": created_at or utc_now(),
+        "reviewer": normalize_text(feedback.get("reviewer")),
+        "review_session_id": normalize_text(feedback.get("review_session_id")),
+        "reviewed_at": normalize_text(feedback.get("reviewed_at")),
+        "source_brief": str(brief_json_path),
+        "brief_version": brief.get("brief_version"),
+        "signals_reviewed": int(brief.get("signals_reviewed", len(review_items))),
+        "decisions_recorded": len(records),
+        "decision_counts": decision_counts(records),
+        "follow_up_required_count": sum(1 for record in records if record["follow_up_required"]),
+        "feedback_records": records,
+        "recommended_next_actions": recommended_next_actions(records),
+        "safety_flags": dict(SAFETY_FLAGS),
+    }
+
+
+def write_json(path: str | pathlib.Path, content: dict[str, Any]) -> None:
+    output_path = pathlib.Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(content, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_feedback(
+    brief_json_path: str | pathlib.Path,
+    feedback_input_path: str | pathlib.Path,
+    output_path: str | pathlib.Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    report = build_feedback_report(brief_json_path, feedback_input_path, created_at=created_at)
+    write_json(output_path, report)
+    return report
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run DysonX Owner Review Feedback V1.")
+    parser.add_argument("--brief-json", required=True, help="Path to Internal Intelligence Brief V1 JSON.")
+    parser.add_argument("--feedback-input", required=True, help="Path to Owner feedback input JSON.")
+    parser.add_argument("--output", required=True, help="Path to write Owner Review Feedback V1 JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        report = run_feedback(args.brief_json, args.feedback_input, args.output)
+    except FeedbackInputError as exc:
+        print(f"[owner-review-feedback] failed: {exc}")
+        return 1
+    print(
+        "[owner-review-feedback] wrote report: "
+        f"{args.output} decisions_recorded={report['decisions_recorded']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/owner_review_feedback_v1/internal_intelligence_brief.json
+++ b/tests/fixtures/owner_review_feedback_v1/internal_intelligence_brief.json
@@ -1,0 +1,184 @@
+{
+  "blocked_count": 2,
+  "blocked_or_low_value": [
+    {
+      "critical_risk_flags": [],
+      "missing_fields": [
+        "related_entities"
+      ],
+      "quality_score_max": 65,
+      "quality_score_total": 31,
+      "quality_tier": "Tier C: Needs Review",
+      "recommended_action": "improve_or_regenerate",
+      "risk_flags": [],
+      "score_explanation": "Score 31/65 (47.69%) maps to Tier C: Needs Review.",
+      "signal_id": "signal_tier_c",
+      "source_url": "https://example.com/tier-c",
+      "title": "Potentially relevant research update"
+    },
+    {
+      "critical_risk_flags": [
+        "generic_summary",
+        "missing_agi_capability",
+        "missing_source_url",
+        "missing_watch_next",
+        "missing_why_it_matters"
+      ],
+      "missing_fields": [
+        "source_url",
+        "why_it_matters",
+        "agi_capability",
+        "related_entities",
+        "watch_next"
+      ],
+      "quality_score_max": 65,
+      "quality_score_total": 9,
+      "quality_tier": "Tier D: Reject / Low-value",
+      "recommended_action": "blocked_by_quality_risk",
+      "risk_flags": [
+        "generic_summary",
+        "missing_agi_capability",
+        "missing_source_url",
+        "missing_watch_next",
+        "missing_why_it_matters"
+      ],
+      "score_explanation": "Score 9/65 (13.85%) is blocked by critical risks.",
+      "signal_id": "signal_tier_d",
+      "source_url": "",
+      "title": "AI changes everything"
+    }
+  ],
+  "brief_version": "internal_intelligence_brief_v1",
+  "correlation_recommended_count": 2,
+  "created_at": "2026-06-20T00:00:00+00:00",
+  "decision_grade_candidates": [
+    {
+      "critical_risk_flags": [],
+      "missing_fields": [],
+      "quality_score_max": 65,
+      "quality_score_total": 57,
+      "quality_tier": "Tier A: Decision-grade Signal",
+      "recommended_action": "candidate_for_human_approval",
+      "risk_flags": [],
+      "score_explanation": "Score 57/65 (87.69%) maps to Tier A: Decision-grade Signal.",
+      "signal_id": "signal_tier_a",
+      "source_url": "https://openai.com/example-agent-update",
+      "title": "OpenAI releases agent infrastructure update"
+    }
+  ],
+  "generated_for": "internal_owner_review",
+  "human_review_count": 4,
+  "overall_recommendation": "Review Tier A candidates internally, but do not publish yet.",
+  "owner_review_queue": [
+    {
+      "action": "candidate_for_human_approval",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_a",
+      "tier": "Tier A: Decision-grade Signal",
+      "title": "OpenAI releases agent infrastructure update"
+    },
+    {
+      "action": "needs_human_review",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_b",
+      "tier": "Tier B: Useful Signal",
+      "title": "Useful model evaluation update"
+    },
+    {
+      "action": "improve_or_regenerate",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_c",
+      "tier": "Tier C: Needs Review",
+      "title": "Potentially relevant research update"
+    },
+    {
+      "action": "blocked_by_quality_risk",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_d",
+      "tier": "Tier D: Reject / Low-value",
+      "title": "AI changes everything"
+    },
+    {
+      "action": "candidate_for_human_approval",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_hold",
+      "tier": "Tier A: Decision-grade Signal",
+      "title": "Held infrastructure signal"
+    }
+  ],
+  "recommended_next_actions": [
+    "Review Tier A and Tier B Signals internally.",
+    "Regenerate or improve Tier C and Tier D Signals.",
+    "Run confidence calibration later.",
+    "Run correlation later.",
+    "Do not publish yet."
+  ],
+  "safety_flags": {
+    "article_body_scraping_performed": false,
+    "deployment_performed": false,
+    "knowledge_graph_write_performed": false,
+    "live_github_api_used": false,
+    "notion_mutation_performed": false,
+    "openai_call_performed": false,
+    "prediction_engine_performed": false,
+    "public_content_generated": false,
+    "publishing_performed": false,
+    "raw_provider_response_stored": false,
+    "social_posting_performed": false,
+    "website_pages_written": false,
+    "workflow_dispatched": false
+  },
+  "signals_reviewed": 5,
+  "source_score_report": "tests/fixtures/internal_intelligence_brief_v1/signal_quality_score.json",
+  "tier_counts": {
+    "Tier A: Decision-grade Signal": 2,
+    "Tier B: Useful Signal": 1,
+    "Tier C: Needs Review": 1,
+    "Tier D: Reject / Low-value": 1
+  },
+  "useful_review_queue": [
+    {
+      "critical_risk_flags": [],
+      "missing_fields": [],
+      "quality_score_max": 65,
+      "quality_score_total": 43,
+      "quality_tier": "Tier B: Useful Signal",
+      "recommended_action": "needs_human_review",
+      "risk_flags": [],
+      "score_explanation": "Score 43/65 (66.15%) maps to Tier B: Useful Signal.",
+      "signal_id": "signal_tier_b",
+      "source_url": "https://example.com/tier-b",
+      "title": "Useful model evaluation update"
+    }
+  ]
+}

--- a/tests/fixtures/owner_review_feedback_v1/owner_feedback_input.json
+++ b/tests/fixtures/owner_review_feedback_v1/owner_feedback_input.json
@@ -1,0 +1,49 @@
+{
+  "brief_source": "internal_intelligence_brief.json",
+  "brief_version": "internal_intelligence_brief_v1",
+  "decisions": [
+    {
+      "follow_up_note": "Check whether source evidence is sufficient before any later gate.",
+      "follow_up_required": true,
+      "owner_comment": "Strong enough to preserve for later review, not publication.",
+      "owner_decision": "approve_for_future_publish_readiness_review",
+      "priority": "high",
+      "signal_id": "signal_tier_a"
+    },
+    {
+      "follow_up_note": "Attach first-party benchmark context.",
+      "follow_up_required": true,
+      "owner_comment": "Useful but needs stronger evidence.",
+      "owner_decision": "request_more_sources",
+      "priority": "medium",
+      "signal_id": "signal_tier_b"
+    },
+    {
+      "follow_up_note": "Regenerate with clearer why_it_matters and entity links.",
+      "follow_up_required": true,
+      "owner_comment": "Too thin for current review.",
+      "owner_decision": "request_regeneration",
+      "priority": "medium",
+      "signal_id": "signal_tier_c"
+    },
+    {
+      "follow_up_note": "",
+      "follow_up_required": false,
+      "owner_comment": "Reject low-value generic output.",
+      "owner_decision": "reject",
+      "priority": "low",
+      "signal_id": "signal_tier_d"
+    },
+    {
+      "follow_up_note": "Revisit after next brief.",
+      "follow_up_required": false,
+      "owner_comment": "",
+      "owner_decision": "hold",
+      "priority": "low",
+      "signal_id": "signal_hold"
+    }
+  ],
+  "review_session_id": "owner-review-2026-06-20",
+  "reviewed_at": "2026-06-20T09:45:00+00:00",
+  "reviewer": "Owner"
+}

--- a/tests/test_dysonx_owner_review_feedback.py
+++ b/tests/test_dysonx_owner_review_feedback.py
@@ -1,0 +1,266 @@
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_owner_review_feedback as feedback
+
+
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "owner_review_feedback_v1"
+BRIEF_FIXTURE = FIXTURE_DIR / "internal_intelligence_brief.json"
+FEEDBACK_FIXTURE = FIXTURE_DIR / "owner_feedback_input.json"
+FIXED_TIME = "2026-06-20T00:00:00+00:00"
+
+
+class DysonXOwnerReviewFeedbackTests(unittest.TestCase):
+    def build_fixture_feedback(self) -> dict:
+        return feedback.build_feedback_report(BRIEF_FIXTURE, FEEDBACK_FIXTURE, created_at=FIXED_TIME)
+
+    def write_json(self, path: pathlib.Path, data: dict) -> None:
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+    def load_feedback_input(self) -> dict:
+        return json.loads(FEEDBACK_FIXTURE.read_text(encoding="utf-8"))
+
+    def test_script_reads_fixtures_and_writes_owner_review_feedback_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = pathlib.Path(tmpdir) / "owner_review_feedback.json"
+
+            exit_code = feedback.main([
+                "--brief-json",
+                str(BRIEF_FIXTURE),
+                "--feedback-input",
+                str(FEEDBACK_FIXTURE),
+                "--output",
+                str(output),
+            ])
+
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(output.exists())
+            report = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(report["feedback_version"], feedback.FEEDBACK_VERSION)
+            self.assertEqual(report["decisions_recorded"], 5)
+
+    def test_output_includes_all_required_top_level_fields(self):
+        report = self.build_fixture_feedback()
+
+        expected = {
+            "feedback_version",
+            "created_at",
+            "reviewer",
+            "review_session_id",
+            "reviewed_at",
+            "source_brief",
+            "brief_version",
+            "signals_reviewed",
+            "decisions_recorded",
+            "decision_counts",
+            "follow_up_required_count",
+            "feedback_records",
+            "recommended_next_actions",
+            "safety_flags",
+        }
+        self.assertEqual(set(report.keys()), expected)
+
+    def test_feedback_records_include_all_required_fields(self):
+        report = self.build_fixture_feedback()
+        expected = {
+            "signal_id",
+            "title",
+            "original_tier",
+            "original_recommended_action",
+            "owner_decision",
+            "owner_comment",
+            "priority",
+            "follow_up_required",
+            "follow_up_note",
+            "resulting_status",
+            "next_action",
+        }
+
+        for record in report["feedback_records"]:
+            self.assertEqual(set(record.keys()), expected)
+
+    def test_allowed_decisions_map_to_correct_resulting_status(self):
+        report = self.build_fixture_feedback()
+        statuses = {record["owner_decision"]: record["resulting_status"] for record in report["feedback_records"]}
+
+        self.assertEqual(
+            statuses,
+            {
+                "approve_for_future_publish_readiness_review": "owner_approved_for_later_publish_readiness_review_only",
+                "request_more_sources": "needs_more_sources",
+                "request_regeneration": "needs_regeneration",
+                "reject": "owner_rejected",
+                "hold": "owner_hold",
+            },
+        )
+
+    def test_allowed_decisions_map_to_correct_next_action(self):
+        report = self.build_fixture_feedback()
+        actions = {record["owner_decision"]: record["next_action"] for record in report["feedback_records"]}
+
+        self.assertEqual(
+            actions,
+            {
+                "approve_for_future_publish_readiness_review": "later_publish_readiness_review_required",
+                "request_more_sources": "collect_or_attach_more_sources",
+                "request_regeneration": "regenerate_or_improve_signal_analysis",
+                "reject": "remove_from_current_review_queue",
+                "hold": "keep_for_later_review",
+            },
+        )
+
+    def test_unknown_decision_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feedback_path = pathlib.Path(tmpdir) / "feedback.json"
+            data = self.load_feedback_input()
+            data["decisions"][0]["owner_decision"] = "publish_now"
+            self.write_json(feedback_path, data)
+
+            with self.assertRaises(feedback.FeedbackInputError):
+                feedback.build_feedback_report(BRIEF_FIXTURE, feedback_path, created_at=FIXED_TIME)
+
+    def test_unknown_priority_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feedback_path = pathlib.Path(tmpdir) / "feedback.json"
+            data = self.load_feedback_input()
+            data["decisions"][0]["priority"] = "urgent"
+            self.write_json(feedback_path, data)
+
+            with self.assertRaises(feedback.FeedbackInputError):
+                feedback.build_feedback_report(BRIEF_FIXTURE, feedback_path, created_at=FIXED_TIME)
+
+    def test_missing_reviewer_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feedback_path = pathlib.Path(tmpdir) / "feedback.json"
+            data = self.load_feedback_input()
+            del data["reviewer"]
+            self.write_json(feedback_path, data)
+
+            with self.assertRaises(feedback.FeedbackInputError):
+                feedback.build_feedback_report(BRIEF_FIXTURE, feedback_path, created_at=FIXED_TIME)
+
+    def test_empty_decisions_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feedback_path = pathlib.Path(tmpdir) / "feedback.json"
+            data = self.load_feedback_input()
+            data["decisions"] = []
+            self.write_json(feedback_path, data)
+
+            with self.assertRaises(feedback.FeedbackInputError):
+                feedback.build_feedback_report(BRIEF_FIXTURE, feedback_path, created_at=FIXED_TIME)
+
+    def test_unknown_signal_id_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            feedback_path = pathlib.Path(tmpdir) / "feedback.json"
+            data = self.load_feedback_input()
+            data["decisions"][0]["signal_id"] = "unknown_signal"
+            self.write_json(feedback_path, data)
+
+            with self.assertRaises(feedback.FeedbackInputError):
+                feedback.build_feedback_report(BRIEF_FIXTURE, feedback_path, created_at=FIXED_TIME)
+
+    def test_approve_for_future_review_does_not_enable_publishing_or_publish_readiness(self):
+        report = self.build_fixture_feedback()
+        approved = [
+            record for record in report["feedback_records"]
+            if record["owner_decision"] == "approve_for_future_publish_readiness_review"
+        ][0]
+
+        self.assertEqual(
+            approved["resulting_status"],
+            "owner_approved_for_later_publish_readiness_review_only",
+        )
+        self.assertEqual(approved["next_action"], "later_publish_readiness_review_required")
+        self.assertFalse(report["safety_flags"]["publish_readiness_enabled"])
+        self.assertFalse(report["safety_flags"]["publishing_performed"])
+        self.assertIn(
+            "Future publish-readiness review is required; do not publish automatically.",
+            report["recommended_next_actions"],
+        )
+
+    def test_safety_flags_are_all_false(self):
+        report = self.build_fixture_feedback()
+
+        expected_flags = {
+            "openai_call_performed",
+            "workflow_dispatched",
+            "publishing_performed",
+            "publish_readiness_enabled",
+            "public_content_generated",
+            "website_pages_written",
+            "social_posting_performed",
+            "notion_mutation_performed",
+            "live_github_api_used",
+            "article_body_scraping_performed",
+            "raw_provider_response_stored",
+            "knowledge_graph_write_performed",
+            "prediction_engine_performed",
+            "confidence_calibration_performed",
+            "correlation_performed",
+            "deployment_performed",
+        }
+        self.assertEqual(set(report["safety_flags"].keys()), expected_flags)
+        for flag_name, value in report["safety_flags"].items():
+            self.assertFalse(value, flag_name)
+
+    def test_no_openai_api_key_is_required(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            report = self.build_fixture_feedback()
+
+        self.assertEqual(report["reviewer"], "Owner")
+
+    def test_malformed_input_exits_nonzero_and_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            malformed = pathlib.Path(tmpdir) / "malformed.json"
+            malformed.write_text("{not json", encoding="utf-8")
+            output = pathlib.Path(tmpdir) / "owner_review_feedback.json"
+
+            exit_code = feedback.main([
+                "--brief-json",
+                str(BRIEF_FIXTURE),
+                "--feedback-input",
+                str(malformed),
+                "--output",
+                str(output),
+            ])
+
+            self.assertEqual(exit_code, 1)
+            self.assertFalse(output.exists())
+
+    def test_no_raw_provider_response_is_required_or_stored(self):
+        report = self.build_fixture_feedback()
+        serialized = json.dumps(report)
+
+        self.assertFalse(report["safety_flags"]["raw_provider_response_stored"])
+        self.assertNotIn('"raw_provider_response":', serialized)
+
+    def test_no_public_content_seo_social_kg_prediction_confidence_correlation_deployment_or_workflow_behavior(self):
+        report = self.build_fixture_feedback()
+        serialized = json.dumps(report).lower()
+
+        for flag_name in (
+            "public_content_generated",
+            "website_pages_written",
+            "social_posting_performed",
+            "knowledge_graph_write_performed",
+            "prediction_engine_performed",
+            "confidence_calibration_performed",
+            "correlation_performed",
+            "deployment_performed",
+            "workflow_dispatched",
+        ):
+            self.assertFalse(report["safety_flags"][flag_name], flag_name)
+        self.assertNotIn("seo_metadata", serialized)
+        self.assertNotIn("social_draft", serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Implement DysonX Owner Review Feedback V1 as an offline deterministic tool for capturing Owner decisions on Internal Intelligence Brief V1 items as structured JSON.

Also add the 2026-06-20 weekly handoff note so Phase 2 can pause and resume with clear context.

## Scope

Files changed:

- docs/DYSONX_OWNER_REVIEW_FEEDBACK_V1.md
- docs/DYSONX_WEEKLY_HANDOFF_2026_06_20.md
- scripts/dysonx_owner_review_feedback.py
- tests/test_dysonx_owner_review_feedback.py
- tests/fixtures/owner_review_feedback_v1/internal_intelligence_brief.json
- tests/fixtures/owner_review_feedback_v1/owner_feedback_input.json

## Implementation

- Adds an offline CLI accepting --brief-json, --feedback-input, and --output.
- Validates Owner feedback input against Internal Intelligence Brief V1 owner_review_queue entries.
- Supports allowed decisions and priorities only.
- Maps decisions to resulting_status and next_action.
- Preserves the boundary that approve_for_future_publish_readiness_review is only later review eligibility, not publication permission.
- Emits all required safety flags as false.

## Weekly handoff

The handoff records the Phase 2 closing point: DysonX has shifted from backend intelligence layering toward the minimal usable Owner intelligence loop: SignalQualityScore -> Internal Intelligence Brief -> Owner Review Feedback.

Recommended next week: review Owner Review Feedback output, then choose Brief Field Completeness V1 if the brief is too thin, otherwise Minimal Internal Frontend Preview V1.

## Governance compliance

- Signal-first preserved.
- English-default / Chinese-switchable posture preserved.
- Notion-source-managed posture preserved.
- LLM-first after collection preserved.
- Quality-gated posture preserved.
- No generic news/RSS/article/SEO drift.
- No production deployment.

## Safety boundaries

This does not call OpenAI, require OPENAI_API_KEY, dispatch workflows, publish content, generate public content, write website pages, generate SEO metadata, create social drafts, mutate Notion, use live GitHub API collection, scrape article bodies, store raw provider responses, write Knowledge Graph records, implement Prediction Engine work, implement confidence calibration, implement correlation, implement human approval gate, implement publish readiness gate, deploy, or modify production.

## Validation

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests, 209 tests OK
- python3 scripts/dysonx_owner_review_feedback.py --brief-json tests/fixtures/owner_review_feedback_v1/internal_intelligence_brief.json --feedback-input tests/fixtures/owner_review_feedback_v1/owner_feedback_input.json --output tmp/dysonx_owner_review_feedback.json
- git diff --check origin/main...HEAD

## Deployment impact

None. No production deployment was performed.

## Known limitations

- This is file-based JSON feedback only; no internal frontend is implemented.
- It does not improve brief field completeness.
- It does not implement confidence calibration, correlation, publish readiness, or publishing.
- Owner feedback is captured as an artifact, not yet persisted in an application database.