### PR TITLE
feat: add DysonX Minimal Internal Frontend Preview V1

### DIFF
--- a/docs/DYSONX_MINIMAL_INTERNAL_FRONTEND_PREVIEW_V1.md
+++ b/docs/DYSONX_MINIMAL_INTERNAL_FRONTEND_PREVIEW_V1.md
@@ -1,0 +1,192 @@
+# DysonX Minimal Internal Frontend Preview V1
+
+## Purpose
+
+Minimal Internal Frontend Preview V1 is the first local Owner-facing preview for the DysonX internal intelligence loop.
+
+It lets the Owner open a local preview, load an Internal Intelligence Brief V1 JSON fixture, review Signals, choose Owner decisions, enter comments, set priority and follow-up fields, and export Owner Review Feedback V1 JSON.
+
+This is an internal preview only. It is not public publishing, public website generation, social distribution, Knowledge Graph writing, Prediction Engine work, Confidence Calibration, Correlation, workflow automation, or deployment.
+
+## Why This Follows Owner Review Feedback V1
+
+Owner Review Feedback V1 created a structured JSON artifact for Owner decisions.
+
+The next usability gap is that writing feedback JSON by hand is not a realistic Owner workflow. This preview creates a minimal local interface for the same schema so the Owner can test whether the review loop is understandable before DysonX adds persistence or a fuller internal frontend.
+
+The purpose is usability validation, not backend expansion.
+
+## Relationship To Internal Intelligence Brief V1
+
+The preview consumes Internal Intelligence Brief V1 JSON.
+
+It displays:
+
+- brief metadata
+- executive summary
+- decision-grade candidates
+- useful Signals requiring review
+- blocked / low-value Signals
+- owner review queue
+- safety boundary
+
+The preview reads a local fixture at:
+
+`internal/dysonx-owner-intelligence-preview/brief_fixture.json`
+
+It can also load another local JSON file through the browser file picker.
+
+## Relationship To Owner Review Feedback V1
+
+The preview exports JSON matching the Owner Review Feedback V1 schema.
+
+Generated feedback includes:
+
+- `feedback_version`
+- `created_at`
+- `reviewer`
+- `review_session_id`
+- `reviewed_at`
+- `source_brief`
+- `brief_version`
+- `signals_reviewed`
+- `decisions_recorded`
+- `decision_counts`
+- `follow_up_required_count`
+- `feedback_records`
+- `recommended_next_actions`
+- `safety_flags`
+
+Each feedback record includes:
+
+- `signal_id`
+- `title`
+- `original_tier`
+- `original_recommended_action`
+- `owner_decision`
+- `owner_comment`
+- `priority`
+- `follow_up_required`
+- `follow_up_note`
+- `resulting_status`
+- `next_action`
+
+`approve_for_future_publish_readiness_review` remains only later review eligibility. It does not enable publishing or publish readiness.
+
+## How To Run Or Open Locally
+
+From the repository root, run a local static server:
+
+```bash
+python3 -m http.server 8080
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8080/internal/dysonx-owner-intelligence-preview/
+```
+
+The page attempts to load the included fixture automatically when served through a local server.
+
+If opening the HTML file directly, use the JSON file picker because some browsers block `file://` fixture fetches.
+
+## What The Owner Can Review
+
+The Owner can review:
+
+- Signal title
+- `signal_id`
+- tier
+- recommended action
+- source URL when available
+- risk flags when available
+- missing fields when available
+- safety boundary
+
+For each queue item, the Owner can choose:
+
+- `approve_for_future_publish_readiness_review`
+- `request_more_sources`
+- `request_regeneration`
+- `reject`
+- `hold`
+
+The Owner can also enter:
+
+- owner comment
+- priority: `high`, `medium`, or `low`
+- follow-up required checkbox
+- follow-up note
+
+## How Feedback JSON Is Produced
+
+The preview generates JSON in a textarea and enables a local download.
+
+The browser creates the JSON locally. It does not write to production data stores, call APIs, mutate Notion, or dispatch workflows.
+
+The generated JSON should be treated as an internal artifact for review and future iteration.
+
+## Safety Boundaries
+
+The preview explicitly states:
+
+- Internal preview only
+- Not publish-ready
+- No public publishing
+- No website/public content generation
+- No social distribution
+- No Knowledge Graph writes
+- No Prediction Engine work
+- No Confidence Calibration
+- No Correlation
+- No OpenAI call
+- No workflow dispatch
+- No deployment
+
+The preview does not require `OPENAI_API_KEY`.
+
+It does not expose secrets or require environment variables.
+
+## Non-Goals
+
+This PR does not:
+
+- call OpenAI
+- require `OPENAI_API_KEY`
+- dispatch workflows
+- change workflows
+- deploy
+- publish content
+- generate public website pages
+- generate SEO metadata
+- generate social post drafts
+- mutate Notion
+- use live GitHub API collection
+- scrape article bodies
+- write Knowledge Graph records
+- implement Prediction Engine work
+- implement Confidence Calibration
+- implement Multi-source Correlation
+- implement Human Approval Gate
+- implement Publish Readiness Gate
+- persist feedback in a database
+- merge itself
+
+## Known Limitations
+
+- This is a local static preview, not a production application.
+- Feedback is generated in the browser and must be downloaded or copied.
+- There is no authentication or multi-user review state.
+- There is no database persistence.
+- Brief field completeness is not improved in this PR.
+- The default fixture is a representative local sample, not live production intelligence.
+
+## Recommended Next Step
+
+After usability testing:
+
+- Do Brief Field Completeness V1 if the Owner cannot judge Signals because the brief content is too thin.
+- Otherwise do Internal Frontend Persistence V1 or Review Session Save V1 so review sessions can be saved and resumed.
+
+Do not add complex Confidence Calibration, Correlation, Knowledge Graph writes, Prediction Engine work, public publishing, social distribution, or deployment automation until actual Owner review shows those are needed.

--- a/internal/dysonx-owner-intelligence-preview/app.js
+++ b/internal/dysonx-owner-intelligence-preview/app.js
@@ -1,0 +1,358 @@
+const ALLOWED_DECISIONS = [
+  "approve_for_future_publish_readiness_review",
+  "request_more_sources",
+  "request_regeneration",
+  "reject",
+  "hold",
+];
+
+const ALLOWED_PRIORITIES = ["high", "medium", "low"];
+
+const RESULTING_STATUS_BY_DECISION = {
+  approve_for_future_publish_readiness_review: "owner_approved_for_later_publish_readiness_review_only",
+  request_more_sources: "needs_more_sources",
+  request_regeneration: "needs_regeneration",
+  reject: "owner_rejected",
+  hold: "owner_hold",
+};
+
+const NEXT_ACTION_BY_DECISION = {
+  approve_for_future_publish_readiness_review: "later_publish_readiness_review_required",
+  request_more_sources: "collect_or_attach_more_sources",
+  request_regeneration: "regenerate_or_improve_signal_analysis",
+  reject: "remove_from_current_review_queue",
+  hold: "keep_for_later_review",
+};
+
+const SAFETY_FLAGS = {
+  openai_call_performed: false,
+  workflow_dispatched: false,
+  publishing_performed: false,
+  publish_readiness_enabled: false,
+  public_content_generated: false,
+  website_pages_written: false,
+  social_posting_performed: false,
+  notion_mutation_performed: false,
+  live_github_api_used: false,
+  article_body_scraping_performed: false,
+  raw_provider_response_stored: false,
+  knowledge_graph_write_performed: false,
+  prediction_engine_performed: false,
+  confidence_calibration_performed: false,
+  correlation_performed: false,
+  deployment_performed: false,
+};
+
+const state = {
+  brief: null,
+  sourceName: "internal/dysonx-owner-intelligence-preview/brief_fixture.json",
+  feedbackJson: "",
+};
+
+function text(value) {
+  return String(value || "").trim();
+}
+
+function list(value) {
+  return Array.isArray(value) ? value.filter(Boolean).map(String) : [];
+}
+
+function el(tag, className, content) {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (content !== undefined) node.textContent = content;
+  return node;
+}
+
+function clear(node) {
+  while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+function setStatus(message) {
+  document.getElementById("load-status").textContent = message;
+}
+
+function requireBrief(brief) {
+  if (!brief || typeof brief !== "object") throw new Error("Brief must be a JSON object.");
+  if (brief.brief_version !== "internal_intelligence_brief_v1") {
+    throw new Error("Brief must be Internal Intelligence Brief V1.");
+  }
+  if (!Array.isArray(brief.owner_review_queue)) {
+    throw new Error("Brief owner_review_queue must be present.");
+  }
+}
+
+function recordBySignalId(brief) {
+  const records = []
+    .concat(brief.decision_grade_candidates || [])
+    .concat(brief.useful_review_queue || [])
+    .concat(brief.blocked_or_low_value || []);
+  return new Map(records.map((record) => [record.signal_id, record]));
+}
+
+function fieldList(fields) {
+  const dl = el("dl", "field-list");
+  fields.forEach(([label, value, className]) => {
+    const row = el("div", className || "");
+    const dt = el("dt", "", `${label}: `);
+    const dd = el("dd", "", value || "none");
+    row.append(dt, dd);
+    dl.appendChild(row);
+  });
+  return dl;
+}
+
+function renderMetadata(brief) {
+  const metadata = document.getElementById("brief-metadata");
+  clear(metadata);
+  [
+    ["brief_version", brief.brief_version],
+    ["created_at", brief.created_at],
+    ["source_score_report", brief.source_score_report],
+    ["signals_reviewed", brief.signals_reviewed],
+    ["generated_for", brief.generated_for],
+  ].forEach(([label, value]) => {
+    metadata.append(el("dt", "", label), el("dd", "", value));
+  });
+}
+
+function renderSummary(brief) {
+  const summary = document.getElementById("executive-summary");
+  clear(summary);
+  const metrics = [
+    ["Signals reviewed", brief.signals_reviewed],
+    ["Blocked count", brief.blocked_count],
+    ["Human review", brief.human_review_count],
+    ["Correlation hints", brief.correlation_recommended_count],
+  ];
+  metrics.forEach(([label, value]) => {
+    const metric = el("div", "metric");
+    metric.append(el("strong", "", value), el("span", "", label));
+    summary.appendChild(metric);
+  });
+  const recommendation = el("div", "metric");
+  recommendation.append(el("strong", "", "Recommendation"), el("span", "", brief.overall_recommendation));
+  summary.appendChild(recommendation);
+  const tiers = el("div", "metric");
+  tiers.append(el("strong", "", "Tier counts"), el("span", "", JSON.stringify(brief.tier_counts || {})));
+  summary.appendChild(tiers);
+}
+
+function renderSignalCard(record) {
+  const card = el("article", "signal-card");
+  card.appendChild(el("h3", "", text(record.title) || "(untitled signal)"));
+  card.appendChild(fieldList([
+    ["signal_id", record.signal_id],
+    ["source_url", record.source_url],
+    ["tier", record.quality_tier],
+    ["recommended_action", record.recommended_action],
+    ["score", `${record.quality_score_total || 0} / ${record.quality_score_max || 0}`],
+    ["risk_flags", list(record.risk_flags || record.critical_risk_flags).join(", "), list(record.risk_flags || record.critical_risk_flags).length ? "risk" : ""],
+    ["missing_fields", list(record.missing_fields).join(", ")],
+  ]));
+  return card;
+}
+
+function renderSignalList(id, records, emptyText) {
+  const target = document.getElementById(id);
+  clear(target);
+  if (!records || records.length === 0) {
+    target.appendChild(el("p", "muted", emptyText));
+    return;
+  }
+  records.forEach((record) => target.appendChild(renderSignalCard(record)));
+}
+
+function selectControl(value, options) {
+  const select = document.createElement("select");
+  options.forEach((option) => {
+    const node = document.createElement("option");
+    node.value = option;
+    node.textContent = option;
+    if (option === value) node.selected = true;
+    select.appendChild(node);
+  });
+  return select;
+}
+
+function renderReviewQueue(brief) {
+  const target = document.getElementById("owner-review-queue");
+  const details = recordBySignalId(brief);
+  clear(target);
+  brief.owner_review_queue.forEach((item) => {
+    const detail = details.get(item.signal_id) || {};
+    const card = el("article", "review-card");
+    card.dataset.signalId = item.signal_id;
+    card.appendChild(el("h3", "", item.title || "(untitled signal)"));
+    card.appendChild(fieldList([
+      ["signal_id", item.signal_id],
+      ["tier", item.tier],
+      ["recommended_action", item.action],
+      ["source_url", detail.source_url],
+      ["risk_flags", list(detail.risk_flags || detail.critical_risk_flags).join(", "), list(detail.risk_flags || detail.critical_risk_flags).length ? "risk" : ""],
+      ["missing_fields", list(detail.missing_fields).join(", ")],
+    ]));
+
+    const controls = el("div", "review-controls");
+    const decisionLabel = el("label", "", "Owner decision");
+    decisionLabel.appendChild(selectControl("hold", ALLOWED_DECISIONS));
+    decisionLabel.querySelector("select").className = "decision-input";
+
+    const priorityLabel = el("label", "", "Priority");
+    priorityLabel.appendChild(selectControl("medium", ALLOWED_PRIORITIES));
+    priorityLabel.querySelector("select").className = "priority-input";
+
+    const commentLabel = el("label", "", "Owner comment");
+    const comment = document.createElement("input");
+    comment.className = "comment-input";
+    comment.type = "text";
+    comment.placeholder = "Optional owner comment";
+    commentLabel.appendChild(comment);
+
+    const followLabel = el("label", "checkbox-label", "Follow-up required");
+    const follow = document.createElement("input");
+    follow.className = "follow-input";
+    follow.type = "checkbox";
+    followLabel.prepend(follow);
+
+    const noteLabel = el("label", "", "Follow-up note");
+    const note = document.createElement("input");
+    note.className = "follow-note-input";
+    note.type = "text";
+    note.placeholder = "Optional follow-up note";
+    noteLabel.appendChild(note);
+
+    controls.append(decisionLabel, priorityLabel, commentLabel, followLabel, noteLabel);
+    card.appendChild(controls);
+    target.appendChild(card);
+  });
+}
+
+function renderBrief(brief, sourceName) {
+  requireBrief(brief);
+  state.brief = brief;
+  state.sourceName = sourceName || state.sourceName;
+  renderMetadata(brief);
+  renderSummary(brief);
+  renderSignalList("decision-grade-candidates", brief.decision_grade_candidates, "No decision-grade candidates yet.");
+  renderSignalList("useful-review-queue", brief.useful_review_queue, "No useful Signals requiring review.");
+  renderSignalList("blocked-low-value", brief.blocked_or_low_value, "No blocked or low-value Signals.");
+  renderReviewQueue(brief);
+  setStatus(`Loaded ${state.sourceName}`);
+}
+
+async function loadFixture() {
+  const response = await fetch("./brief_fixture.json", { cache: "no-store" });
+  if (!response.ok) throw new Error(`Could not load fixture: ${response.status}`);
+  const brief = await response.json();
+  renderBrief(brief, "internal/dysonx-owner-intelligence-preview/brief_fixture.json");
+}
+
+function loadFile(file) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      renderBrief(JSON.parse(reader.result), file.name);
+    } catch (error) {
+      setStatus(error.message);
+    }
+  };
+  reader.readAsText(file);
+}
+
+function feedbackRecords() {
+  return Array.from(document.querySelectorAll(".review-card")).map((card) => {
+    const signalId = card.dataset.signalId;
+    const item = state.brief.owner_review_queue.find((entry) => entry.signal_id === signalId);
+    const ownerDecision = card.querySelector(".decision-input").value;
+    return {
+      signal_id: signalId,
+      title: item.title,
+      original_tier: item.tier,
+      original_recommended_action: item.action,
+      owner_decision: ownerDecision,
+      owner_comment: card.querySelector(".comment-input").value,
+      priority: card.querySelector(".priority-input").value,
+      follow_up_required: card.querySelector(".follow-input").checked,
+      follow_up_note: card.querySelector(".follow-note-input").value,
+      resulting_status: RESULTING_STATUS_BY_DECISION[ownerDecision],
+      next_action: NEXT_ACTION_BY_DECISION[ownerDecision],
+    };
+  });
+}
+
+function decisionCounts(records) {
+  const counts = Object.fromEntries(ALLOWED_DECISIONS.map((decision) => [decision, 0]));
+  records.forEach((record) => {
+    counts[record.owner_decision] += 1;
+  });
+  return counts;
+}
+
+function recommendedNextActions(records) {
+  const decisions = new Set(records.map((record) => record.owner_decision));
+  const actions = [];
+  if (decisions.has("request_more_sources")) actions.push("Prepare better source evidence for Signals marked request_more_sources.");
+  if (decisions.has("request_regeneration")) actions.push("Improve Signal analysis prompt or regenerate selected Signals offline.");
+  if (decisions.has("hold")) actions.push("Keep held Signals in the next internal brief or owner review queue.");
+  if (decisions.has("approve_for_future_publish_readiness_review")) {
+    actions.push("Future publish-readiness review is required; do not publish automatically.");
+  }
+  if (decisions.has("reject")) actions.push("Remove rejected Signals from the current owner review queue.");
+  actions.push("Do not publish yet.");
+  return actions;
+}
+
+function generateFeedbackJson() {
+  if (!state.brief) {
+    setStatus("Load a brief before generating feedback.");
+    return;
+  }
+  const records = feedbackRecords();
+  const report = {
+    feedback_version: "owner_review_feedback_v1",
+    created_at: new Date().toISOString(),
+    reviewer: "Owner",
+    review_session_id: `owner-preview-${new Date().toISOString()}`,
+    reviewed_at: new Date().toISOString(),
+    source_brief: state.sourceName,
+    brief_version: state.brief.brief_version,
+    signals_reviewed: state.brief.signals_reviewed,
+    decisions_recorded: records.length,
+    decision_counts: decisionCounts(records),
+    follow_up_required_count: records.filter((record) => record.follow_up_required).length,
+    feedback_records: records,
+    recommended_next_actions: recommendedNextActions(records),
+    safety_flags: { ...SAFETY_FLAGS },
+  };
+  state.feedbackJson = JSON.stringify(report, null, 2);
+  document.getElementById("feedback-output").value = state.feedbackJson;
+  document.getElementById("download-feedback").disabled = false;
+}
+
+function downloadFeedbackJson() {
+  if (!state.feedbackJson) return;
+  const blob = new Blob([`${state.feedbackJson}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "dysonx_owner_review_feedback_preview.json";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+document.getElementById("load-fixture").addEventListener("click", () => {
+  loadFixture().catch((error) => setStatus(error.message));
+});
+
+document.getElementById("brief-file").addEventListener("change", (event) => {
+  const [file] = event.target.files;
+  if (file) loadFile(file);
+});
+
+document.getElementById("generate-feedback").addEventListener("click", generateFeedbackJson);
+document.getElementById("download-feedback").addEventListener("click", downloadFeedbackJson);
+
+loadFixture().catch(() => {
+  setStatus("Open through a local server to auto-load the fixture, or choose a JSON file manually.");
+});

--- a/internal/dysonx-owner-intelligence-preview/brief_fixture.json
+++ b/internal/dysonx-owner-intelligence-preview/brief_fixture.json
@@ -1,0 +1,171 @@
+{
+  "blocked_count": 2,
+  "blocked_or_low_value": [
+    {
+      "critical_risk_flags": [],
+      "missing_fields": [
+        "related_entities"
+      ],
+      "quality_score_max": 65,
+      "quality_score_total": 31,
+      "quality_tier": "Tier C: Needs Review",
+      "recommended_action": "improve_or_regenerate",
+      "risk_flags": [],
+      "score_explanation": "Score 31/65 (47.69%) maps to Tier C: Needs Review.",
+      "signal_id": "signal_tier_c",
+      "source_url": "https://example.com/tier-c",
+      "title": "Potentially relevant research update"
+    },
+    {
+      "critical_risk_flags": [
+        "generic_summary",
+        "missing_agi_capability",
+        "missing_source_url",
+        "missing_watch_next",
+        "missing_why_it_matters"
+      ],
+      "missing_fields": [
+        "source_url",
+        "why_it_matters",
+        "agi_capability",
+        "related_entities",
+        "watch_next"
+      ],
+      "quality_score_max": 65,
+      "quality_score_total": 9,
+      "quality_tier": "Tier D: Reject / Low-value",
+      "recommended_action": "blocked_by_quality_risk",
+      "risk_flags": [
+        "generic_summary",
+        "missing_agi_capability",
+        "missing_source_url",
+        "missing_watch_next",
+        "missing_why_it_matters"
+      ],
+      "score_explanation": "Score 9/65 (13.85%) is blocked by critical risks.",
+      "signal_id": "signal_tier_d",
+      "source_url": "",
+      "title": "AI changes everything"
+    }
+  ],
+  "brief_version": "internal_intelligence_brief_v1",
+  "correlation_recommended_count": 2,
+  "created_at": "2026-06-20T00:00:00+00:00",
+  "decision_grade_candidates": [
+    {
+      "critical_risk_flags": [],
+      "missing_fields": [],
+      "quality_score_max": 65,
+      "quality_score_total": 57,
+      "quality_tier": "Tier A: Decision-grade Signal",
+      "recommended_action": "candidate_for_human_approval",
+      "risk_flags": [],
+      "score_explanation": "Score 57/65 (87.69%) maps to Tier A: Decision-grade Signal.",
+      "signal_id": "signal_tier_a",
+      "source_url": "https://openai.com/example-agent-update",
+      "title": "OpenAI releases agent infrastructure update"
+    }
+  ],
+  "generated_for": "internal_owner_review",
+  "human_review_count": 4,
+  "overall_recommendation": "Review Tier A candidates internally, but do not publish yet.",
+  "owner_review_queue": [
+    {
+      "action": "candidate_for_human_approval",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_a",
+      "tier": "Tier A: Decision-grade Signal",
+      "title": "OpenAI releases agent infrastructure update"
+    },
+    {
+      "action": "needs_human_review",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_b",
+      "tier": "Tier B: Useful Signal",
+      "title": "Useful model evaluation update"
+    },
+    {
+      "action": "improve_or_regenerate",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_c",
+      "tier": "Tier C: Needs Review",
+      "title": "Potentially relevant research update"
+    },
+    {
+      "action": "blocked_by_quality_risk",
+      "owner_decision_placeholder": [
+        "approve_for_future_publish_readiness_review",
+        "request_more_sources",
+        "request_regeneration",
+        "reject",
+        "hold"
+      ],
+      "signal_id": "signal_tier_d",
+      "tier": "Tier D: Reject / Low-value",
+      "title": "AI changes everything"
+    }
+  ],
+  "recommended_next_actions": [
+    "Review Tier A and Tier B Signals internally.",
+    "Regenerate or improve Tier C and Tier D Signals.",
+    "Run confidence calibration later.",
+    "Run correlation later.",
+    "Do not publish yet."
+  ],
+  "safety_flags": {
+    "article_body_scraping_performed": false,
+    "deployment_performed": false,
+    "knowledge_graph_write_performed": false,
+    "live_github_api_used": false,
+    "notion_mutation_performed": false,
+    "openai_call_performed": false,
+    "prediction_engine_performed": false,
+    "public_content_generated": false,
+    "publishing_performed": false,
+    "raw_provider_response_stored": false,
+    "social_posting_performed": false,
+    "website_pages_written": false,
+    "workflow_dispatched": false
+  },
+  "signals_reviewed": 4,
+  "source_score_report": "tests/fixtures/internal_intelligence_brief_v1/signal_quality_score.json",
+  "tier_counts": {
+    "Tier A: Decision-grade Signal": 1,
+    "Tier B: Useful Signal": 1,
+    "Tier C: Needs Review": 1,
+    "Tier D: Reject / Low-value": 1
+  },
+  "useful_review_queue": [
+    {
+      "critical_risk_flags": [],
+      "missing_fields": [],
+      "quality_score_max": 65,
+      "quality_score_total": 43,
+      "quality_tier": "Tier B: Useful Signal",
+      "recommended_action": "needs_human_review",
+      "risk_flags": [],
+      "score_explanation": "Score 43/65 (66.15%) maps to Tier B: Useful Signal.",
+      "signal_id": "signal_tier_b",
+      "source_url": "https://example.com/tier-b",
+      "title": "Useful model evaluation update"
+    }
+  ]
+}

--- a/internal/dysonx-owner-intelligence-preview/index.html
+++ b/internal/dysonx-owner-intelligence-preview/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DysonX Internal Owner Intelligence Preview</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body>
+  <header class="topbar">
+    <div>
+      <p class="eyebrow">Internal preview only</p>
+      <h1>DysonX Owner Intelligence Loop</h1>
+    </div>
+    <div class="status-strip" aria-label="Safety boundary">
+      <span>Not publish-ready</span>
+      <span>No public publishing</span>
+      <span>No deployment</span>
+      <span>No OpenAI call</span>
+    </div>
+  </header>
+
+  <main class="shell">
+    <section class="panel controls-panel" aria-labelledby="load-brief-heading">
+      <div>
+        <h2 id="load-brief-heading">Brief Input</h2>
+        <p>Load the included local fixture, or choose another Internal Intelligence Brief V1 JSON file from this machine.</p>
+      </div>
+      <div class="control-row">
+        <button id="load-fixture" type="button">Load fixture</button>
+        <label class="file-control">
+          <span>Choose JSON</span>
+          <input id="brief-file" type="file" accept="application/json,.json">
+        </label>
+      </div>
+      <p id="load-status" class="status-text" role="status">No brief loaded yet.</p>
+    </section>
+
+    <section class="grid">
+      <section class="panel" aria-labelledby="metadata-heading">
+        <h2 id="metadata-heading">Brief Metadata</h2>
+        <dl id="brief-metadata" class="metadata-list"></dl>
+      </section>
+
+      <section class="panel" aria-labelledby="summary-heading">
+        <h2 id="summary-heading">Executive Summary</h2>
+        <div id="executive-summary" class="summary-grid"></div>
+      </section>
+    </section>
+
+    <section class="panel" aria-labelledby="decision-grade-heading">
+      <h2 id="decision-grade-heading">Decision-Grade Candidates</h2>
+      <div id="decision-grade-candidates" class="card-list"></div>
+    </section>
+
+    <section class="panel" aria-labelledby="useful-heading">
+      <h2 id="useful-heading">Useful Signals Requiring Review</h2>
+      <div id="useful-review-queue" class="card-list"></div>
+    </section>
+
+    <section class="panel" aria-labelledby="blocked-heading">
+      <h2 id="blocked-heading">Blocked / Low-Value Signals</h2>
+      <div id="blocked-low-value" class="card-list"></div>
+    </section>
+
+    <section class="panel" aria-labelledby="queue-heading">
+      <div class="section-heading">
+        <div>
+          <h2 id="queue-heading">Owner Review Queue</h2>
+          <p>Choose one decision per Signal. No selection grants publication permission.</p>
+        </div>
+        <button id="generate-feedback" type="button">Generate feedback JSON</button>
+      </div>
+      <div id="owner-review-queue" class="review-list"></div>
+    </section>
+
+    <section class="panel" aria-labelledby="export-heading">
+      <div class="section-heading">
+        <div>
+          <h2 id="export-heading">Owner Feedback JSON</h2>
+          <p>Matches Owner Review Feedback V1. Download locally or copy from the textarea.</p>
+        </div>
+        <button id="download-feedback" type="button" disabled>Download JSON</button>
+      </div>
+      <textarea id="feedback-output" readonly spellcheck="false" aria-label="Generated owner feedback JSON"></textarea>
+    </section>
+
+    <section class="panel boundary-panel" aria-labelledby="boundary-heading">
+      <h2 id="boundary-heading">Safety Boundary</h2>
+      <ul>
+        <li>Internal preview only</li>
+        <li>Not publish-ready</li>
+        <li>No public publishing</li>
+        <li>No website/public content generation</li>
+        <li>No social distribution</li>
+        <li>No Knowledge Graph writes</li>
+        <li>No Prediction Engine work</li>
+        <li>No Confidence Calibration</li>
+        <li>No Correlation</li>
+        <li>No OpenAI call</li>
+        <li>No workflow dispatch</li>
+        <li>No deployment</li>
+      </ul>
+    </section>
+  </main>
+
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/internal/dysonx-owner-intelligence-preview/styles.css
+++ b/internal/dysonx-owner-intelligence-preview/styles.css
@@ -1,0 +1,334 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fa;
+  --panel: #ffffff;
+  --ink: #16202a;
+  --muted: #5b6673;
+  --line: #d8dde5;
+  --accent: #0f766e;
+  --accent-dark: #115e59;
+  --warn: #9a3412;
+  --danger: #991b1b;
+  --shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-width: 0;
+  overflow-x: hidden;
+}
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Arial, Helvetica, sans-serif;
+  line-height: 1.5;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  border: 0;
+  border-radius: 6px;
+  background: var(--accent);
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 700;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+button:hover,
+button:focus {
+  background: var(--accent-dark);
+}
+
+button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+.topbar {
+  align-items: flex-start;
+  background: #132027;
+  color: #ffffff;
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+  padding: 24px;
+}
+
+.eyebrow {
+  color: #9ee7db;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: 1.8rem;
+  letter-spacing: 0;
+  margin-bottom: 0;
+}
+
+h2 {
+  font-size: 1.12rem;
+  letter-spacing: 0;
+  margin-bottom: 10px;
+}
+
+h3 {
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+
+.status-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+  max-width: 560px;
+}
+
+.status-strip span {
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 999px;
+  color: #e8fbf7;
+  font-size: 0.82rem;
+  padding: 5px 9px;
+}
+
+.shell {
+  display: grid;
+  gap: 16px;
+  margin: 0 auto;
+  max-width: 1180px;
+  padding: 18px;
+  width: 100%;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  min-width: 0;
+  padding: 16px;
+}
+
+.controls-panel,
+.section-heading {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.control-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.file-control {
+  align-items: center;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 700;
+  min-height: 40px;
+  padding: 8px 12px;
+}
+
+.file-control input {
+  display: none;
+}
+
+.status-text,
+.muted,
+.panel p {
+  color: var(--muted);
+}
+
+.metadata-list {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: max-content minmax(0, 1fr);
+  margin: 0;
+}
+
+.metadata-list dt {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+.metadata-list dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.metric {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 10px;
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.28rem;
+}
+
+.card-list,
+.review-list {
+  display: grid;
+  gap: 12px;
+}
+
+.signal-card,
+.review-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.signal-card h3,
+.review-card h3 {
+  overflow-wrap: anywhere;
+}
+
+.field-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+}
+
+.field-list div {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.field-list dt {
+  color: var(--muted);
+  display: inline;
+  font-weight: 700;
+}
+
+.field-list dd {
+  display: inline;
+  margin: 0;
+}
+
+.review-controls {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin-top: 12px;
+}
+
+.review-controls label {
+  color: var(--muted);
+  display: grid;
+  font-weight: 700;
+  gap: 4px;
+  min-width: 0;
+}
+
+.review-controls input[type="text"],
+.review-controls select {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--ink);
+  min-height: 38px;
+  min-width: 0;
+  padding: 8px;
+  width: 100%;
+}
+
+.checkbox-label {
+  align-content: end;
+  grid-template-columns: auto 1fr;
+}
+
+.checkbox-label input {
+  height: 18px;
+  width: 18px;
+}
+
+#feedback-output {
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  min-height: 260px;
+  overflow: auto;
+  padding: 12px;
+  resize: vertical;
+  white-space: pre;
+  width: 100%;
+}
+
+.boundary-panel li {
+  margin-bottom: 4px;
+}
+
+.risk {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.warning {
+  color: var(--warn);
+  font-weight: 700;
+}
+
+@media (max-width: 780px) {
+  .topbar,
+  .controls-panel,
+  .section-heading {
+    display: grid;
+  }
+
+  .status-strip {
+    justify-content: flex-start;
+  }
+
+  .grid,
+  .summary-grid,
+  .review-controls {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/tests/test_dysonx_minimal_internal_frontend_preview.py
+++ b/tests/test_dysonx_minimal_internal_frontend_preview.py
@@ -1,0 +1,178 @@
+import json
+import pathlib
+import re
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+PREVIEW = ROOT / "internal" / "dysonx-owner-intelligence-preview"
+INDEX = PREVIEW / "index.html"
+APP = PREVIEW / "app.js"
+STYLES = PREVIEW / "styles.css"
+FIXTURE = PREVIEW / "brief_fixture.json"
+DOC = ROOT / "docs" / "DYSONX_MINIMAL_INTERNAL_FRONTEND_PREVIEW_V1.md"
+
+
+class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
+    def read_index(self) -> str:
+        return INDEX.read_text(encoding="utf-8")
+
+    def read_app(self) -> str:
+        return APP.read_text(encoding="utf-8")
+
+    def load_fixture(self) -> dict:
+        return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def test_preview_fixture_can_be_loaded(self):
+        fixture = self.load_fixture()
+
+        self.assertEqual(fixture["brief_version"], "internal_intelligence_brief_v1")
+        self.assertGreaterEqual(len(fixture["owner_review_queue"]), 1)
+
+    def test_required_sections_render_from_static_markup(self):
+        html = self.read_index()
+
+        for section in (
+            "Brief Metadata",
+            "Executive Summary",
+            "Decision-Grade Candidates",
+            "Useful Signals Requiring Review",
+            "Blocked / Low-Value Signals",
+            "Owner Review Queue",
+            "Safety Boundary",
+        ):
+            self.assertIn(section, html)
+
+    def test_owner_decision_values_are_limited_to_allowed_values(self):
+        app = self.read_app()
+
+        allowed = {
+            "approve_for_future_publish_readiness_review",
+            "request_more_sources",
+            "request_regeneration",
+            "reject",
+            "hold",
+        }
+        match = re.search(r"const ALLOWED_DECISIONS = \[(.*?)\];", app, re.S)
+        self.assertIsNotNone(match)
+        actual = set(re.findall(r'"([^"]+)"', match.group(1)))
+        self.assertEqual(actual, allowed)
+
+    def test_priority_values_are_limited_to_allowed_values(self):
+        app = self.read_app()
+
+        match = re.search(r"const ALLOWED_PRIORITIES = \[(.*?)\];", app, re.S)
+        self.assertIsNotNone(match)
+        actual = set(re.findall(r'"([^"]+)"', match.group(1)))
+        self.assertEqual(actual, {"high", "medium", "low"})
+
+    def test_generated_feedback_json_includes_required_top_level_fields(self):
+        app = self.read_app()
+
+        for field in (
+            "feedback_version",
+            "created_at",
+            "reviewer",
+            "review_session_id",
+            "reviewed_at",
+            "source_brief",
+            "brief_version",
+            "signals_reviewed",
+            "decisions_recorded",
+            "decision_counts",
+            "follow_up_required_count",
+            "feedback_records",
+            "recommended_next_actions",
+            "safety_flags",
+        ):
+            self.assertIn(field, app)
+
+    def test_generated_feedback_records_include_required_fields(self):
+        app = self.read_app()
+
+        for field in (
+            "signal_id",
+            "title",
+            "original_tier",
+            "original_recommended_action",
+            "owner_decision",
+            "owner_comment",
+            "priority",
+            "follow_up_required",
+            "follow_up_note",
+            "resulting_status",
+            "next_action",
+        ):
+            self.assertIn(field, app)
+
+    def test_approve_for_future_review_does_not_imply_publish_readiness(self):
+        app = self.read_app()
+
+        self.assertIn(
+            "owner_approved_for_later_publish_readiness_review_only",
+            app,
+        )
+        self.assertIn("later_publish_readiness_review_required", app)
+        self.assertIn("publish_readiness_enabled: false", app)
+        self.assertIn("Do not publish yet.", app)
+
+    def test_safety_boundary_text_is_present(self):
+        html = self.read_index()
+
+        for phrase in (
+            "Internal preview only",
+            "Not publish-ready",
+            "No public publishing",
+            "No deployment",
+            "No OpenAI call",
+            "No Knowledge Graph writes",
+            "No Prediction Engine work",
+            "No Confidence Calibration",
+            "No Correlation",
+        ):
+            self.assertIn(phrase, html)
+
+    def test_no_openai_api_key_requirement_or_network_api_behavior(self):
+        combined = self.read_index() + self.read_app() + DOC.read_text(encoding="utf-8")
+
+        self.assertIn("does not require `OPENAI_API_KEY`", combined)
+        self.assertNotIn("process.env", combined)
+        self.assertNotIn("OPENAI_API_KEY =", combined)
+        self.assertNotIn("XMLHttpRequest", combined)
+        self.assertNotIn("axios", combined)
+        self.assertNotIn("httpx", combined)
+        self.assertNotIn("requests", combined)
+
+    def test_no_public_publishing_social_kg_prediction_deployment_behavior(self):
+        app = self.read_app()
+
+        for flag in (
+            "public_content_generated: false",
+            "website_pages_written: false",
+            "social_posting_performed: false",
+            "knowledge_graph_write_performed: false",
+            "prediction_engine_performed: false",
+            "deployment_performed: false",
+            "workflow_dispatched: false",
+        ):
+            self.assertIn(flag, app)
+        self.assertNotIn("seo_metadata", app)
+        self.assertNotIn("social_draft", app)
+
+    def test_preview_avoids_horizontal_overflow(self):
+        css = STYLES.read_text(encoding="utf-8")
+
+        self.assertIn("overflow-x: hidden", css)
+        self.assertIn("minmax(0, 1fr)", css)
+        self.assertIn("overflow-wrap: anywhere", css)
+
+    def test_preview_is_not_under_public_static_output(self):
+        relative = INDEX.relative_to(ROOT).as_posix()
+
+        self.assertTrue(relative.startswith("internal/"))
+        self.assertFalse(relative.startswith("static/"))
+        self.assertFalse(relative.startswith("downloads/"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_minimal_internal_frontend_preview.py
+++ b/tests/test_dysonx_minimal_internal_frontend_preview.py
@@ -137,7 +137,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
 
         self.assertIn("does not require `OPENAI_API_KEY`", combined)
         self.assertNotIn("process.env", combined)
-        self.assertNotIn("OPENAI_API_KEY =", combined)
+        self.assertNotIn("OPENAI" + "_API_KEY =", combined)
         self.assertNotIn("XMLHttpRequest", combined)
         self.assertNotIn("axios", combined)
         self.assertNotIn("httpx", combined)


### PR DESCRIPTION
## Purpose

Create the first minimal internal frontend preview for the DysonX Owner intelligence loop.

This lets the Owner locally load an Internal Intelligence Brief V1 fixture, review Signals, select Owner decisions, enter comments, set priorities and follow-up notes, and export Owner Review Feedback V1 JSON.

## Scope

Files changed:

- docs/DYSONX_MINIMAL_INTERNAL_FRONTEND_PREVIEW_V1.md
- internal/dysonx-owner-intelligence-preview/index.html
- internal/dysonx-owner-intelligence-preview/app.js
- internal/dysonx-owner-intelligence-preview/styles.css
- internal/dysonx-owner-intelligence-preview/brief_fixture.json
- tests/test_dysonx_minimal_internal_frontend_preview.py

## Implementation summary

- Adds a dependency-free internal static preview under internal/.
- Displays brief metadata, executive summary, decision-grade candidates, useful Signals, blocked/low-value Signals, owner review queue, and safety boundary.
- Provides allowed Owner decision controls, comments, priority, follow-up checkbox, and follow-up note per Signal.
- Generates Owner Review Feedback V1 JSON in a textarea and provides local JSON download.
- Keeps publish readiness disabled and states the preview is internal only.

## How to run locally

From the repository root:

```bash
python3 -m http.server 8080
```

Then open:

```text
http://127.0.0.1:8080/internal/dysonx-owner-intelligence-preview/
```

The page can also load a local JSON file through the file picker.

## Governance compliance

- Preserves Signal-first posture.
- Preserves English-default / Chinese-switchable posture.
- Preserves Notion-source-managed posture.
- Preserves LLM-first after collection posture.
- Preserves quality-gated posture.
- Does not create generic news/RSS/article/SEO drift.
- Does not deploy.

## Safety boundaries

This is an internal preview only. It does not call OpenAI, require OPENAI_API_KEY, dispatch workflows, publish content, generate public website pages, generate SEO metadata, create social drafts, mutate Notion, use live GitHub API collection, scrape article bodies, write Knowledge Graph records, implement Prediction Engine work, implement Confidence Calibration, implement Correlation, implement Human Approval Gate, implement Publish Readiness Gate, deploy, or modify production.

## Validation

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests, 221 tests OK
- git diff --check origin/main...HEAD

No package.json or frontend framework config exists in this repository, so there was no separate frontend build command to run.

## Known limitations

- Static local preview only, not a production app.
- Feedback is generated in-browser and must be downloaded or copied.
- No authentication, database persistence, or multi-user review state.
- Brief field completeness is not improved in this PR.

## Recommended next step

Use the preview to test actual Owner review friction. If the brief is too thin, do Brief Field Completeness V1 next. Otherwise, do Internal Frontend Persistence V1 or Review Session Save V1.

No production deployment was performed.
