### PR TITLE
feat: add DysonX Review Session Save V1

### DIFF
--- a/docs/DYSONX_REVIEW_SESSION_SAVE_V1.md
+++ b/docs/DYSONX_REVIEW_SESSION_SAVE_V1.md
@@ -1,0 +1,152 @@
+# DysonX Review Session Save V1
+
+## Purpose
+
+Review Session Save V1 adds local browser persistence to the internal DysonX Owner Console. It lets the Owner save, restore, clear, download, and resume a review session after changing decisions, priorities, comments, follow-up flags, or follow-up notes.
+
+This creates a local decision trail for future Publish Readiness Gate work without publishing, approving publication, writing to a server, or using a database.
+
+## Why Local Review Persistence Is Needed Before Daily Use
+
+The Owner Console now supports Auto Decision and a compressed decision workflow, but review work is not durable if the page refreshes. Daily use requires the Owner to safely resume review state without manually rebuilding decisions or comments.
+
+Local persistence removes that friction while keeping the feature internal and browser-only.
+
+## Relationship To Auto Decision Engine V1
+
+Auto Decision Engine V1 supplies conservative system defaults such as `auto_reject`, `needs_more_sources`, `needs_regeneration`, `hold`, and `candidate_for_publish_readiness_review`.
+
+Review Session Save V1 preserves the Owner's selected decision alongside the system default so later review can see where the Owner accepted or overrode automation.
+
+## Relationship To Owner Console Workflow Compression V2
+
+Workflow Compression V2 made the console usable as an auto-decision control desk. Review Session Save V1 makes that control desk resumable by saving compact-card form values and override status in local browser storage.
+
+## Relationship To Owner Feedback JSON
+
+Owner Feedback JSON remains the exportable structured feedback artifact. Review Session Save V1 integrates with it by preserving the same selected/default decision state and including review session metadata in generated feedback JSON.
+
+## Relationship To Future Publish Readiness Gate
+
+A future Publish Readiness Gate will need a decision trail showing system defaults, Owner overrides, comments, follow-up requirements, and session metadata.
+
+Review Session Save V1 creates that trail locally. It does not implement the Publish Readiness Gate.
+
+## Why Saved Sessions Are Not Publication Approval
+
+A saved review session is not publication approval.
+
+A saved review session does not publish, does not approve publication, and does not generate public pages.
+
+In V1:
+
+- `publication_approved` remains `false`
+- `auto_decision_is_not_publication_approval` is `true`
+- `owner_feedback_is_not_publication_approval` is `true`
+- `review_session_is_not_publication_approval` is `true`
+
+The strongest allowed meaning remains later review only.
+
+## Review Session Schema
+
+The saved session contains:
+
+- `review_session_version`
+- `review_session`
+- `last_saved_at`
+- `source_brief`
+- `records`
+- `generated_feedback_json`
+- safety statements
+
+The `review_session` metadata includes:
+
+- `review_session_id`
+- `created_at`
+- `updated_at`
+- `console_version`
+- `brief_id`
+- `source_brief_title`
+- `source_fixture`
+- `total_signals`
+- `system_decided_count`
+- `owner_overridden_count`
+- `needs_owner_attention_count`
+- `saved_locally`
+- `publication_approved`
+
+Each record includes the Signal ID, system default decision, selected Owner decision, override status, priority, Owner comment, follow-up values, publish-readiness candidate marker, and `publication_approved: false`.
+
+## LocalStorage Behavior
+
+The console uses this namespaced key:
+
+```text
+dysonx.ownerConsole.reviewSession.v1
+```
+
+The browser stores only local review state. It must not store secrets, API keys, raw provider responses, article bodies, or production data.
+
+## Auto-Save Behavior
+
+The console auto-saves when the Owner changes:
+
+- decision dropdown
+- priority
+- Owner comment
+- follow-up required
+- follow-up note
+
+The UI shows a saved/restored status and last saved timestamp.
+
+## Save / Load / Clear / Download Controls
+
+Review Session Save V1 adds:
+
+- Save Review Session
+- Load Saved Session
+- Clear Saved Session
+- Download Session JSON
+
+Clear Saved Session removes only this console's localStorage state and restores system defaults. It does not change fixtures, code, server data, or public content.
+
+## Safety Boundaries
+
+This feature is local-only and browser-only. It does not call OpenAI, require `OPENAI_API_KEY`, dispatch workflows, publish content, approve publication, generate public pages, write Knowledge Graph records, run Prediction Engine work, mutate Notion, use live GitHub APIs, scrape article bodies, deploy, or change production.
+
+## Non-Goals
+
+This PR does not implement:
+
+- backend API
+- database
+- server persistence
+- public publishing
+- public website generation
+- Publish Readiness Gate implementation
+- OpenAI call
+- workflow dispatch
+- deployment
+- production changes
+
+## How To Run Locally
+
+From the repository root:
+
+```bash
+python3 -m http.server 8090
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8090/internal/dysonx-owner-intelligence-preview/?v=review-session-save-v1
+```
+
+If port 8090 is busy, use 8091 and adjust the URL.
+
+## Recommended Next Step
+
+If the Owner confirms saved sessions are usable, the next practical step is Publish Readiness Gate V1.
+
+If local persistence creates confusion, do Owner Console Usability Fix V3 before adding publish-readiness logic.

--- a/internal/dysonx-owner-intelligence-preview/app.js
+++ b/internal/dysonx-owner-intelligence-preview/app.js
@@ -23,6 +23,8 @@ const DECISION_OPTIONS = [
 
 const ALLOWED_DECISIONS = DECISION_OPTIONS.map((option) => option.value);
 const ALLOWED_PRIORITIES = ["high", "medium", "low"];
+const CONSOLE_VERSION = "owner_console_review_session_save_v1";
+const REVIEW_SESSION_STORAGE_KEY = "dysonx.ownerConsole.reviewSession.v1";
 
 const AUTO_DECISION_TO_OWNER_DECISION = {
   auto_reject: "reject",
@@ -90,6 +92,10 @@ const state = {
   sourceName: "internal/dysonx-owner-intelligence-preview/brief_fixture.json",
   feedbackJson: "",
   ownerDecisionDefaults: new Map(),
+  reviewSession: null,
+  sessionJson: "",
+  restoredSession: null,
+  suppressAutosave: false,
 };
 
 function text(value) {
@@ -117,6 +123,10 @@ function setStatus(message) {
 
 function setExportStatus(message) {
   document.getElementById("export-status").textContent = message;
+}
+
+function setSessionStatus(message) {
+  document.getElementById("session-status").textContent = message;
 }
 
 function requireBrief(brief) {
@@ -218,6 +228,43 @@ function workCounts(brief) {
   };
   counts.readyToExport = counts.total > 0 ? counts.total : 0;
   return counts;
+}
+
+function sessionIdFromDate(date) {
+  return `dysonx-review-${date.toISOString().replace(/[-:]/g, "").slice(0, 15)}`;
+}
+
+function briefId(brief) {
+  return `${brief.brief_version || "brief"}:${brief.created_at || "unknown"}:${brief.signals_reviewed || 0}`;
+}
+
+function sourceBriefTitle(brief) {
+  const top = topSignal(brief);
+  return top?.title || "DysonX Internal Intelligence Brief";
+}
+
+function currentSessionMetadata(now = new Date()) {
+  const createdAt = state.reviewSession?.review_session?.created_at || now.toISOString();
+  const counts = state.brief ? workCounts(state.brief) : {
+    total: 0,
+    ownerAttention: 0,
+    overridden: 0,
+  };
+  return {
+    review_session_id: state.reviewSession?.review_session?.review_session_id || sessionIdFromDate(now),
+    created_at: createdAt,
+    updated_at: now.toISOString(),
+    console_version: CONSOLE_VERSION,
+    brief_id: state.brief ? briefId(state.brief) : "no-brief-loaded",
+    source_brief_title: state.brief ? sourceBriefTitle(state.brief) : "No brief loaded",
+    source_fixture: state.sourceName,
+    total_signals: counts.total,
+    system_decided_count: counts.total,
+    owner_overridden_count: document.querySelectorAll('.review-card[data-owner-overridden="true"]').length,
+    needs_owner_attention_count: counts.ownerAttention,
+    saved_locally: false,
+    publication_approved: false,
+  };
 }
 
 function compactList(values) {
@@ -474,6 +521,7 @@ function renderBrief(brief, sourceName) {
   renderMetadata(brief);
   setStatus(`Loaded ${state.sourceName}`);
   document.getElementById("generate-feedback-top").disabled = false;
+  restoreSessionIfAvailable();
   updateWorkflowStatus();
 }
 
@@ -527,6 +575,167 @@ function feedbackRecords() {
   });
 }
 
+function formStateRecords() {
+  return allQueueDetails(state.brief).map((detail) => {
+    const signalId = detail.signal_id;
+    const card = document.querySelector(`.review-card[data-signal-id="${CSS.escape(signalId)}"]`);
+    const defaultDecision = card?.dataset.systemDefaultOwnerDecision || ownerDecisionDefault(detail);
+    const selectedDecision = card?.querySelector(".decision-input").value || defaultDecision;
+    return {
+      signal_id: signalId,
+      system_default_owner_decision: defaultDecision,
+      selected_owner_decision: selectedDecision,
+      owner_overridden: selectedDecision !== defaultDecision,
+      priority: card?.querySelector(".priority-input").value || "low",
+      owner_comment: card?.querySelector(".comment-input").value || "",
+      follow_up_required: card?.querySelector(".follow-input").checked || false,
+      follow_up_note: card?.querySelector(".follow-note-input").value || "",
+      publication_approved: false,
+      publish_readiness_candidate: Boolean(detail.publish_readiness_candidate),
+    };
+  });
+}
+
+function buildReviewSession(savedLocally, now = new Date()) {
+  const metadata = currentSessionMetadata(now);
+  metadata.saved_locally = Boolean(savedLocally);
+  const records = formStateRecords();
+  return {
+    review_session_version: "review_session_save_v1",
+    review_session: metadata,
+    last_saved_at: metadata.updated_at,
+    source_brief: state.sourceName,
+    records,
+    generated_feedback_json: state.feedbackJson || "",
+    safety_statement: "Saved review session is not publication approval.",
+    auto_decision_is_not_publication_approval: true,
+    owner_feedback_is_not_publication_approval: true,
+    review_session_is_not_publication_approval: true,
+    publication_approved: false,
+  };
+}
+
+function applySession(session) {
+  if (!session || !Array.isArray(session.records)) return false;
+  state.suppressAutosave = true;
+  session.records.forEach((record) => {
+    const card = document.querySelector(`.review-card[data-signal-id="${CSS.escape(record.signal_id)}"]`);
+    if (!card) return;
+    const defaultDecision = card.dataset.systemDefaultOwnerDecision;
+    const decision = card.querySelector(".decision-input");
+    const priority = card.querySelector(".priority-input");
+    const comment = card.querySelector(".comment-input");
+    const follow = card.querySelector(".follow-input");
+    const note = card.querySelector(".follow-note-input");
+    if (decision && ALLOWED_DECISIONS.includes(record.selected_owner_decision)) {
+      decision.value = record.selected_owner_decision;
+    }
+    if (priority && ALLOWED_PRIORITIES.includes(record.priority)) priority.value = record.priority;
+    if (comment) comment.value = record.owner_comment || "";
+    if (follow) follow.checked = Boolean(record.follow_up_required);
+    if (note) note.value = record.follow_up_note || "";
+    const selected = decision?.value || defaultDecision;
+    const overridden = selected !== defaultDecision;
+    card.dataset.ownerOverridden = overridden ? "true" : "false";
+    const status = card.querySelector(".system-default");
+    if (status) status.textContent = overridden ? "Owner override" : "System default decision applied. Owner can override.";
+  });
+  if (session.generated_feedback_json) {
+    state.feedbackJson = session.generated_feedback_json;
+    document.getElementById("feedback-output").value = state.feedbackJson;
+    setFeedbackButtonsEnabled(true);
+  }
+  state.suppressAutosave = false;
+  updateWorkflowStatus();
+  return true;
+}
+
+function loadStoredSession() {
+  try {
+    const raw = localStorage.getItem(REVIEW_SESSION_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveReviewSession(showMessage = true) {
+  if (!state.brief) return null;
+  const session = buildReviewSession(true);
+  localStorage.setItem(REVIEW_SESSION_STORAGE_KEY, JSON.stringify(session));
+  state.reviewSession = session;
+  state.sessionJson = JSON.stringify(session, null, 2);
+  document.getElementById("download-session").disabled = false;
+  if (showMessage) setSessionStatus(`Saved locally. Last saved: ${session.last_saved_at}`);
+  return session;
+}
+
+function autoSaveReviewSession() {
+  if (state.suppressAutosave || !state.brief) return;
+  const session = saveReviewSession(false);
+  if (session) setSessionStatus(`Saved locally. Last saved: ${session.last_saved_at}`);
+}
+
+function restoreSessionIfAvailable() {
+  const stored = state.restoredSession || loadStoredSession();
+  if (!stored) return;
+  if (applySession(stored)) {
+    state.reviewSession = stored;
+    state.sessionJson = JSON.stringify(stored, null, 2);
+    document.getElementById("download-session").disabled = false;
+    setSessionStatus(`Local review session restored. Last saved: ${stored.last_saved_at || stored.review_session?.updated_at || "unknown"}`);
+  }
+}
+
+function loadSavedSession() {
+  const stored = loadStoredSession();
+  if (!stored) {
+    setSessionStatus("No saved local review session found.");
+    return;
+  }
+  state.restoredSession = stored;
+  if (state.brief && applySession(stored)) {
+    state.reviewSession = stored;
+    state.sessionJson = JSON.stringify(stored, null, 2);
+    document.getElementById("download-session").disabled = false;
+    setSessionStatus(`Local review session restored. Last saved: ${stored.last_saved_at || stored.review_session?.updated_at || "unknown"}`);
+  }
+}
+
+function clearSavedSession() {
+  localStorage.removeItem(REVIEW_SESSION_STORAGE_KEY);
+  state.reviewSession = null;
+  state.sessionJson = "";
+  state.restoredSession = null;
+  state.feedbackJson = "";
+  document.getElementById("feedback-output").value = "";
+  setFeedbackButtonsEnabled(false);
+  document.getElementById("download-session").disabled = true;
+  if (state.brief) renderBrief(state.brief, state.sourceName);
+  setSessionStatus("Saved local review session cleared. System defaults restored.");
+}
+
+function downloadSessionJson() {
+  if (!state.sessionJson) {
+    const session = saveReviewSession(false);
+    if (!session) return;
+  }
+  const blob = new Blob([`${state.sessionJson}\n`], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "dysonx_owner_console_review_session.json";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+function setFeedbackButtonsEnabled(enabled) {
+  document.getElementById("download-feedback").disabled = !enabled;
+  document.getElementById("copy-feedback").disabled = !enabled;
+  document.getElementById("download-feedback-sticky").disabled = !enabled;
+  document.getElementById("copy-feedback-sticky").disabled = !enabled;
+}
+
 function updateWorkflowStatus() {
   const cards = Array.from(document.querySelectorAll(".review-card"));
   const overridden = cards.filter((card) => card.dataset.ownerOverridden === "true").length;
@@ -561,6 +770,7 @@ function markOwnerConfirmed(event) {
   const status = card.querySelector(".system-default");
   if (status) status.textContent = overridden ? "Owner override" : "System default decision applied. Owner can override.";
   updateWorkflowStatus();
+  autoSaveReviewSession();
 }
 
 function wireReviewProgressHandlers() {
@@ -599,31 +809,42 @@ function generateFeedbackJson() {
   }
   const now = new Date().toISOString();
   const records = feedbackRecords();
+  const session = saveReviewSession(false) || buildReviewSession(false, new Date(now));
+  const metadata = session.review_session;
   const report = {
     feedback_version: "owner_review_feedback_v1",
     created_at: now,
+    updated_at: now,
     reviewer: "Owner",
-    review_session_id: `owner-console-${now}`,
+    review_session_id: metadata.review_session_id,
     reviewed_at: now,
     source_brief: state.sourceName,
+    source_brief_title: metadata.source_brief_title,
+    brief_id: metadata.brief_id,
     brief_version: state.brief.brief_version,
     signals_reviewed: state.brief.signals_reviewed,
+    total_signals: metadata.total_signals,
+    system_decided_count: metadata.system_decided_count,
+    owner_overridden_count: metadata.owner_overridden_count,
+    needs_owner_attention_count: metadata.needs_owner_attention_count,
     decisions_recorded: records.length,
     decision_counts: decisionCounts(records),
     follow_up_required_count: records.filter((record) => record.follow_up_required).length,
     publish_readiness_enabled: false,
     publication_approved: false,
     safety_statement: "This is not publication approval.",
+    auto_decision_is_not_publication_approval: true,
+    owner_feedback_is_not_publication_approval: true,
+    review_session_is_not_publication_approval: true,
+    records,
     feedback_records: records,
     recommended_next_actions: recommendedNextActions(records),
     safety_flags: { ...SAFETY_FLAGS },
   };
   state.feedbackJson = JSON.stringify(report, null, 2);
   document.getElementById("feedback-output").value = state.feedbackJson;
-  document.getElementById("download-feedback").disabled = false;
-  document.getElementById("copy-feedback").disabled = false;
-  document.getElementById("download-feedback-sticky").disabled = false;
-  document.getElementById("copy-feedback-sticky").disabled = false;
+  setFeedbackButtonsEnabled(true);
+  saveReviewSession(false);
   setExportStatus("Feedback JSON generated locally. This is not publishing approval.");
 }
 
@@ -656,6 +877,10 @@ document.getElementById("brief-file").addEventListener("change", (event) => {
 document.getElementById("generate-feedback").addEventListener("click", generateFeedbackJson);
 document.getElementById("generate-feedback-top").addEventListener("click", generateFeedbackJson);
 document.getElementById("generate-feedback-sticky").addEventListener("click", generateFeedbackJson);
+document.getElementById("save-session").addEventListener("click", () => saveReviewSession(true));
+document.getElementById("load-session").addEventListener("click", loadSavedSession);
+document.getElementById("clear-session").addEventListener("click", clearSavedSession);
+document.getElementById("download-session").addEventListener("click", downloadSessionJson);
 document.getElementById("download-feedback").addEventListener("click", downloadFeedbackJson);
 document.getElementById("download-feedback-sticky").addEventListener("click", downloadFeedbackJson);
 document.getElementById("copy-feedback").addEventListener("click", () => {

--- a/internal/dysonx-owner-intelligence-preview/index.html
+++ b/internal/dysonx-owner-intelligence-preview/index.html
@@ -16,6 +16,7 @@
     <div class="status-strip" aria-label="Safety status">
       <span>Not publish-ready</span>
       <span>No public publishing</span>
+      <span>Saved review session is not publication approval</span>
       <span>No deployment triggered by this page</span>
       <span>No OpenAI call from this page</span>
       <span>No KG writes</span>
@@ -35,6 +36,23 @@
         </div>
       </div>
       <div id="work-summary" class="work-summary" aria-label="Owner Work Summary"></div>
+    </section>
+
+    <section class="panel session-panel" aria-labelledby="session-heading">
+      <div class="section-heading action-heading">
+        <div>
+          <p class="eyebrow">Review Session Save</p>
+          <h2 id="session-heading">Review Session Save</h2>
+          <p>Save, restore, clear, or download local browser review state. A saved review session is not publication approval.</p>
+        </div>
+        <div class="button-row">
+          <button id="save-session" type="button">Save Review Session</button>
+          <button id="load-session" type="button">Load Saved Session</button>
+          <button id="clear-session" type="button">Clear Saved Session</button>
+          <button id="download-session" type="button" disabled>Download Session JSON</button>
+        </div>
+      </div>
+      <p id="session-status" class="status-text" role="status">No saved local review session loaded yet.</p>
     </section>
 
     <section class="product-grid">
@@ -58,6 +76,8 @@
         </div>
         <ul class="safety-list">
           <li>Auto Decision is not publication approval</li>
+          <li>Owner feedback is not publication approval</li>
+          <li>Saved review session is not publication approval</li>
           <li>Internal owner console only</li>
           <li>No public publishing</li>
           <li>Not publish-ready</li>

--- a/internal/dysonx-owner-intelligence-preview/styles.css
+++ b/internal/dysonx-owner-intelligence-preview/styles.css
@@ -204,6 +204,15 @@ h3 {
   font-size: 0.84rem;
 }
 
+.session-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.session-panel .button-row {
+  justify-content: flex-end;
+}
+
 .score-card {
   background: #f8fafc;
   border: 1px solid var(--line);

--- a/tests/test_dysonx_minimal_internal_frontend_preview.py
+++ b/tests/test_dysonx_minimal_internal_frontend_preview.py
@@ -13,6 +13,7 @@ FIXTURE = PREVIEW / "brief_fixture.json"
 PREVIEW_DOC = ROOT / "docs" / "DYSONX_MINIMAL_INTERNAL_FRONTEND_PREVIEW_V1.md"
 LAUNCH_PLAN = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_LAUNCH_PLAN.md"
 WORKFLOW_COMPRESSION_DOC = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_WORKFLOW_COMPRESSION_V2.md"
+REVIEW_SESSION_DOC = ROOT / "docs" / "DYSONX_REVIEW_SESSION_SAVE_V1.md"
 
 
 class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
@@ -304,6 +305,135 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("const ownerDecision = card?.querySelector(\".decision-input\").value || defaultDecision", app)
         self.assertIn("owner_overridden: ownerOverridden", app)
 
+    def test_review_session_save_ui_exists(self):
+        html = self.read_index()
+
+        for phrase in (
+            "Review Session Save",
+            "Save Review Session",
+            "Load Saved Session",
+            "Clear Saved Session",
+            "Download Session JSON",
+        ):
+            self.assertIn(phrase, html)
+        for element_id in (
+            'id="save-session"',
+            'id="load-session"',
+            'id="clear-session"',
+            'id="download-session"',
+            'id="session-status"',
+        ):
+            self.assertIn(element_id, html)
+
+    def test_review_session_uses_namespaced_local_storage_key(self):
+        app = self.read_app()
+
+        self.assertIn('const REVIEW_SESSION_STORAGE_KEY = "dysonx.ownerConsole.reviewSession.v1"', app)
+        self.assertIn("localStorage.setItem(REVIEW_SESSION_STORAGE_KEY", app)
+        self.assertIn("localStorage.getItem(REVIEW_SESSION_STORAGE_KEY", app)
+        self.assertIn("localStorage.removeItem(REVIEW_SESSION_STORAGE_KEY", app)
+
+    def test_review_session_metadata_fields_are_present(self):
+        app = self.read_app()
+
+        for field in (
+            "review_session_id",
+            "created_at",
+            "updated_at",
+            "console_version",
+            "brief_id",
+            "source_brief_title",
+            "source_fixture",
+            "total_signals",
+            "system_decided_count",
+            "owner_overridden_count",
+            "needs_owner_attention_count",
+            "saved_locally",
+            "publication_approved",
+        ):
+            self.assertIn(field, app)
+        self.assertIn('const CONSOLE_VERSION = "owner_console_review_session_save_v1"', app)
+        self.assertIn("dysonx-review-", app)
+
+    def test_review_session_persists_form_values(self):
+        app = self.read_app()
+
+        for selector in (
+            ".decision-input",
+            ".priority-input",
+            ".comment-input",
+            ".follow-input",
+            ".follow-note-input",
+        ):
+            self.assertIn(selector, app)
+        for field in (
+            "selected_owner_decision",
+            "priority",
+            "owner_comment",
+            "follow_up_required",
+            "follow_up_note",
+            "owner_overridden",
+        ):
+            self.assertIn(field, app)
+        self.assertIn("function autoSaveReviewSession()", app)
+        self.assertIn("autoSaveReviewSession();", app)
+
+    def test_review_session_restore_and_saved_status_messages_exist(self):
+        app = self.read_app()
+
+        self.assertIn("Local review session restored.", app)
+        self.assertIn("Saved locally. Last saved:", app)
+        self.assertIn("No saved local review session found.", app)
+        self.assertIn("Saved local review session cleared. System defaults restored.", app)
+
+    def test_review_session_owner_override_can_toggle_false_again(self):
+        app = self.read_app()
+
+        self.assertIn("const ownerOverridden = ownerDecision !== defaultDecision", app)
+        self.assertIn("const overridden = decision !== defaultDecision", app)
+        self.assertIn('card.dataset.ownerOverridden = overridden ? "true" : "false"', app)
+        self.assertIn('status.textContent = overridden ? "Owner override" : "System default decision applied. Owner can override."', app)
+
+    def test_feedback_json_includes_review_session_metadata_and_safety_flags(self):
+        app = self.read_app()
+
+        for field in (
+            "review_session_id",
+            "updated_at",
+            "source_brief_title",
+            "brief_id",
+            "total_signals",
+            "system_decided_count",
+            "owner_overridden_count",
+            "needs_owner_attention_count",
+            "auto_decision_is_not_publication_approval: true",
+            "owner_feedback_is_not_publication_approval: true",
+            "review_session_is_not_publication_approval: true",
+            "publication_approved: false",
+        ):
+            self.assertIn(field, app)
+
+    def test_session_json_download_and_clear_behavior_are_present(self):
+        app = self.read_app()
+
+        self.assertIn("function downloadSessionJson()", app)
+        self.assertIn("dysonx_owner_console_review_session.json", app)
+        self.assertIn("function clearSavedSession()", app)
+        self.assertIn("state.restoredSession = null", app)
+        self.assertIn("Clear Saved Session", self.read_index())
+
+    def test_saved_review_session_safety_text_is_present(self):
+        html = self.read_index()
+        doc = REVIEW_SESSION_DOC.read_text(encoding="utf-8")
+
+        self.assertIn("Saved review session is not publication approval", html)
+        self.assertIn("Owner feedback is not publication approval", html)
+        self.assertIn("No public publishing", html)
+        self.assertIn("No OpenAI call from this page", html)
+        self.assertIn("No deployment triggered by this page", html)
+        self.assertIn("saved review session does not publish", doc.lower())
+        self.assertIn("does not implement", doc)
+
     def test_safety_boundary_text_is_present(self):
         html = self.read_index()
 
@@ -325,6 +455,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
             + PREVIEW_DOC.read_text(encoding="utf-8")
             + LAUNCH_PLAN.read_text(encoding="utf-8")
             + WORKFLOW_COMPRESSION_DOC.read_text(encoding="utf-8")
+            + REVIEW_SESSION_DOC.read_text(encoding="utf-8")
         )
 
         self.assertIn("does not require `OPENAI_API_KEY`", combined)


### PR DESCRIPTION
## Summary
- Adds local browser Review Session Save V1 to the internal Owner Console.
- Saves and restores Owner decisions, priorities, comments, follow-up flags, follow-up notes, and override state using localStorage.
- Adds review session metadata and session JSON export.
- Integrates saved state with feedback JSON.
- Preserves publication_approved false and clearly states saved sessions are not publication approval.
- Creates a local decision trail needed for a future Publish Readiness Gate.

## Safety boundary
- No backend APIs.
- No database or server persistence.
- No Publish Readiness Gate implementation.
- No public publishing or public website generation.
- No OpenAI calls or OPENAI_API_KEY requirement.
- No workflow dispatch.
- No deployment or production changes.

## Validation
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- git diff --check origin/main...HEAD
- Local route HTTP 200: http://127.0.0.1:8090/internal/dysonx-owner-intelligence-preview/?v=review-session-save-v1