### PR TITLE
feat: add DysonX Owner guided review workflow

### DIFF
--- a/docs/DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md
+++ b/docs/DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md
@@ -1,0 +1,192 @@
+# DysonX Owner Guided Review Workflow V1
+
+## 1. Purpose
+
+Owner Guided Review Workflow V1 turns the internal DysonX Owner Console from a passive control panel into a guided operating workflow. The Owner should always know the current step, what to click now, what is complete, what is locked, and what final export action remains.
+
+This improves internal review usability without implementing public publishing, Publish Readiness Gate, backend APIs, database storage, OpenAI calls, workflow dispatch, deployment, or production changes.
+
+## 2. Why Button Existence Was Not Enough
+
+The previous console exposed the right controls, but the Owner still had to infer the operating sequence. A console can be technically functional and still fail if the Owner has to ask which button to press next.
+
+Guided review makes the workflow explicit:
+
+1. Review attention items.
+2. Confirm auto-handled items.
+3. Save the review session.
+4. Generate Owner Feedback JSON.
+5. Download or copy outputs.
+
+## 3. Owner Guided Workflow Model
+
+The primary workflow is:
+
+```text
+Review Attention Items
+-> Confirm Auto-handled
+-> Save Session
+-> Generate Feedback
+-> Download / Copy
+```
+
+The workflow highlights the current action, marks completed steps, and locks future steps until prerequisites are complete.
+
+## 4. Stepper States
+
+Each step has one visible state:
+
+- `active`: current step
+- `complete`: finished step
+- `locked`: future step unavailable until prerequisites complete
+
+The UI uses text labels and class names, not color alone.
+
+## 5. Current Action Banner
+
+The current action banner tells the Owner what to do next.
+
+Examples:
+
+- Current action: Review the highlighted Signal.
+- Current action: Confirm auto-handled Signals.
+- Current action: Save the review session.
+- Current action: Generate Owner Feedback JSON.
+- Current action: Download or copy outputs.
+- Complete: Internal review saved and feedback generated. No publication occurred.
+
+## 6. Active Item Highlighting
+
+During Review Attention Items, the active Needs Owner Attention card is highlighted. Completed attention cards show `Done`. Future attention cards show `Next` and stay visually secondary until active.
+
+Only one attention card should be strongly highlighted at a time.
+
+## 7. Per-Card Actions
+
+Each Needs Owner Attention card includes:
+
+- Accept system decision
+- Override decision
+- Mark done
+
+Accept system decision resets the selected Owner decision to the system default, clears override state, marks the Signal done, and advances the workflow.
+
+Override decision focuses the Owner decision control but does not mark the Signal done. The Owner must choose the decision and click Mark done.
+
+Mark done completes the current Signal and advances to the next attention item.
+
+## 8. Auto-Handled Confirmation
+
+Auto-handled Signals already have system decisions. The Owner should not manually review every auto-rejected, held, or regeneration-needed Signal.
+
+The guided workflow provides:
+
+- Accept all auto-handled system decisions
+- Review auto-handled details
+
+The default path is to accept all auto-handled decisions unless the Owner disagrees.
+
+## 9. Save / Generate / Download Gating
+
+Save Session remains locked until attention items and auto-handled confirmation are complete.
+
+Generate Owner Feedback JSON remains locked until the review session is saved.
+
+Download and copy actions remain locked until Owner Feedback JSON exists.
+
+Restored sessions may unlock later steps when their persisted workflow state shows prerequisites are complete.
+
+## 10. Workflow Persistence
+
+The workflow persists locally through the existing key:
+
+```text
+dysonx.ownerConsole.reviewSession.v1
+```
+
+Persisted workflow fields include:
+
+- `active_step`
+- `completed_steps`
+- `attention_item_statuses`
+- `auto_handled_confirmed`
+- `session_saved`
+- `feedback_generated`
+- `outputs_ready`
+
+Clear Saved Session resets the workflow to Step 1.
+
+## 11. Completion State
+
+After feedback generation, the console shows a completion panel:
+
+- Internal review complete.
+- Owner Feedback JSON generated.
+- Review Session JSON generated.
+- No public publishing occurred.
+- No publication approval occurred.
+- Next future stage is Publish Readiness Gate V1.
+
+A completed guided review is not publication approval.
+
+## 12. Safety Boundaries
+
+Owner Guided Review Workflow V1 does not:
+
+- publish content
+- approve publication
+- generate public website pages
+- implement Publish Readiness Gate
+- write Knowledge Graph records
+- run Prediction Engine work
+- perform Confidence Calibration
+- perform Multi-source Correlation
+- mutate Notion
+- use live GitHub APIs
+- scrape article bodies
+- call OpenAI
+- require `OPENAI_API_KEY`
+- dispatch workflows
+- deploy
+- change production
+
+`publication_approved` remains `false`.
+
+## 13. Non-Goals
+
+This PR does not implement:
+
+- backend API
+- database
+- server persistence
+- public publishing
+- public website generation
+- Publish Readiness Gate implementation
+- OpenAI call
+- workflow dispatch
+- deployment
+- production changes
+
+## 14. How To Run Locally
+
+From the repository root:
+
+```bash
+python3 -m http.server 8090
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8090/internal/dysonx-owner-intelligence-preview/?v=guided-review-workflow-v1
+```
+
+If port 8090 is busy, use 8091 and adjust the URL.
+
+## 15. Recommended Next Step
+
+Owner tests guided workflow locally.
+
+If Owner can complete a review without external explanation, proceed to Publish Readiness Gate V1.
+
+If not, do not proceed to Publish Readiness Gate. Do another Owner Console usability fix first.

--- a/docs/DYSONX_REVIEW_SESSION_SAVE_V1.md
+++ b/docs/DYSONX_REVIEW_SESSION_SAVE_V1.md
@@ -22,6 +22,8 @@ Review Session Save V1 preserves the Owner's selected decision alongside the sys
 
 Workflow Compression V2 made the console usable as an auto-decision control desk. Review Session Save V1 makes that control desk resumable by saving compact-card form values and override status in local browser storage.
 
+Review Session Save must be embedded in a guided workflow. The Owner should not have to infer which button to press next.
+
 ## Relationship To Owner Feedback JSON
 
 Owner Feedback JSON remains the exportable structured feedback artifact. Review Session Save V1 integrates with it by preserving the same selected/default decision state and including review session metadata in generated feedback JSON.

--- a/internal/dysonx-owner-intelligence-preview/app.js
+++ b/internal/dysonx-owner-intelligence-preview/app.js
@@ -26,6 +26,34 @@ const ALLOWED_PRIORITIES = ["high", "medium", "low"];
 const CONSOLE_VERSION = "owner_console_review_session_save_v1";
 const REVIEW_SESSION_STORAGE_KEY = "dysonx.ownerConsole.reviewSession.v1";
 
+const WORKFLOW_STEPS = [
+  {
+    id: "review_attention_items",
+    label: "Review Attention Items",
+    action: "Review the highlighted Signal.",
+  },
+  {
+    id: "confirm_auto_handled",
+    label: "Confirm Auto-handled",
+    action: "Confirm auto-handled Signals.",
+  },
+  {
+    id: "save_session",
+    label: "Save Session",
+    action: "Save the review session.",
+  },
+  {
+    id: "generate_feedback",
+    label: "Generate Feedback",
+    action: "Generate Owner Feedback JSON.",
+  },
+  {
+    id: "download_copy",
+    label: "Download / Copy",
+    action: "Download or copy outputs.",
+  },
+];
+
 const AUTO_DECISION_TO_OWNER_DECISION = {
   auto_reject: "reject",
   needs_more_sources: "request_more_sources",
@@ -96,7 +124,20 @@ const state = {
   sessionJson: "",
   restoredSession: null,
   suppressAutosave: false,
+  guidedWorkflow: defaultGuidedWorkflowState(),
 };
+
+function defaultGuidedWorkflowState() {
+  return {
+    active_step: "review_attention_items",
+    completed_steps: [],
+    attention_item_statuses: {},
+    auto_handled_confirmed: false,
+    session_saved: false,
+    feedback_generated: false,
+    outputs_ready: false,
+  };
+}
 
 function text(value) {
   return String(value || "").trim();
@@ -230,6 +271,110 @@ function workCounts(brief) {
   return counts;
 }
 
+function completedSteps() {
+  return new Set(state.guidedWorkflow.completed_steps || []);
+}
+
+function setCompleted(stepId, complete) {
+  const steps = completedSteps();
+  if (complete) steps.add(stepId);
+  else steps.delete(stepId);
+  state.guidedWorkflow.completed_steps = Array.from(steps);
+}
+
+function attentionRecords() {
+  return state.brief ? allQueueDetails(state.brief).filter(isOwnerAttention) : [];
+}
+
+function autoHandledRecords() {
+  return state.brief
+    ? allQueueDetails(state.brief).filter((record) => !isOwnerAttention(record) && !isBlockedLowValue(record))
+    : [];
+}
+
+function initializeGuidedWorkflowForBrief() {
+  const existing = state.guidedWorkflow || defaultGuidedWorkflowState();
+  const next = { ...defaultGuidedWorkflowState(), ...existing };
+  next.attention_item_statuses = { ...(existing.attention_item_statuses || {}) };
+  attentionRecords().forEach((record, index) => {
+    const current = next.attention_item_statuses[record.signal_id];
+    next.attention_item_statuses[record.signal_id] = current === "done" ? "done" : (index === 0 ? "active" : "next");
+  });
+  state.guidedWorkflow = next;
+  reconcileGuidedWorkflow();
+}
+
+function firstIncompleteAttentionId() {
+  return attentionRecords().find((record) => state.guidedWorkflow.attention_item_statuses[record.signal_id] !== "done")?.signal_id || null;
+}
+
+function attentionComplete() {
+  return attentionRecords().every((record) => state.guidedWorkflow.attention_item_statuses[record.signal_id] === "done");
+}
+
+function reviewPrerequisitesComplete() {
+  return completedSteps().has("review_attention_items") && completedSteps().has("confirm_auto_handled");
+}
+
+function reconcileGuidedWorkflow() {
+  if (!state.brief) return;
+  const firstIncomplete = firstIncompleteAttentionId();
+  attentionRecords().forEach((record) => {
+    if (state.guidedWorkflow.attention_item_statuses[record.signal_id] === "done") return;
+    state.guidedWorkflow.attention_item_statuses[record.signal_id] = record.signal_id === firstIncomplete ? "active" : "next";
+  });
+  setCompleted("review_attention_items", attentionComplete());
+  setCompleted("confirm_auto_handled", Boolean(state.guidedWorkflow.auto_handled_confirmed));
+  setCompleted("save_session", Boolean(state.guidedWorkflow.session_saved));
+  setCompleted("generate_feedback", Boolean(state.guidedWorkflow.feedback_generated));
+  setCompleted("download_copy", Boolean(state.guidedWorkflow.outputs_ready));
+  if (!completedSteps().has("review_attention_items")) state.guidedWorkflow.active_step = "review_attention_items";
+  else if (!completedSteps().has("confirm_auto_handled")) state.guidedWorkflow.active_step = "confirm_auto_handled";
+  else if (!completedSteps().has("save_session")) state.guidedWorkflow.active_step = "save_session";
+  else if (!completedSteps().has("generate_feedback")) state.guidedWorkflow.active_step = "generate_feedback";
+  else state.guidedWorkflow.active_step = "download_copy";
+}
+
+function workflowStepState(stepId) {
+  if (completedSteps().has(stepId)) return "complete";
+  if (state.guidedWorkflow.active_step === stepId) return "active";
+  return "locked";
+}
+
+function currentActionText() {
+  if (!state.brief) return "Load the local brief fixture to begin guided review.";
+  if (completedSteps().has("download_copy")) return "Complete: Internal review saved and feedback generated. No publication occurred.";
+  const step = WORKFLOW_STEPS.find((item) => item.id === state.guidedWorkflow.active_step);
+  if (step?.id === "review_attention_items") return "Review this Signal or accept the system decision.";
+  if (step?.id === "confirm_auto_handled") return "Confirm auto-handled Signals.";
+  if (step?.id === "save_session") return "Save the review session.";
+  if (step?.id === "generate_feedback") return "Generate Owner Feedback JSON.";
+  if (step?.id === "download_copy") return "Download or copy outputs.";
+  return step?.action || "Review the highlighted Signal.";
+}
+
+function guidedBadgeText(status) {
+  if (status === "done") return "Done";
+  if (status === "active") return "Current action";
+  if (status === "next") return "Next";
+  return "System handled";
+}
+
+function refreshGuidedCardStates() {
+  document.querySelectorAll(".review-card").forEach((card) => {
+    const status = state.guidedWorkflow.attention_item_statuses[card.dataset.signalId] || (card.dataset.needsOwnerAttention === "true" ? "next" : "auto-handled");
+    card.dataset.guidedStatus = status;
+    card.classList.toggle("active-attention-item", status === "active");
+    card.classList.toggle("completed-attention-item", status === "done");
+    card.classList.toggle("future-attention-item", status === "next");
+    const badge = card.querySelector(".guided-card-status");
+    if (badge) {
+      badge.className = `guided-card-status ${status}`;
+      badge.textContent = guidedBadgeText(status);
+    }
+  });
+}
+
 function sessionIdFromDate(date) {
   return `dysonx-review-${date.toISOString().replace(/[-:]/g, "").slice(0, 15)}`;
 }
@@ -270,6 +415,60 @@ function currentSessionMetadata(now = new Date()) {
 function compactList(values) {
   const filtered = arrayValue(values);
   return filtered.length ? filtered.join(", ") : "none";
+}
+
+function setButtonsDisabled(ids, disabled) {
+  ids.forEach((id) => {
+    const node = document.getElementById(id);
+    if (node) node.disabled = disabled;
+  });
+}
+
+function renderGuidedWorkflow() {
+  reconcileGuidedWorkflow();
+  const stepper = document.getElementById("workflow-stepper");
+  clear(stepper);
+  WORKFLOW_STEPS.forEach((step, index) => {
+    const status = workflowStepState(step.id);
+    const item = el("li", `workflow-step ${status}`, "");
+    item.dataset.step = step.id;
+    item.dataset.stepState = status;
+    item.setAttribute("aria-current", status === "active" ? "step" : "false");
+    const marker = el("span", "step-marker", status === "complete" ? "✓" : String(index + 1));
+    const label = el("span", "step-label", step.label);
+    const stateLabel = status === "locked" ? "locked" : status;
+    item.append(marker, label, el("span", "step-state", stateLabel));
+    stepper.appendChild(item);
+  });
+
+  const banner = document.getElementById("current-action-banner");
+  const bannerLabel = completedSteps().has("download_copy") ? "Complete:" : "Current action:";
+  banner.innerHTML = "";
+  banner.append(el("strong", "", bannerLabel), el("span", "", currentActionText()));
+
+  const saveReady = state.guidedWorkflow.active_step === "save_session" || completedSteps().has("save_session");
+  const feedbackReady = completedSteps().has("save_session");
+  const outputsReady = completedSteps().has("generate_feedback");
+  setButtonsDisabled(["save-session"], !saveReady);
+  setButtonsDisabled(["generate-feedback", "generate-feedback-top", "generate-feedback-sticky"], !feedbackReady);
+  setButtonsDisabled(["download-session"], !completedSteps().has("save_session"));
+  setButtonsDisabled(["copy-feedback", "copy-feedback-sticky", "download-feedback", "download-feedback-sticky"], !outputsReady);
+
+  const autoPanel = document.getElementById("auto-handled-confirmation");
+  autoPanel.classList.toggle("active", state.guidedWorkflow.active_step === "confirm_auto_handled");
+  autoPanel.classList.toggle("complete", completedSteps().has("confirm_auto_handled"));
+  autoPanel.classList.toggle("locked", !completedSteps().has("review_attention_items"));
+  document.getElementById("accept-auto-handled").disabled = !completedSteps().has("review_attention_items") || completedSteps().has("confirm_auto_handled");
+
+  const metadata = currentSessionMetadata();
+  document.getElementById("session-id-display").textContent = metadata.review_session_id;
+  document.getElementById("session-save-status").textContent = completedSteps().has("save_session") ? "Saved locally" : "Not saved";
+  document.getElementById("session-last-saved").textContent = state.reviewSession?.last_saved_at || "Not saved yet";
+  document.getElementById("next-required-action").textContent = currentActionText();
+  document.getElementById("review-session-card").classList.toggle("active", state.guidedWorkflow.active_step === "save_session");
+
+  const completion = document.getElementById("completion-panel");
+  completion.hidden = !completedSteps().has("generate_feedback");
 }
 
 function fieldRow(label, value, className) {
@@ -421,8 +620,14 @@ function compactSignalCard(detail, index) {
   card.dataset.systemDefaultOwnerDecision = defaultDecision;
   card.dataset.ownerOverridden = "false";
   card.dataset.needsOwnerAttention = isOwnerAttention(detail) ? "true" : "false";
+  const guidedStatus = state.guidedWorkflow.attention_item_statuses[detail.signal_id] || (isOwnerAttention(detail) ? "next" : "auto-handled");
+  card.dataset.guidedStatus = guidedStatus;
+  card.classList.toggle("active-attention-item", guidedStatus === "active");
+  card.classList.toggle("completed-attention-item", guidedStatus === "done");
+  card.classList.toggle("future-attention-item", guidedStatus === "next");
   state.ownerDecisionDefaults.set(detail.signal_id, defaultDecision);
   card.appendChild(el("div", "queue-rank", `#${index + 1}`));
+  card.appendChild(el("div", `guided-card-status ${guidedStatus}`, guidedBadgeText(guidedStatus)));
   card.appendChild(el("h3", "", detail.title || "(untitled signal)"));
   card.appendChild(el("p", "takeaway", shortText(detail.executive_takeaway || detail.why_it_matters || "No executive takeaway provided.", 190)));
   card.appendChild(el("p", "system-default", "System default decision applied. Owner can override."));
@@ -470,6 +675,21 @@ function compactSignalCard(detail, index) {
   controls.append(decisionLabel, priorityLabel, commentLabel, followLabel, noteLabel);
   card.appendChild(controls);
 
+  if (isOwnerAttention(detail)) {
+    const guidedActions = el("div", "guided-card-actions");
+    const accept = el("button", "accept-system-decision", "Accept system decision");
+    accept.type = "button";
+    accept.dataset.action = "accept-system-decision";
+    const override = el("button", "override-decision", "Override decision");
+    override.type = "button";
+    override.dataset.action = "override-decision";
+    const done = el("button", "mark-signal-done", "Mark done");
+    done.type = "button";
+    done.dataset.action = "mark-done";
+    guidedActions.append(accept, override, done);
+    card.appendChild(guidedActions);
+  }
+
   const details = document.createElement("details");
   details.className = "signal-details";
   const summary = document.createElement("summary");
@@ -497,6 +717,7 @@ function renderReviewQueue(brief) {
   clear(attentionTarget);
   clear(autoTarget);
   state.ownerDecisionDefaults.clear();
+  initializeGuidedWorkflowForBrief();
   const records = allQueueDetails(brief);
   const attention = records.filter(isOwnerAttention);
   const autoHandled = records.filter((record) => !isOwnerAttention(record) && !isBlockedLowValue(record));
@@ -506,6 +727,7 @@ function renderReviewQueue(brief) {
   autoHandled.forEach((detail, index) => autoTarget.appendChild(compactSignalCard(detail, index)));
   wireReviewProgressHandlers();
   updateWorkflowStatus();
+  renderGuidedWorkflow();
 }
 
 function renderBrief(brief, sourceName) {
@@ -520,7 +742,6 @@ function renderBrief(brief, sourceName) {
   renderBlocked(brief);
   renderMetadata(brief);
   setStatus(`Loaded ${state.sourceName}`);
-  document.getElementById("generate-feedback-top").disabled = false;
   restoreSessionIfAvailable();
   updateWorkflowStatus();
 }
@@ -597,6 +818,7 @@ function formStateRecords() {
 }
 
 function buildReviewSession(savedLocally, now = new Date()) {
+  reconcileGuidedWorkflow();
   const metadata = currentSessionMetadata(now);
   metadata.saved_locally = Boolean(savedLocally);
   const records = formStateRecords();
@@ -607,6 +829,15 @@ function buildReviewSession(savedLocally, now = new Date()) {
     source_brief: state.sourceName,
     records,
     generated_feedback_json: state.feedbackJson || "",
+    guided_workflow_status: { ...state.guidedWorkflow },
+    active_step: state.guidedWorkflow.active_step,
+    completed_steps: [...state.guidedWorkflow.completed_steps],
+    attention_item_statuses: { ...state.guidedWorkflow.attention_item_statuses },
+    auto_handled_confirmed: state.guidedWorkflow.auto_handled_confirmed,
+    session_saved: state.guidedWorkflow.session_saved,
+    feedback_generated: state.guidedWorkflow.feedback_generated,
+    outputs_ready: state.guidedWorkflow.outputs_ready,
+    internal_review_complete: Boolean(state.guidedWorkflow.outputs_ready),
     safety_statement: "Saved review session is not publication approval.",
     auto_decision_is_not_publication_approval: true,
     owner_feedback_is_not_publication_approval: true,
@@ -618,6 +849,17 @@ function buildReviewSession(savedLocally, now = new Date()) {
 function applySession(session) {
   if (!session || !Array.isArray(session.records)) return false;
   state.suppressAutosave = true;
+  state.guidedWorkflow = {
+    ...defaultGuidedWorkflowState(),
+    ...(session.guided_workflow_status || {}),
+    active_step: session.active_step || session.guided_workflow_status?.active_step || "review_attention_items",
+    completed_steps: session.completed_steps || session.guided_workflow_status?.completed_steps || [],
+    attention_item_statuses: session.attention_item_statuses || session.guided_workflow_status?.attention_item_statuses || {},
+    auto_handled_confirmed: Boolean(session.auto_handled_confirmed || session.guided_workflow_status?.auto_handled_confirmed),
+    session_saved: Boolean(session.session_saved || session.guided_workflow_status?.session_saved),
+    feedback_generated: Boolean(session.feedback_generated || session.guided_workflow_status?.feedback_generated),
+    outputs_ready: Boolean(session.outputs_ready || session.guided_workflow_status?.outputs_ready),
+  };
   session.records.forEach((record) => {
     const card = document.querySelector(`.review-card[data-signal-id="${CSS.escape(record.signal_id)}"]`);
     if (!card) return;
@@ -659,20 +901,25 @@ function loadStoredSession() {
   }
 }
 
-function saveReviewSession(showMessage = true) {
+function saveReviewSession(showMessage = true, markWorkflowSaved = true) {
   if (!state.brief) return null;
+  if (markWorkflowSaved) {
+    state.guidedWorkflow.session_saved = true;
+    setCompleted("save_session", true);
+  }
   const session = buildReviewSession(true);
   localStorage.setItem(REVIEW_SESSION_STORAGE_KEY, JSON.stringify(session));
   state.reviewSession = session;
   state.sessionJson = JSON.stringify(session, null, 2);
   document.getElementById("download-session").disabled = false;
   if (showMessage) setSessionStatus(`Saved locally. Last saved: ${session.last_saved_at}`);
+  renderGuidedWorkflow();
   return session;
 }
 
 function autoSaveReviewSession() {
   if (state.suppressAutosave || !state.brief) return;
-  const session = saveReviewSession(false);
+  const session = saveReviewSession(false, false);
   if (session) setSessionStatus(`Saved locally. Last saved: ${session.last_saved_at}`);
 }
 
@@ -708,6 +955,7 @@ function clearSavedSession() {
   state.sessionJson = "";
   state.restoredSession = null;
   state.feedbackJson = "";
+  state.guidedWorkflow = defaultGuidedWorkflowState();
   document.getElementById("feedback-output").value = "";
   setFeedbackButtonsEnabled(false);
   document.getElementById("download-session").disabled = true;
@@ -758,6 +1006,7 @@ function updateWorkflowStatus() {
     el("span", "", `Needs Owner attention: ${ownerAttention}`),
   );
   if (state.brief) renderWorkSummary(state.brief);
+  if (state.brief) renderGuidedWorkflow();
 }
 
 function markOwnerConfirmed(event) {
@@ -773,10 +1022,63 @@ function markOwnerConfirmed(event) {
   autoSaveReviewSession();
 }
 
+function markAttentionDone(signalId) {
+  if (!signalId) return;
+  state.guidedWorkflow.attention_item_statuses[signalId] = "done";
+  reconcileGuidedWorkflow();
+  refreshGuidedCardStates();
+  updateWorkflowStatus();
+  autoSaveReviewSession();
+}
+
+function acceptSystemDecision(card) {
+  const decision = card.querySelector(".decision-input");
+  if (decision) decision.value = card.dataset.systemDefaultOwnerDecision;
+  card.dataset.ownerOverridden = "false";
+  const status = card.querySelector(".system-default");
+  if (status) status.textContent = "System default decision applied. Owner can override.";
+  markAttentionDone(card.dataset.signalId);
+}
+
+function overrideDecision(card) {
+  const decision = card.querySelector(".decision-input");
+  if (decision) {
+    decision.focus();
+    decision.classList.add("override-focus");
+  }
+  const status = card.querySelector(".system-default");
+  if (status) status.textContent = "Owner override pending. Choose a decision, then Mark done.";
+}
+
+function handleGuidedCardAction(event) {
+  const button = event.target.closest("[data-action]");
+  if (!button) return;
+  const card = button.closest(".review-card");
+  if (!card) return;
+  if (button.dataset.action === "accept-system-decision") acceptSystemDecision(card);
+  if (button.dataset.action === "override-decision") overrideDecision(card);
+  if (button.dataset.action === "mark-done") markAttentionDone(card.dataset.signalId);
+}
+
+function acceptAllAutoHandled() {
+  state.guidedWorkflow.auto_handled_confirmed = true;
+  setCompleted("confirm_auto_handled", true);
+  reconcileGuidedWorkflow();
+  renderGuidedWorkflow();
+  autoSaveReviewSession();
+}
+
+function reviewAutoHandledDetails() {
+  document.getElementById("auto-handled")?.querySelector("details")?.setAttribute("open", "open");
+}
+
 function wireReviewProgressHandlers() {
   document.querySelectorAll(".review-card select, .review-card textarea, .review-card input").forEach((input) => {
     input.addEventListener("change", markOwnerConfirmed);
     input.addEventListener("input", markOwnerConfirmed);
+  });
+  document.querySelectorAll(".guided-card-actions button").forEach((button) => {
+    button.addEventListener("click", handleGuidedCardAction);
   });
 }
 
@@ -807,9 +1109,13 @@ function generateFeedbackJson() {
     setStatus("Load a brief before generating feedback.");
     return;
   }
+  if (!completedSteps().has("save_session")) {
+    setExportStatus("Save the review session before generating Owner Feedback JSON.");
+    return;
+  }
   const now = new Date().toISOString();
   const records = feedbackRecords();
-  const session = saveReviewSession(false) || buildReviewSession(false, new Date(now));
+  const session = saveReviewSession(false, false) || buildReviewSession(false, new Date(now));
   const metadata = session.review_session;
   const report = {
     feedback_version: "owner_review_feedback_v1",
@@ -832,6 +1138,9 @@ function generateFeedbackJson() {
     follow_up_required_count: records.filter((record) => record.follow_up_required).length,
     publish_readiness_enabled: false,
     publication_approved: false,
+    guided_workflow_status: { ...state.guidedWorkflow },
+    completed_steps: [...state.guidedWorkflow.completed_steps],
+    internal_review_complete: false,
     safety_statement: "This is not publication approval.",
     auto_decision_is_not_publication_approval: true,
     owner_feedback_is_not_publication_approval: true,
@@ -841,11 +1150,19 @@ function generateFeedbackJson() {
     recommended_next_actions: recommendedNextActions(records),
     safety_flags: { ...SAFETY_FLAGS },
   };
+  state.guidedWorkflow.feedback_generated = true;
+  state.guidedWorkflow.outputs_ready = true;
+  setCompleted("generate_feedback", true);
+  setCompleted("download_copy", true);
+  report.guided_workflow_status = { ...state.guidedWorkflow };
+  report.completed_steps = [...state.guidedWorkflow.completed_steps];
+  report.internal_review_complete = true;
   state.feedbackJson = JSON.stringify(report, null, 2);
   document.getElementById("feedback-output").value = state.feedbackJson;
   setFeedbackButtonsEnabled(true);
-  saveReviewSession(false);
+  saveReviewSession(false, false);
   setExportStatus("Feedback JSON generated locally. This is not publishing approval.");
+  renderGuidedWorkflow();
 }
 
 async function copyFeedbackJson() {
@@ -881,6 +1198,8 @@ document.getElementById("save-session").addEventListener("click", () => saveRevi
 document.getElementById("load-session").addEventListener("click", loadSavedSession);
 document.getElementById("clear-session").addEventListener("click", clearSavedSession);
 document.getElementById("download-session").addEventListener("click", downloadSessionJson);
+document.getElementById("accept-auto-handled").addEventListener("click", acceptAllAutoHandled);
+document.getElementById("review-auto-handled-details").addEventListener("click", reviewAutoHandledDetails);
 document.getElementById("download-feedback").addEventListener("click", downloadFeedbackJson);
 document.getElementById("download-feedback-sticky").addEventListener("click", downloadFeedbackJson);
 document.getElementById("copy-feedback").addEventListener("click", () => {

--- a/internal/dysonx-owner-intelligence-preview/index.html
+++ b/internal/dysonx-owner-intelligence-preview/index.html
@@ -39,11 +39,18 @@
     </section>
 
     <section class="panel session-panel" aria-labelledby="session-heading">
+      <div class="workflow-shell" aria-label="Guided review workflow">
+        <ol id="workflow-stepper" class="workflow-stepper" aria-label="Workflow stepper"></ol>
+        <div id="current-action-banner" class="current-action-banner" role="status">
+          <strong>Current action:</strong>
+          <span>Load the local brief fixture to begin guided review.</span>
+        </div>
+      </div>
       <div class="section-heading action-heading">
         <div>
           <p class="eyebrow">Review Session Save</p>
           <h2 id="session-heading">Review Session Save</h2>
-          <p>Save, restore, clear, or download local browser review state. A saved review session is not publication approval.</p>
+          <p>Follow the guided workflow, then save local browser review state. A saved review session is not publication approval.</p>
         </div>
         <div class="button-row">
           <button id="save-session" type="button">Save Review Session</button>
@@ -51,6 +58,16 @@
           <button id="clear-session" type="button">Clear Saved Session</button>
           <button id="download-session" type="button" disabled>Download Session JSON</button>
         </div>
+      </div>
+      <div id="review-session-card" class="workflow-card">
+        <dl class="session-facts">
+          <div><dt>Session ID</dt><dd id="session-id-display">Not created yet</dd></div>
+          <div><dt>Save status</dt><dd id="session-save-status">Not saved</dd></div>
+          <div><dt>Last saved</dt><dd id="session-last-saved">Not saved yet</dd></div>
+          <div><dt>Storage</dt><dd>Local browser only</dd></div>
+          <div><dt>Publication approval</dt><dd>No</dd></div>
+          <div><dt>Next required action</dt><dd id="next-required-action">Review the highlighted Signal.</dd></div>
+        </dl>
       </div>
       <p id="session-status" class="status-text" role="status">No saved local review session loaded yet.</p>
     </section>
@@ -110,6 +127,13 @@
       </section>
       <section class="queue-group" aria-labelledby="auto-handled-heading">
         <h3 id="auto-handled-heading">Auto-handled</h3>
+        <div id="auto-handled-confirmation" class="auto-handled-panel locked" aria-label="Auto-handled confirmation">
+          <p>These Signals already have system decisions. You do not need to review them unless you disagree.</p>
+          <div class="button-row">
+            <button id="accept-auto-handled" type="button">Accept all auto-handled system decisions</button>
+            <button id="review-auto-handled-details" type="button">Review auto-handled details</button>
+          </div>
+        </div>
         <div id="auto-handled" class="review-list"></div>
       </section>
     </section>
@@ -149,6 +173,40 @@
       </div>
       <textarea id="feedback-output" readonly spellcheck="false" aria-label="Generated owner feedback JSON"></textarea>
       <p id="export-status" class="status-text" role="status">Generate feedback to preview JSON here.</p>
+    </section>
+
+    <section id="completion-panel" class="panel completion-panel" aria-labelledby="completion-heading" hidden>
+      <div class="section-heading">
+        <div>
+          <p class="eyebrow">Review Complete</p>
+          <h2 id="completion-heading">Internal review complete.</h2>
+        </div>
+      </div>
+      <p>Completed internal review. No public publishing occurred.</p>
+      <div class="completion-grid">
+        <div>
+          <h3>Generated</h3>
+          <ul>
+            <li>Owner Feedback JSON</li>
+            <li>Review Session JSON</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Not performed</h3>
+          <ul>
+            <li>public publishing</li>
+            <li>publication approval</li>
+            <li>deployment</li>
+            <li>OpenAI call</li>
+            <li>KG write</li>
+            <li>Prediction Engine</li>
+          </ul>
+        </div>
+        <div>
+          <h3>Next future stage</h3>
+          <p>Publish Readiness Gate V1</p>
+        </div>
+      </div>
     </section>
 
     <details class="panel secondary-details">

--- a/internal/dysonx-owner-intelligence-preview/styles.css
+++ b/internal/dysonx-owner-intelligence-preview/styles.css
@@ -209,6 +209,117 @@ h3 {
   gap: 10px;
 }
 
+.workflow-shell,
+.workflow-card,
+.auto-handled-panel,
+.completion-panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 12px;
+}
+
+.workflow-stepper {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.workflow-step {
+  background: #f8fafc;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.workflow-step.active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 2px rgba(15, 118, 110, 0.18);
+}
+
+.workflow-step.complete {
+  background: #eefdf3;
+  border-color: #86efac;
+  color: #14532d;
+}
+
+.workflow-step.locked {
+  background: #f1f5f9;
+  color: #64748b;
+}
+
+.step-marker,
+.step-state {
+  font-weight: 800;
+}
+
+.step-label,
+.step-state {
+  overflow-wrap: anywhere;
+}
+
+.current-action-banner {
+  align-items: center;
+  background: #fffdf3;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px;
+}
+
+.workflow-card.active,
+.auto-handled-panel.active {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 2px rgba(15, 118, 110, 0.16);
+}
+
+.auto-handled-panel.locked {
+  opacity: 0.65;
+}
+
+.auto-handled-panel.complete {
+  background: #eefdf3;
+  border-color: #86efac;
+}
+
+.session-facts,
+.completion-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+}
+
+.session-facts div,
+.completion-grid > div {
+  background: #f8fafc;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.session-facts dt {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.session-facts dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 .session-panel .button-row {
   justify-content: flex-end;
 }
@@ -343,6 +454,20 @@ a {
   position: relative;
 }
 
+.review-card.active-attention-item {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 2px rgba(15, 118, 110, 0.18);
+}
+
+.review-card.completed-attention-item {
+  background: #f8fafc;
+  opacity: 0.82;
+}
+
+.review-card.future-attention-item {
+  background: #fbfdff;
+}
+
 .compact-signal-card {
   display: grid;
   gap: 10px;
@@ -360,6 +485,31 @@ a {
   padding: 4px 8px;
 }
 
+.guided-card-status {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 4px 8px;
+  width: fit-content;
+}
+
+.guided-card-status.active {
+  background: var(--accent-soft);
+  color: var(--accent-dark);
+}
+
+.guided-card-status.done {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.guided-card-status.next,
+.guided-card-status.auto-handled {
+  background: #e2e8f0;
+  color: #334155;
+}
+
 .system-default {
   background: #eef6ff;
   border: 1px solid #bfdbfe;
@@ -367,6 +517,16 @@ a {
   color: #1e3a8a;
   font-weight: 800;
   padding: 8px;
+}
+
+.guided-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.override-focus {
+  outline: 3px solid #fbbf24;
 }
 
 .review-card[data-owner-overridden="true"] .system-default {
@@ -565,7 +725,10 @@ a {
 
   .score-cards,
   .work-summary,
-  .review-controls {
+  .review-controls,
+  .workflow-stepper,
+  .session-facts,
+  .completion-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/tests/test_dysonx_minimal_internal_frontend_preview.py
+++ b/tests/test_dysonx_minimal_internal_frontend_preview.py
@@ -14,6 +14,7 @@ PREVIEW_DOC = ROOT / "docs" / "DYSONX_MINIMAL_INTERNAL_FRONTEND_PREVIEW_V1.md"
 LAUNCH_PLAN = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_LAUNCH_PLAN.md"
 WORKFLOW_COMPRESSION_DOC = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_WORKFLOW_COMPRESSION_V2.md"
 REVIEW_SESSION_DOC = ROOT / "docs" / "DYSONX_REVIEW_SESSION_SAVE_V1.md"
+GUIDED_WORKFLOW_DOC = ROOT / "docs" / "DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md"
 
 
 class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
@@ -422,6 +423,147 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("state.restoredSession = null", app)
         self.assertIn("Clear Saved Session", self.read_index())
 
+    def test_guided_workflow_stepper_exists(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertIn('id="workflow-stepper"', html)
+        for step in (
+            "Review Attention Items",
+            "Confirm Auto-handled",
+            "Save Session",
+            "Generate Feedback",
+            "Download / Copy",
+        ):
+            self.assertIn(step, app)
+        for state in ("active", "complete", "locked"):
+            self.assertIn(state, app)
+
+    def test_current_action_banner_exists(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertIn('id="current-action-banner"', html)
+        self.assertIn("Current action:", html)
+        self.assertIn("Current action:", app)
+        self.assertIn("Review this Signal or accept the system decision.", app)
+
+    def test_attention_item_guided_states_exist(self):
+        app = self.read_app()
+
+        self.assertIn("active-attention-item", app)
+        self.assertIn("completed-attention-item", app)
+        self.assertIn("future-attention-item", app)
+        self.assertIn("Done", app)
+        self.assertIn("Next", app)
+        self.assertIn("Current action", app)
+
+    def test_per_card_guided_actions_exist(self):
+        app = self.read_app()
+
+        for phrase in (
+            "Accept system decision",
+            "Override decision",
+            "Mark done",
+            "accept-system-decision",
+            "override-decision",
+            "mark-done",
+        ):
+            self.assertIn(phrase, app)
+        self.assertIn("function acceptSystemDecision", app)
+        self.assertIn("function overrideDecision", app)
+        self.assertIn("function markAttentionDone", app)
+
+    def test_auto_handled_confirmation_step_exists(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertIn('id="auto-handled-confirmation"', html)
+        self.assertIn("These Signals already have system decisions", html)
+        self.assertIn("Accept all auto-handled system decisions", html)
+        self.assertIn("Review auto-handled details", html)
+        self.assertIn("function acceptAllAutoHandled", app)
+
+    def test_workflow_gates_later_actions(self):
+        app = self.read_app()
+
+        self.assertIn('setButtonsDisabled(["save-session"], !saveReady)', app)
+        self.assertIn('setButtonsDisabled(["generate-feedback", "generate-feedback-top", "generate-feedback-sticky"], !feedbackReady)', app)
+        self.assertIn('setButtonsDisabled(["copy-feedback", "copy-feedback-sticky", "download-feedback", "download-feedback-sticky"], !outputsReady)', app)
+        self.assertIn('state.guidedWorkflow.active_step === "save_session"', app)
+        self.assertIn('completedSteps().has("save_session")', app)
+        self.assertIn('completedSteps().has("generate_feedback")', app)
+
+    def test_workflow_state_is_persisted_in_local_storage(self):
+        app = self.read_app()
+
+        for field in (
+            "guided_workflow_status",
+            "active_step",
+            "completed_steps",
+            "attention_item_statuses",
+            "auto_handled_confirmed",
+            "session_saved",
+            "feedback_generated",
+            "outputs_ready",
+        ):
+            self.assertIn(field, app)
+        self.assertIn("localStorage.setItem(REVIEW_SESSION_STORAGE_KEY", app)
+
+    def test_clear_saved_session_resets_workflow_to_step_one(self):
+        app = self.read_app()
+
+        self.assertIn("state.guidedWorkflow = defaultGuidedWorkflowState();", app)
+        self.assertIn('active_step: "review_attention_items"', app)
+        self.assertIn("Saved local review session cleared. System defaults restored.", app)
+
+    def test_final_completion_panel_exists(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertIn('id="completion-panel"', html)
+        self.assertIn("Internal review complete.", html)
+        self.assertIn("Completed internal review. No public publishing occurred.", html)
+        self.assertIn("Next future stage", html)
+        self.assertIn("Publish Readiness Gate V1", html)
+        self.assertIn("completion.hidden = !completedSteps().has(\"generate_feedback\")", app)
+
+    def test_feedback_json_includes_guided_workflow_status(self):
+        app = self.read_app()
+
+        self.assertIn("guided_workflow_status", app)
+        self.assertIn("completed_steps", app)
+        self.assertIn("internal_review_complete", app)
+        self.assertIn("publication_approved: false", app)
+
+    def test_raw_json_stays_below_guided_workflow(self):
+        html = self.read_index()
+
+        workflow_index = html.index('id="workflow-stepper"')
+        output_index = html.index('id="feedback-output"')
+        self.assertLess(workflow_index, output_index)
+        self.assertIn("Brief source and technical details", html)
+        self.assertIn("<details", html)
+
+    def test_guided_workflow_documentation_exists(self):
+        doc = GUIDED_WORKFLOW_DOC.read_text(encoding="utf-8")
+
+        for phrase in (
+            "Why Button Existence Was Not Enough",
+            "Owner Guided Workflow Model",
+            "Stepper States",
+            "Current Action Banner",
+            "Active Item Highlighting",
+            "Per-Card Actions",
+            "Auto-Handled Confirmation",
+            "Save / Generate / Download Gating",
+            "Workflow Persistence",
+            "Completion State",
+            "Safety Boundaries",
+            "If Owner can complete a review without external explanation, proceed to Publish Readiness Gate V1.",
+        ):
+            self.assertIn(phrase, doc)
+
     def test_saved_review_session_safety_text_is_present(self):
         html = self.read_index()
         doc = REVIEW_SESSION_DOC.read_text(encoding="utf-8")
@@ -456,6 +598,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
             + LAUNCH_PLAN.read_text(encoding="utf-8")
             + WORKFLOW_COMPRESSION_DOC.read_text(encoding="utf-8")
             + REVIEW_SESSION_DOC.read_text(encoding="utf-8")
+            + GUIDED_WORKFLOW_DOC.read_text(encoding="utf-8")
         )
 
         self.assertIn("does not require `OPENAI_API_KEY`", combined)


### PR DESCRIPTION
Adds DysonX Owner Guided Review Workflow V1 to the internal Owner Console.

This PR:
- Converts Owner Console from a passive panel into a guided workflow.
- Adds a workflow stepper with active, complete, and locked states.
- Adds a current action banner.
- Highlights the active attention item.
- Adds Accept system decision, Override decision, and Mark done actions.
- Adds Accept all auto-handled system decisions.
- Gates Save Session, Generate Feedback, and Download/Copy actions by workflow progress.
- Persists guided workflow state locally.
- Adds a final completion panel.
- Preserves localStorage session save, compressed console layout, feedback JSON safety, and publication_approved false.

This does not implement backend APIs, database, server persistence, Publish Readiness Gate, public publishing, public website generation, OpenAI calls, workflow dispatch, deployment, or production changes.