### PR TITLE
fix: make DysonX Owner Console single-action guided workflow

### DIFF
--- a/docs/DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md
+++ b/docs/DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md
@@ -32,6 +32,8 @@ Review Attention Items
 
 The workflow highlights the current action, marks completed steps, and locks future steps until prerequisites are complete.
 
+The guided workflow must behave as a single active action console. Multiple competing highlighted actions, expanded completed cards, or unexplained disabled buttons are product failures.
+
 ## 4. Stepper States
 
 Each step has one visible state:

--- a/docs/DYSONX_OWNER_SINGLE_ACTIVE_ACTION_WORKFLOW_V1.md
+++ b/docs/DYSONX_OWNER_SINGLE_ACTIVE_ACTION_WORKFLOW_V1.md
@@ -1,0 +1,236 @@
+# DysonX Owner Single Active Action Workflow V1
+
+## 1. Purpose
+
+Owner Single Active Action Workflow V1 fixes the Owner Console usability failure where too many buttons, highlighted sections, expanded cards, and export controls competed for attention.
+
+The console must behave like an internal operating panel: one current task, one primary action, clear completed state, clear locked state, and a final output action.
+
+This is an Owner Console usability fix only. It does not implement public publishing, Publish Readiness Gate, backend APIs, database storage, OpenAI calls, workflow dispatch, deployment, or production changes.
+
+## 2. Why The Previous Guided Workflow Still Failed
+
+Owner Guided Review Workflow V1 added a stepper and gated actions, but the page could still feel ambiguous:
+
+- multiple actions looked important at once
+- completed cards remained visually prominent
+- disabled buttons looked broken instead of intentionally locked
+- future cards were too visible
+- export actions appeared in multiple places
+- review-complete state could compete with incomplete-looking controls
+
+The problem was not missing explanatory text. The problem was interaction state.
+
+## 3. Single Active Action Rule
+
+At any moment, the Owner Console must expose exactly one primary action.
+
+Secondary actions may exist only when they support the current task and must be visually subordinate.
+
+The current primary action must be obvious within three seconds.
+
+## 4. Active Task Header
+
+The Active Task Header is the primary operating surface. It shows:
+
+- step number
+- current task title
+- one sentence instruction
+- one primary action
+- optional secondary action
+- progress text
+
+The rest of the page supports the active task; it must not compete with it.
+
+## 5. One Primary Action Rule
+
+The UI must maintain one primary action marker, such as:
+
+```text
+data-primary-action="true"
+```
+
+Examples:
+
+- review attention item: Accept system decision and mark done
+- override mode: Mark done
+- auto-handled step: Accept all auto-handled system decisions
+- save step: Save review session locally
+- feedback step: Generate Owner Feedback JSON
+- output step: Download Owner Feedback JSON
+
+## 6. Collapsed Completed Cards
+
+Completed attention cards collapse to a short summary:
+
+```text
+Done -- title -- selected decision -- Edit
+```
+
+Completed cards must not keep full forms, full details, or strong highlights visible.
+
+## 7. Collapsed Future Cards
+
+Future attention cards collapse to:
+
+```text
+Next -- title -- system suggested decision -- locked until previous item complete
+```
+
+Future cards must not expose active controls before they become current.
+
+## 8. Active Card Behavior
+
+Only the active attention card shows the full compact review controls:
+
+- Auto Decision
+- score
+- tier
+- risk summary
+- missing fields
+- why it matters
+- watch next
+- Owner decision dropdown
+- priority
+- comment
+- follow-up fields
+- active review actions
+
+Only one attention card should be strongly highlighted.
+
+## 9. Auto-Handled Confirmation Behavior
+
+Auto-handled Signals remain collapsed and muted until their step.
+
+During the auto-handled step, the console should show a concise confirmation panel:
+
+```text
+These Signals are already system-decided. Accept all unless you disagree.
+```
+
+The default primary action is:
+
+```text
+Accept all auto-handled system decisions
+```
+
+Reviewing details is secondary.
+
+## 10. Save / Feedback / Output Gating
+
+Save, feedback, and output actions must be gated by workflow progress:
+
+- save unlocks after attention and auto-handled steps are complete
+- feedback unlocks after session save
+- download/copy unlock after feedback generation
+- final completion appears only after the output step completes
+
+Locked actions should be explained with text, not shown as unexplained broken buttons.
+
+## 11. Final Completion State
+
+The final state says:
+
+```text
+Internal review complete.
+No public publishing occurred.
+Next future stage: Publish Readiness Gate V1.
+```
+
+A completed single-action review is not publication approval.
+
+## 12. Reset / Clear Behavior
+
+Clear saved review must be secondary and labeled for local testing, such as:
+
+```text
+Reset local test state
+```
+
+It must not sit in the primary path where the Owner may click it accidentally.
+
+## 13. Responsive Usability Requirement
+
+The single active action panel must remain readable on narrow screens.
+
+Metric cards, stepper labels, collapsed summaries, and primary action buttons must not wrap into unreadable fragments.
+
+## 14. Persistence State
+
+The workflow continues to use:
+
+```text
+dysonx.ownerConsole.reviewSession.v1
+```
+
+Persisted workflow state includes existing Review Session Save fields plus:
+
+- `active_attention_index`
+- `override_mode_for_active_item`
+- `output_downloaded`
+- `output_step_complete`
+- `active_primary_action`
+
+Reloading a saved session must restore the correct active task.
+
+## 15. Safety Boundaries
+
+Single Active Action Workflow V1 does not:
+
+- publish content
+- approve publication
+- generate public website pages
+- implement Publish Readiness Gate
+- write Knowledge Graph records
+- run Prediction Engine work
+- perform Confidence Calibration
+- perform Multi-source Correlation
+- mutate Notion
+- use live GitHub APIs
+- scrape article bodies
+- call OpenAI
+- require `OPENAI_API_KEY`
+- dispatch workflows
+- deploy
+- change production
+
+`publication_approved` remains `false`.
+
+## 16. Non-Goals
+
+This PR does not implement:
+
+- backend API
+- database
+- server persistence
+- public publishing
+- public website generation
+- Publish Readiness Gate implementation
+- OpenAI call
+- workflow dispatch
+- deployment
+- production changes
+
+## 17. How To Run Locally
+
+From the repository root:
+
+```bash
+python3 -m http.server 8090
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8090/internal/dysonx-owner-intelligence-preview/?v=single-active-action-v1
+```
+
+If port 8090 is busy, use 8091 and adjust the URL.
+
+## 18. Recommended Next Step
+
+Owner tests single active action workflow locally.
+
+If Owner can complete internal review without asking what to click next, proceed to Publish Readiness Gate V1.
+
+If not, fix Owner Console again before Publish Readiness Gate.

--- a/docs/DYSONX_REVIEW_SESSION_SAVE_V1.md
+++ b/docs/DYSONX_REVIEW_SESSION_SAVE_V1.md
@@ -24,6 +24,8 @@ Workflow Compression V2 made the console usable as an auto-decision control desk
 
 Review Session Save must be embedded in a guided workflow. The Owner should not have to infer which button to press next.
 
+Review Session Save controls must not appear as an unstructured button cluster. Save must be presented as the current active task only when prerequisites are complete.
+
 ## Relationship To Owner Feedback JSON
 
 Owner Feedback JSON remains the exportable structured feedback artifact. Review Session Save V1 integrates with it by preserving the same selected/default decision state and including review session metadata in generated feedback JSON.

--- a/internal/dysonx-owner-intelligence-preview/app.js
+++ b/internal/dysonx-owner-intelligence-preview/app.js
@@ -23,7 +23,8 @@ const DECISION_OPTIONS = [
 
 const ALLOWED_DECISIONS = DECISION_OPTIONS.map((option) => option.value);
 const ALLOWED_PRIORITIES = ["high", "medium", "low"];
-const CONSOLE_VERSION = "owner_console_review_session_save_v1";
+const CONSOLE_VERSION = "owner_console_single_active_action_v1";
+const SINGLE_ACTIVE_ACTION_WORKFLOW_VERSION = "v1";
 const REVIEW_SESSION_STORAGE_KEY = "dysonx.ownerConsole.reviewSession.v1";
 
 const WORKFLOW_STEPS = [
@@ -136,6 +137,11 @@ function defaultGuidedWorkflowState() {
     session_saved: false,
     feedback_generated: false,
     outputs_ready: false,
+    active_attention_index: 0,
+    override_mode_for_active_item: false,
+    output_downloaded: false,
+    output_step_complete: false,
+    active_primary_action: "accept_active_attention",
   };
 }
 
@@ -308,6 +314,18 @@ function firstIncompleteAttentionId() {
   return attentionRecords().find((record) => state.guidedWorkflow.attention_item_statuses[record.signal_id] !== "done")?.signal_id || null;
 }
 
+function activeAttentionRecord() {
+  const activeId = firstIncompleteAttentionId();
+  return attentionRecords().find((record) => record.signal_id === activeId) || null;
+}
+
+function activeAttentionIndex() {
+  const records = attentionRecords();
+  const active = activeAttentionRecord();
+  const index = active ? records.findIndex((record) => record.signal_id === active.signal_id) : -1;
+  return Math.max(0, index);
+}
+
 function attentionComplete() {
   return attentionRecords().every((record) => state.guidedWorkflow.attention_item_statuses[record.signal_id] === "done");
 }
@@ -319,6 +337,8 @@ function reviewPrerequisitesComplete() {
 function reconcileGuidedWorkflow() {
   if (!state.brief) return;
   const firstIncomplete = firstIncompleteAttentionId();
+  const activeRecord = activeAttentionRecord();
+  state.guidedWorkflow.active_attention_index = activeAttentionIndex();
   attentionRecords().forEach((record) => {
     if (state.guidedWorkflow.attention_item_statuses[record.signal_id] === "done") return;
     state.guidedWorkflow.attention_item_statuses[record.signal_id] = record.signal_id === firstIncomplete ? "active" : "next";
@@ -327,12 +347,16 @@ function reconcileGuidedWorkflow() {
   setCompleted("confirm_auto_handled", Boolean(state.guidedWorkflow.auto_handled_confirmed));
   setCompleted("save_session", Boolean(state.guidedWorkflow.session_saved));
   setCompleted("generate_feedback", Boolean(state.guidedWorkflow.feedback_generated));
-  setCompleted("download_copy", Boolean(state.guidedWorkflow.outputs_ready));
+  setCompleted("download_copy", Boolean(state.guidedWorkflow.output_step_complete || state.guidedWorkflow.outputs_ready));
   if (!completedSteps().has("review_attention_items")) state.guidedWorkflow.active_step = "review_attention_items";
   else if (!completedSteps().has("confirm_auto_handled")) state.guidedWorkflow.active_step = "confirm_auto_handled";
   else if (!completedSteps().has("save_session")) state.guidedWorkflow.active_step = "save_session";
   else if (!completedSteps().has("generate_feedback")) state.guidedWorkflow.active_step = "generate_feedback";
   else state.guidedWorkflow.active_step = "download_copy";
+  if (state.guidedWorkflow.active_step !== "review_attention_items" || !activeRecord) {
+    state.guidedWorkflow.override_mode_for_active_item = false;
+  }
+  state.guidedWorkflow.active_primary_action = activePrimaryAction();
 }
 
 function workflowStepState(stepId) {
@@ -351,6 +375,103 @@ function currentActionText() {
   if (step?.id === "generate_feedback") return "Generate Owner Feedback JSON.";
   if (step?.id === "download_copy") return "Download or copy outputs.";
   return step?.action || "Review the highlighted Signal.";
+}
+
+function activeTaskModel() {
+  if (!state.brief) {
+    return {
+      step: "Step 1 of 5",
+      title: "Load review brief",
+      instruction: "Load the local fixture to begin the internal review workflow.",
+      progress: "No brief loaded",
+      primary: "Load fixture",
+      primaryAction: "load_fixture",
+      secondary: "",
+      secondaryAction: "",
+    };
+  }
+  const step = state.guidedWorkflow.active_step;
+  const attention = attentionRecords();
+  const active = activeAttentionRecord();
+  if (step === "review_attention_items") {
+    const index = activeAttentionIndex();
+    const overrideMode = Boolean(state.guidedWorkflow.override_mode_for_active_item);
+    return {
+      step: "Step 1 of 5",
+      title: `Review attention item ${Math.min(index + 1, attention.length)} of ${attention.length}`,
+      instruction: overrideMode
+        ? "Choose the Owner decision, then mark this Signal done."
+        : "Accept the system decision or override it, then mark this item done.",
+      progress: active ? active.title : "All attention items complete",
+      primary: overrideMode ? "Mark done" : "Accept system decision and mark done",
+      primaryAction: overrideMode ? "mark_active_done" : "accept_active_attention",
+      secondary: overrideMode ? "" : "Override decision",
+      secondaryAction: overrideMode ? "" : "override_active_attention",
+    };
+  }
+  if (step === "confirm_auto_handled") {
+    const count = autoHandledRecords().length;
+    return {
+      step: "Step 2 of 5",
+      title: "Confirm auto-handled Signals",
+      instruction: `These ${count} Signals already have system decisions. Accept all unless you disagree.`,
+      progress: `${count} system-decided Signals`,
+      primary: "Accept all auto-handled system decisions",
+      primaryAction: "accept_auto_handled",
+      secondary: "Review auto-handled details",
+      secondaryAction: "review_auto_handled",
+    };
+  }
+  if (step === "save_session") {
+    return {
+      step: "Step 3 of 5",
+      title: "Save review session",
+      instruction: "Save the local browser review session before generating feedback.",
+      progress: "Save unlocks Owner Feedback JSON generation.",
+      primary: "Save review session locally",
+      primaryAction: "save_session",
+      secondary: "",
+      secondaryAction: "",
+    };
+  }
+  if (step === "generate_feedback") {
+    return {
+      step: "Step 4 of 5",
+      title: "Generate Owner Feedback JSON",
+      instruction: "Generate structured internal feedback. This is not publication approval.",
+      progress: "Feedback unlocks output download and copy actions.",
+      primary: "Generate Owner Feedback JSON",
+      primaryAction: "generate_feedback",
+      secondary: "",
+      secondaryAction: "",
+    };
+  }
+  if (completedSteps().has("download_copy")) {
+    return {
+      step: "Complete",
+      title: "Internal review complete",
+      instruction: "No public publishing occurred. Outputs remain local unless downloaded or copied.",
+      progress: "Next future stage: Publish Readiness Gate V1",
+      primary: "Start new review / clear saved review",
+      primaryAction: "clear_saved_review",
+      secondary: "Download outputs again",
+      secondaryAction: "download_feedback",
+    };
+  }
+  return {
+    step: "Step 5 of 5",
+    title: "Generate and download feedback",
+    instruction: "Download Owner Feedback JSON as the final active output action.",
+    progress: "Copy and session download are secondary actions.",
+    primary: "Download Owner Feedback JSON",
+    primaryAction: "download_feedback",
+    secondary: "Copy Feedback JSON",
+    secondaryAction: "copy_feedback",
+  };
+}
+
+function activePrimaryAction() {
+  return activeTaskModel().primaryAction;
 }
 
 function guidedBadgeText(status) {
@@ -372,6 +493,11 @@ function refreshGuidedCardStates() {
       badge.className = `guided-card-status ${status}`;
       badge.textContent = guidedBadgeText(status);
     }
+    const decision = card.querySelector(".decision-input")?.value || card.dataset.systemDefaultOwnerDecision;
+    const summary = card.querySelector(".selected-decision-summary");
+    if (summary) summary.textContent = `Selected decision: ${humanAction(decision)}`;
+    const details = card.querySelector("details");
+    if (details && status !== "active") details.open = false;
   });
 }
 
@@ -424,8 +550,46 @@ function setButtonsDisabled(ids, disabled) {
   });
 }
 
+function renderActiveTask() {
+  const task = activeTaskModel();
+  state.guidedWorkflow.active_primary_action = task.primaryAction;
+  document.getElementById("active-task-step").textContent = task.step;
+  document.getElementById("active-task-title").textContent = task.title;
+  document.getElementById("active-task-instruction").textContent = task.instruction;
+  document.getElementById("active-task-progress").textContent = task.progress;
+  const primary = document.getElementById("active-primary-action");
+  primary.textContent = task.primary;
+  primary.dataset.action = task.primaryAction;
+  primary.dataset.primaryAction = "true";
+  primary.disabled = !task.primaryAction;
+  const secondary = document.getElementById("active-secondary-action");
+  secondary.hidden = !task.secondaryAction;
+  secondary.textContent = task.secondary || "";
+  secondary.dataset.action = task.secondaryAction || "";
+}
+
+function updateGateMessages() {
+  const sessionGate = document.getElementById("session-gate-message");
+  if (completedSteps().has("save_session")) {
+    sessionGate.textContent = `Saved locally — ${state.reviewSession?.last_saved_at || "timestamp pending"} — ${currentSessionMetadata().review_session_id}`;
+  } else if (state.guidedWorkflow.active_step === "save_session") {
+    sessionGate.textContent = "Save review session locally is the current active task.";
+  } else {
+    sessionGate.textContent = "Save unlocks after attention and auto-handled steps are complete.";
+  }
+  const feedbackGate = document.getElementById("feedback-gate-message");
+  if (completedSteps().has("generate_feedback")) {
+    feedbackGate.textContent = "Feedback generated. Download is now the active output task.";
+  } else if (state.guidedWorkflow.active_step === "generate_feedback") {
+    feedbackGate.textContent = "Generate Owner Feedback JSON is the current active task.";
+  } else {
+    feedbackGate.textContent = "Feedback unlocks after session save.";
+  }
+}
+
 function renderGuidedWorkflow() {
   reconcileGuidedWorkflow();
+  renderActiveTask();
   const stepper = document.getElementById("workflow-stepper");
   clear(stepper);
   WORKFLOW_STEPS.forEach((step, index) => {
@@ -446,18 +610,18 @@ function renderGuidedWorkflow() {
   banner.innerHTML = "";
   banner.append(el("strong", "", bannerLabel), el("span", "", currentActionText()));
 
-  const saveReady = state.guidedWorkflow.active_step === "save_session" || completedSteps().has("save_session");
-  const feedbackReady = completedSteps().has("save_session");
   const outputsReady = completedSteps().has("generate_feedback");
-  setButtonsDisabled(["save-session"], !saveReady);
-  setButtonsDisabled(["generate-feedback", "generate-feedback-top", "generate-feedback-sticky"], !feedbackReady);
   setButtonsDisabled(["download-session"], !completedSteps().has("save_session"));
-  setButtonsDisabled(["copy-feedback", "copy-feedback-sticky", "download-feedback", "download-feedback-sticky"], !outputsReady);
+  setButtonsDisabled(["copy-feedback", "download-feedback"], !outputsReady);
 
   const autoPanel = document.getElementById("auto-handled-confirmation");
+  const autoCount = autoHandledRecords().length;
   autoPanel.classList.toggle("active", state.guidedWorkflow.active_step === "confirm_auto_handled");
   autoPanel.classList.toggle("complete", completedSteps().has("confirm_auto_handled"));
   autoPanel.classList.toggle("locked", !completedSteps().has("review_attention_items"));
+  autoPanel.querySelector("p").textContent = completedSteps().has("confirm_auto_handled")
+    ? `✓ Auto-handled confirmed — ${autoCount} system decisions accepted.`
+    : `These ${autoCount} Signals are already system-decided. Accept all unless you disagree.`;
   document.getElementById("accept-auto-handled").disabled = !completedSteps().has("review_attention_items") || completedSteps().has("confirm_auto_handled");
 
   const metadata = currentSessionMetadata();
@@ -466,9 +630,10 @@ function renderGuidedWorkflow() {
   document.getElementById("session-last-saved").textContent = state.reviewSession?.last_saved_at || "Not saved yet";
   document.getElementById("next-required-action").textContent = currentActionText();
   document.getElementById("review-session-card").classList.toggle("active", state.guidedWorkflow.active_step === "save_session");
+  updateGateMessages();
 
   const completion = document.getElementById("completion-panel");
-  completion.hidden = !completedSteps().has("generate_feedback");
+  completion.hidden = !completedSteps().has("download_copy");
 }
 
 function fieldRow(label, value, className) {
@@ -629,6 +794,25 @@ function compactSignalCard(detail, index) {
   card.appendChild(el("div", "queue-rank", `#${index + 1}`));
   card.appendChild(el("div", `guided-card-status ${guidedStatus}`, guidedBadgeText(guidedStatus)));
   card.appendChild(el("h3", "", detail.title || "(untitled signal)"));
+  const completedSummary = el("div", "collapsed-card-summary completed-summary");
+  completedSummary.append(
+    el("strong", "", "✓ Done"),
+    el("span", "", detail.title || "(untitled signal)"),
+    el("span", "selected-decision-summary", `Selected decision: ${humanAction(defaultDecision)}`),
+  );
+  const edit = el("button", "edit-completed-card secondary-action", "Edit");
+  edit.type = "button";
+  edit.dataset.action = "edit-completed-card";
+  completedSummary.appendChild(edit);
+  card.appendChild(completedSummary);
+  const futureSummary = el("div", "collapsed-card-summary future-summary");
+  futureSummary.append(
+    el("strong", "", "Next"),
+    el("span", "", detail.title || "(untitled signal)"),
+    el("span", "", `System suggested decision: ${humanAction(defaultDecision)}`),
+    el("span", "locked-note", "Locked until previous item complete"),
+  );
+  card.appendChild(futureSummary);
   card.appendChild(el("p", "takeaway", shortText(detail.executive_takeaway || detail.why_it_matters || "No executive takeaway provided.", 190)));
   card.appendChild(el("p", "system-default", "System default decision applied. Owner can override."));
   card.appendChild(fieldList([
@@ -677,13 +861,13 @@ function compactSignalCard(detail, index) {
 
   if (isOwnerAttention(detail)) {
     const guidedActions = el("div", "guided-card-actions");
-    const accept = el("button", "accept-system-decision", "Accept system decision");
+    const accept = el("button", "accept-system-decision", "Accept system decision and mark done");
     accept.type = "button";
     accept.dataset.action = "accept-system-decision";
-    const override = el("button", "override-decision", "Override decision");
+    const override = el("button", "override-decision secondary-action", "Override decision");
     override.type = "button";
     override.dataset.action = "override-decision";
-    const done = el("button", "mark-signal-done", "Mark done");
+    const done = el("button", "mark-signal-done secondary-action", "Mark done");
     done.type = "button";
     done.dataset.action = "mark-done";
     guidedActions.append(accept, override, done);
@@ -837,6 +1021,11 @@ function buildReviewSession(savedLocally, now = new Date()) {
     session_saved: state.guidedWorkflow.session_saved,
     feedback_generated: state.guidedWorkflow.feedback_generated,
     outputs_ready: state.guidedWorkflow.outputs_ready,
+    active_attention_index: state.guidedWorkflow.active_attention_index,
+    override_mode_for_active_item: state.guidedWorkflow.override_mode_for_active_item,
+    output_downloaded: state.guidedWorkflow.output_downloaded,
+    output_step_complete: state.guidedWorkflow.output_step_complete,
+    active_primary_action: state.guidedWorkflow.active_primary_action,
     internal_review_complete: Boolean(state.guidedWorkflow.outputs_ready),
     safety_statement: "Saved review session is not publication approval.",
     auto_decision_is_not_publication_approval: true,
@@ -859,6 +1048,11 @@ function applySession(session) {
     session_saved: Boolean(session.session_saved || session.guided_workflow_status?.session_saved),
     feedback_generated: Boolean(session.feedback_generated || session.guided_workflow_status?.feedback_generated),
     outputs_ready: Boolean(session.outputs_ready || session.guided_workflow_status?.outputs_ready),
+    active_attention_index: session.active_attention_index || session.guided_workflow_status?.active_attention_index || 0,
+    override_mode_for_active_item: Boolean(session.override_mode_for_active_item || session.guided_workflow_status?.override_mode_for_active_item),
+    output_downloaded: Boolean(session.output_downloaded || session.guided_workflow_status?.output_downloaded),
+    output_step_complete: Boolean(session.output_step_complete || session.guided_workflow_status?.output_step_complete),
+    active_primary_action: session.active_primary_action || session.guided_workflow_status?.active_primary_action || "accept_active_attention",
   };
   session.records.forEach((record) => {
     const card = document.querySelector(`.review-card[data-signal-id="${CSS.escape(record.signal_id)}"]`);
@@ -980,8 +1174,6 @@ function downloadSessionJson() {
 function setFeedbackButtonsEnabled(enabled) {
   document.getElementById("download-feedback").disabled = !enabled;
   document.getElementById("copy-feedback").disabled = !enabled;
-  document.getElementById("download-feedback-sticky").disabled = !enabled;
-  document.getElementById("copy-feedback-sticky").disabled = !enabled;
 }
 
 function updateWorkflowStatus() {
@@ -998,13 +1190,6 @@ function updateWorkflowStatus() {
     el("span", "", `Needs Owner attention: ${ownerAttention}`),
     el("span", "", `Total Signals: ${total}`),
   );
-  const exportSummary = document.getElementById("export-action-summary");
-  exportSummary.innerHTML = "";
-  exportSummary.append(
-    el("span", "", `System-decided: ${systemDecided}`),
-    el("span", "", `Owner-overridden: ${overridden}`),
-    el("span", "", `Needs Owner attention: ${ownerAttention}`),
-  );
   if (state.brief) renderWorkSummary(state.brief);
   if (state.brief) renderGuidedWorkflow();
 }
@@ -1018,6 +1203,8 @@ function markOwnerConfirmed(event) {
   card.dataset.ownerOverridden = overridden ? "true" : "false";
   const status = card.querySelector(".system-default");
   if (status) status.textContent = overridden ? "Owner override" : "System default decision applied. Owner can override.";
+  const summary = card.querySelector(".selected-decision-summary");
+  if (summary) summary.textContent = `Selected decision: ${humanAction(decision)}`;
   updateWorkflowStatus();
   autoSaveReviewSession();
 }
@@ -1025,6 +1212,7 @@ function markOwnerConfirmed(event) {
 function markAttentionDone(signalId) {
   if (!signalId) return;
   state.guidedWorkflow.attention_item_statuses[signalId] = "done";
+  state.guidedWorkflow.override_mode_for_active_item = false;
   reconcileGuidedWorkflow();
   refreshGuidedCardStates();
   updateWorkflowStatus();
@@ -1046,8 +1234,10 @@ function overrideDecision(card) {
     decision.focus();
     decision.classList.add("override-focus");
   }
+  state.guidedWorkflow.override_mode_for_active_item = true;
   const status = card.querySelector(".system-default");
   if (status) status.textContent = "Owner override pending. Choose a decision, then Mark done.";
+  renderGuidedWorkflow();
 }
 
 function handleGuidedCardAction(event) {
@@ -1058,6 +1248,37 @@ function handleGuidedCardAction(event) {
   if (button.dataset.action === "accept-system-decision") acceptSystemDecision(card);
   if (button.dataset.action === "override-decision") overrideDecision(card);
   if (button.dataset.action === "mark-done") markAttentionDone(card.dataset.signalId);
+  if (button.dataset.action === "edit-completed-card") {
+    state.guidedWorkflow.attention_item_statuses[card.dataset.signalId] = "active";
+    state.guidedWorkflow.override_mode_for_active_item = true;
+    setCompleted("review_attention_items", false);
+    reconcileGuidedWorkflow();
+    renderReviewQueue(state.brief);
+  }
+}
+
+function activeAttentionCard() {
+  const record = activeAttentionRecord();
+  if (!record) return null;
+  return document.querySelector(`.review-card[data-signal-id="${CSS.escape(record.signal_id)}"]`);
+}
+
+function runActiveTaskAction(action) {
+  const card = activeAttentionCard();
+  if (action === "load_fixture") {
+    loadFixture().catch((error) => setStatus(error.message));
+    return;
+  }
+  if (action === "accept_active_attention" && card) acceptSystemDecision(card);
+  if (action === "override_active_attention" && card) overrideDecision(card);
+  if (action === "mark_active_done" && card) markAttentionDone(card.dataset.signalId);
+  if (action === "accept_auto_handled") acceptAllAutoHandled();
+  if (action === "review_auto_handled") reviewAutoHandledDetails();
+  if (action === "save_session") saveReviewSession(true);
+  if (action === "generate_feedback") generateFeedbackJson();
+  if (action === "download_feedback") downloadFeedbackJson();
+  if (action === "copy_feedback") copyFeedbackJson().catch(() => setExportStatus("Copy failed. Select the JSON text and copy manually."));
+  if (action === "clear_saved_review") clearSavedSession();
 }
 
 function acceptAllAutoHandled() {
@@ -1069,7 +1290,9 @@ function acceptAllAutoHandled() {
 }
 
 function reviewAutoHandledDetails() {
-  document.getElementById("auto-handled")?.querySelector("details")?.setAttribute("open", "open");
+  const target = document.getElementById("auto-handled");
+  target?.classList.add("review-details");
+  target?.querySelectorAll("details").forEach((details) => details.setAttribute("open", "open"));
 }
 
 function wireReviewProgressHandlers() {
@@ -1138,6 +1361,9 @@ function generateFeedbackJson() {
     follow_up_required_count: records.filter((record) => record.follow_up_required).length,
     publish_readiness_enabled: false,
     publication_approved: false,
+    single_active_action_workflow_version: SINGLE_ACTIVE_ACTION_WORKFLOW_VERSION,
+    active_primary_action: state.guidedWorkflow.active_primary_action,
+    output_step_complete: Boolean(state.guidedWorkflow.output_step_complete),
     guided_workflow_status: { ...state.guidedWorkflow },
     completed_steps: [...state.guidedWorkflow.completed_steps],
     internal_review_complete: false,
@@ -1151,12 +1377,17 @@ function generateFeedbackJson() {
     safety_flags: { ...SAFETY_FLAGS },
   };
   state.guidedWorkflow.feedback_generated = true;
-  state.guidedWorkflow.outputs_ready = true;
+  state.guidedWorkflow.outputs_ready = false;
+  state.guidedWorkflow.output_step_complete = false;
+  state.guidedWorkflow.output_downloaded = false;
   setCompleted("generate_feedback", true);
-  setCompleted("download_copy", true);
+  setCompleted("download_copy", false);
+  reconcileGuidedWorkflow();
   report.guided_workflow_status = { ...state.guidedWorkflow };
   report.completed_steps = [...state.guidedWorkflow.completed_steps];
-  report.internal_review_complete = true;
+  report.active_primary_action = state.guidedWorkflow.active_primary_action;
+  report.output_step_complete = Boolean(state.guidedWorkflow.output_step_complete);
+  report.internal_review_complete = false;
   state.feedbackJson = JSON.stringify(report, null, 2);
   document.getElementById("feedback-output").value = state.feedbackJson;
   setFeedbackButtonsEnabled(true);
@@ -1180,6 +1411,23 @@ function downloadFeedbackJson() {
   link.download = "dysonx_owner_review_feedback_console.json";
   link.click();
   URL.revokeObjectURL(url);
+  state.guidedWorkflow.output_downloaded = true;
+  state.guidedWorkflow.outputs_ready = true;
+  state.guidedWorkflow.output_step_complete = true;
+  setCompleted("download_copy", true);
+  state.feedbackJson = JSON.stringify({
+    ...JSON.parse(state.feedbackJson),
+    guided_workflow_status: { ...state.guidedWorkflow },
+    completed_steps: [...state.guidedWorkflow.completed_steps],
+    active_primary_action: state.guidedWorkflow.active_primary_action,
+    output_step_complete: true,
+    internal_review_complete: true,
+    publication_approved: false,
+  }, null, 2);
+  document.getElementById("feedback-output").value = state.feedbackJson;
+  saveReviewSession(false, false);
+  setExportStatus("Owner Feedback JSON downloaded. Internal review complete; no publication occurred.");
+  renderGuidedWorkflow();
 }
 
 document.getElementById("load-fixture").addEventListener("click", () => {
@@ -1191,21 +1439,15 @@ document.getElementById("brief-file").addEventListener("change", (event) => {
   if (file) loadFile(file);
 });
 
-document.getElementById("generate-feedback").addEventListener("click", generateFeedbackJson);
-document.getElementById("generate-feedback-top").addEventListener("click", generateFeedbackJson);
-document.getElementById("generate-feedback-sticky").addEventListener("click", generateFeedbackJson);
-document.getElementById("save-session").addEventListener("click", () => saveReviewSession(true));
+document.getElementById("active-primary-action").addEventListener("click", (event) => runActiveTaskAction(event.currentTarget.dataset.action));
+document.getElementById("active-secondary-action").addEventListener("click", (event) => runActiveTaskAction(event.currentTarget.dataset.action));
 document.getElementById("load-session").addEventListener("click", loadSavedSession);
 document.getElementById("clear-session").addEventListener("click", clearSavedSession);
 document.getElementById("download-session").addEventListener("click", downloadSessionJson);
 document.getElementById("accept-auto-handled").addEventListener("click", acceptAllAutoHandled);
 document.getElementById("review-auto-handled-details").addEventListener("click", reviewAutoHandledDetails);
 document.getElementById("download-feedback").addEventListener("click", downloadFeedbackJson);
-document.getElementById("download-feedback-sticky").addEventListener("click", downloadFeedbackJson);
 document.getElementById("copy-feedback").addEventListener("click", () => {
-  copyFeedbackJson().catch(() => setExportStatus("Copy failed. Select the JSON text and copy manually."));
-});
-document.getElementById("copy-feedback-sticky").addEventListener("click", () => {
   copyFeedbackJson().catch(() => setExportStatus("Copy failed. Select the JSON text and copy manually."));
 });
 

--- a/internal/dysonx-owner-intelligence-preview/index.html
+++ b/internal/dysonx-owner-intelligence-preview/index.html
@@ -17,6 +17,7 @@
       <span>Not publish-ready</span>
       <span>No public publishing</span>
       <span>Saved review session is not publication approval</span>
+      <span>Completed single-action review is not publication approval</span>
       <span>No deployment triggered by this page</span>
       <span>No OpenAI call from this page</span>
       <span>No KG writes</span>
@@ -32,13 +33,24 @@
         <p id="overall-recommendation">Load the local brief fixture to review today’s owner queue.</p>
         <div class="quick-actions">
           <a href="#queue-heading">Review decisions</a>
-          <button id="generate-feedback-top" type="button">Generate Feedback JSON</button>
         </div>
       </div>
       <div id="work-summary" class="work-summary" aria-label="Owner Work Summary"></div>
     </section>
 
     <section class="panel session-panel" aria-labelledby="session-heading">
+      <section id="owner-active-task" class="owner-active-task" aria-labelledby="active-task-title">
+        <div>
+          <p id="active-task-step" class="eyebrow">Step 1 of 5</p>
+          <h2 id="active-task-title">Review attention item</h2>
+          <p id="active-task-instruction">Accept the system decision or override it, then mark this item done.</p>
+          <p id="active-task-progress" class="active-task-progress">Attention item 1 of 1</p>
+        </div>
+        <div class="active-task-actions">
+          <button id="active-primary-action" class="primary-action" type="button" data-primary-action="true">Accept system decision and mark done</button>
+          <button id="active-secondary-action" class="secondary-action" type="button" hidden>Override decision</button>
+        </div>
+      </section>
       <div class="workflow-shell" aria-label="Guided review workflow">
         <ol id="workflow-stepper" class="workflow-stepper" aria-label="Workflow stepper"></ol>
         <div id="current-action-banner" class="current-action-banner" role="status">
@@ -50,13 +62,7 @@
         <div>
           <p class="eyebrow">Review Session Save</p>
           <h2 id="session-heading">Review Session Save</h2>
-          <p>Follow the guided workflow, then save local browser review state. A saved review session is not publication approval.</p>
-        </div>
-        <div class="button-row">
-          <button id="save-session" type="button">Save Review Session</button>
-          <button id="load-session" type="button">Load Saved Session</button>
-          <button id="clear-session" type="button">Clear Saved Session</button>
-          <button id="download-session" type="button" disabled>Download Session JSON</button>
+          <p id="session-gate-message">Save unlocks after attention and auto-handled steps are complete.</p>
         </div>
       </div>
       <div id="review-session-card" class="workflow-card">
@@ -68,6 +74,11 @@
           <div><dt>Publication approval</dt><dd>No</dd></div>
           <div><dt>Next required action</dt><dd id="next-required-action">Review the highlighted Signal.</dd></div>
         </dl>
+        <div class="secondary-controls" aria-label="Secondary review session controls">
+          <button id="load-session" class="secondary-action" type="button">Load Saved Session</button>
+          <button id="clear-session" class="danger-secondary-action" type="button">Reset local test state</button>
+          <button id="download-session" class="secondary-action" type="button" disabled>Download Review Session JSON</button>
+        </div>
       </div>
       <p id="session-status" class="status-text" role="status">No saved local review session loaded yet.</p>
     </section>
@@ -119,7 +130,6 @@
           <span>Needs Owner attention: 0</span>
           <span>Total Signals: 0</span>
         </div>
-        <button id="generate-feedback" type="button">Generate Feedback JSON</button>
       </div>
       <section class="queue-group" aria-labelledby="needs-owner-attention-heading">
         <h3 id="needs-owner-attention-heading">Needs Owner Attention</h3>
@@ -148,27 +158,16 @@
       <div id="blocked-low-value" class="compact-list"></div>
     </section>
 
-    <aside class="export-action-bar" aria-label="Feedback export actions">
-      <div id="export-action-summary" class="export-action-summary">
-        <span>System-decided: 0</span>
-        <span>Owner-overridden: 0</span>
-        <span>Needs Owner attention: 0</span>
-      </div>
-      <button id="generate-feedback-sticky" type="button">Generate Feedback JSON</button>
-      <button id="copy-feedback-sticky" type="button" disabled>Copy JSON</button>
-      <button id="download-feedback-sticky" type="button" disabled>Download JSON</button>
-    </aside>
-
     <section class="panel export-panel" aria-labelledby="export-heading">
       <div class="section-heading action-heading">
         <div>
           <p class="eyebrow">Export</p>
           <h2 id="export-heading">Owner Feedback JSON</h2>
-          <p>This is structured internal feedback. It is not publishing approval.</p>
+          <p id="feedback-gate-message">Feedback unlocks after session save.</p>
         </div>
-        <div class="button-row">
-          <button id="copy-feedback" type="button" disabled>Copy JSON</button>
-          <button id="download-feedback" type="button" disabled>Download JSON</button>
+        <div id="output-controls" class="button-row secondary-controls">
+          <button id="copy-feedback" class="secondary-action" type="button" disabled>Copy Feedback JSON</button>
+          <button id="download-feedback" class="secondary-action" type="button" disabled>Download Owner Feedback JSON</button>
         </div>
       </div>
       <textarea id="feedback-output" readonly spellcheck="false" aria-label="Generated owner feedback JSON"></textarea>

--- a/internal/dysonx-owner-intelligence-preview/styles.css
+++ b/internal/dysonx-owner-intelligence-preview/styles.css
@@ -55,8 +55,30 @@ button:focus {
 }
 
 button:disabled {
-  background: #94a3b8;
+  background: #e2e8f0;
+  color: #64748b;
   cursor: not-allowed;
+}
+
+.secondary-action,
+.danger-secondary-action {
+  background: #ffffff;
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+
+.secondary-action:hover,
+.secondary-action:focus {
+  background: #f8fafc;
+}
+
+.danger-secondary-action {
+  color: #7f1d1d;
+}
+
+.danger-secondary-action:hover,
+.danger-secondary-action:focus {
+  background: #fef2f2;
 }
 
 .topbar {
@@ -209,6 +231,51 @@ h3 {
   gap: 10px;
 }
 
+.owner-active-task {
+  align-items: center;
+  background: #0f2f35;
+  border: 1px solid #0f766e;
+  border-radius: 10px;
+  color: #ffffff;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 0.34fr);
+  padding: 18px;
+}
+
+.owner-active-task .eyebrow,
+.owner-active-task p {
+  color: #d5f7f1;
+}
+
+.owner-active-task h2 {
+  font-size: 1.38rem;
+  margin-bottom: 8px;
+}
+
+.active-task-progress {
+  font-weight: 800;
+  margin-bottom: 0;
+}
+
+.active-task-actions {
+  display: grid;
+  gap: 10px;
+}
+
+.primary-action[data-primary-action="true"] {
+  background: #f8fafc;
+  color: #0f2f35;
+  font-size: 1rem;
+  min-height: 52px;
+  width: 100%;
+}
+
+.primary-action[data-primary-action="true"]:hover,
+.primary-action[data-primary-action="true"]:focus {
+  background: #ccfbf1;
+}
+
 .workflow-shell,
 .workflow-card,
 .auto-handled-panel,
@@ -219,6 +286,12 @@ h3 {
   gap: 12px;
   min-width: 0;
   padding: 12px;
+}
+
+.workflow-shell {
+  background: #f8fafc;
+  font-size: 0.9rem;
+  opacity: 0.9;
 }
 
 .workflow-stepper {
@@ -250,11 +323,13 @@ h3 {
   background: #eefdf3;
   border-color: #86efac;
   color: #14532d;
+  opacity: 0.72;
 }
 
 .workflow-step.locked {
   background: #f1f5f9;
   color: #64748b;
+  opacity: 0.72;
 }
 
 .step-marker,
@@ -291,6 +366,13 @@ h3 {
 .auto-handled-panel.complete {
   background: #eefdf3;
   border-color: #86efac;
+}
+
+.secondary-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
 }
 
 .session-facts,
@@ -339,7 +421,8 @@ h3 {
 
 .score-card span {
   color: var(--muted);
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
 .work-summary {
@@ -461,11 +544,12 @@ a {
 
 .review-card.completed-attention-item {
   background: #f8fafc;
-  opacity: 0.82;
+  opacity: 0.72;
 }
 
 .review-card.future-attention-item {
-  background: #fbfdff;
+  background: #f8fafc;
+  opacity: 0.72;
 }
 
 .compact-signal-card {
@@ -508,6 +592,55 @@ a {
 .guided-card-status.auto-handled {
   background: #e2e8f0;
   color: #334155;
+}
+
+.collapsed-card-summary {
+  align-items: center;
+  background: #f8fafc;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: none;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px;
+}
+
+.collapsed-card-summary span {
+  min-width: 0;
+  overflow-wrap: break-word;
+}
+
+.locked-note {
+  color: var(--muted);
+  font-weight: 800;
+}
+
+.review-card.completed-attention-item > :not(.queue-rank):not(.guided-card-status):not(.completed-summary) {
+  display: none;
+}
+
+.review-card.future-attention-item > :not(.queue-rank):not(.guided-card-status):not(.future-summary) {
+  display: none;
+}
+
+.review-card.completed-attention-item .completed-summary,
+.review-card.future-attention-item .future-summary {
+  display: flex;
+}
+
+.review-card:not(.active-attention-item) .guided-card-actions,
+.review-card:not(.active-attention-item) .review-controls,
+.review-card:not(.active-attention-item) .signal-details {
+  display: none;
+}
+
+#auto-handled.review-details .signal-details {
+  display: block;
+}
+
+.review-card.active-attention-item .future-summary,
+.review-card.active-attention-item .completed-summary {
+  display: none;
 }
 
 .system-default {
@@ -588,38 +721,6 @@ a {
   font-weight: 800;
 }
 
-.export-action-bar {
-  align-items: center;
-  background: #f8fafc;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  bottom: 10px;
-  box-shadow: var(--shadow);
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: space-between;
-  padding: 10px;
-  position: sticky;
-  z-index: 10;
-}
-
-.export-action-summary {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.export-action-summary span {
-  background: #ffffff;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  color: var(--ink);
-  font-size: 0.82rem;
-  font-weight: 800;
-  padding: 5px 8px;
-}
-
 .button-row,
 .control-row {
   align-items: center;
@@ -698,6 +799,7 @@ a {
   .topbar,
   .cockpit,
   .product-grid,
+  .owner-active-task,
   .controls-panel,
   .section-heading,
   .action-heading {
@@ -726,14 +828,25 @@ a {
   .score-cards,
   .work-summary,
   .review-controls,
-  .workflow-stepper,
   .session-facts,
   .completion-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .export-action-bar {
-    position: static;
+  .workflow-stepper {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .owner-active-task {
+    padding: 14px;
+  }
+
+  .collapsed-card-summary,
+  .secondary-controls,
+  .button-row {
+    align-items: stretch;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .metadata-list {

--- a/tests/test_dysonx_minimal_internal_frontend_preview.py
+++ b/tests/test_dysonx_minimal_internal_frontend_preview.py
@@ -15,6 +15,7 @@ LAUNCH_PLAN = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_LAUNCH_PLAN.md"
 WORKFLOW_COMPRESSION_DOC = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_WORKFLOW_COMPRESSION_V2.md"
 REVIEW_SESSION_DOC = ROOT / "docs" / "DYSONX_REVIEW_SESSION_SAVE_V1.md"
 GUIDED_WORKFLOW_DOC = ROOT / "docs" / "DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md"
+SINGLE_ACTIVE_ACTION_DOC = ROOT / "docs" / "DYSONX_OWNER_SINGLE_ACTIVE_ACTION_WORKFLOW_V1.md"
 
 
 class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
@@ -166,11 +167,11 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
 
     def test_feedback_action_is_prominent_near_workflow(self):
         html = self.read_index()
+        app = self.read_app()
 
-        self.assertIn('id="generate-feedback-top"', html)
-        self.assertIn('id="generate-feedback-sticky"', html)
-        self.assertIn('id="copy-feedback-sticky"', html)
-        self.assertIn('id="download-feedback-sticky"', html)
+        self.assertIn('id="owner-active-task"', html)
+        self.assertIn('id="active-primary-action"', html)
+        self.assertIn("Generate Owner Feedback JSON", app)
         self.assertIn("Review decisions", html)
 
     def test_owner_decision_queue_cards_include_score_values(self):
@@ -311,14 +312,12 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
 
         for phrase in (
             "Review Session Save",
-            "Save Review Session",
             "Load Saved Session",
-            "Clear Saved Session",
-            "Download Session JSON",
+            "Reset local test state",
+            "Download Review Session JSON",
         ):
             self.assertIn(phrase, html)
         for element_id in (
-            'id="save-session"',
             'id="load-session"',
             'id="clear-session"',
             'id="download-session"',
@@ -353,7 +352,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
             "publication_approved",
         ):
             self.assertIn(field, app)
-        self.assertIn('const CONSOLE_VERSION = "owner_console_review_session_save_v1"', app)
+        self.assertIn('const CONSOLE_VERSION = "owner_console_single_active_action_v1"', app)
         self.assertIn("dysonx-review-", app)
 
     def test_review_session_persists_form_values(self):
@@ -421,7 +420,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("dysonx_owner_console_review_session.json", app)
         self.assertIn("function clearSavedSession()", app)
         self.assertIn("state.restoredSession = null", app)
-        self.assertIn("Clear Saved Session", self.read_index())
+        self.assertIn("Reset local test state", self.read_index())
 
     def test_guided_workflow_stepper_exists(self):
         html = self.read_index()
@@ -448,6 +447,38 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("Current action:", app)
         self.assertIn("Review this Signal or accept the system decision.", app)
 
+    def test_single_active_task_header_exists(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertIn('id="owner-active-task"', html)
+        self.assertIn('id="active-task-step"', html)
+        self.assertIn('id="active-task-title"', html)
+        self.assertIn('id="active-task-instruction"', html)
+        self.assertIn('id="active-task-progress"', html)
+        self.assertIn("Step 1 of 5", html)
+        self.assertIn("function activeTaskModel()", app)
+
+    def test_exactly_one_primary_action_marker_exists(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertEqual(html.count('data-primary-action="true"'), 1)
+        self.assertIn('primary.dataset.primaryAction = "true"', app)
+        self.assertIn("active_primary_action", app)
+
+    def test_active_task_primary_action_variants_exist(self):
+        app = self.read_app()
+
+        for phrase in (
+            "Accept system decision and mark done",
+            "Save review session locally",
+            "Generate Owner Feedback JSON",
+            "Download Owner Feedback JSON",
+            "Start new review / clear saved review",
+        ):
+            self.assertIn(phrase, app)
+
     def test_attention_item_guided_states_exist(self):
         app = self.read_app()
 
@@ -462,7 +493,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         app = self.read_app()
 
         for phrase in (
-            "Accept system decision",
+            "Accept system decision and mark done",
             "Override decision",
             "Mark done",
             "accept-system-decision",
@@ -473,6 +504,23 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("function acceptSystemDecision", app)
         self.assertIn("function overrideDecision", app)
         self.assertIn("function markAttentionDone", app)
+
+    def test_attention_cards_collapse_when_not_active(self):
+        app = self.read_app()
+        styles = STYLES.read_text(encoding="utf-8")
+
+        for phrase in (
+            "completed-summary",
+            "future-summary",
+            "Selected decision:",
+            "System suggested decision:",
+            "Locked until previous item complete",
+            "edit-completed-card",
+        ):
+            self.assertIn(phrase, app)
+        self.assertIn(".review-card.completed-attention-item", styles)
+        self.assertIn(".review-card.future-attention-item", styles)
+        self.assertIn("display: none", styles)
 
     def test_auto_handled_confirmation_step_exists(self):
         html = self.read_index()
@@ -486,10 +534,11 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
 
     def test_workflow_gates_later_actions(self):
         app = self.read_app()
+        html = self.read_index()
 
-        self.assertIn('setButtonsDisabled(["save-session"], !saveReady)', app)
-        self.assertIn('setButtonsDisabled(["generate-feedback", "generate-feedback-top", "generate-feedback-sticky"], !feedbackReady)', app)
-        self.assertIn('setButtonsDisabled(["copy-feedback", "copy-feedback-sticky", "download-feedback", "download-feedback-sticky"], !outputsReady)', app)
+        self.assertIn("Save unlocks after attention and auto-handled steps are complete.", html)
+        self.assertIn("Feedback unlocks after session save.", html)
+        self.assertIn('setButtonsDisabled(["copy-feedback", "download-feedback"], !outputsReady)', app)
         self.assertIn('state.guidedWorkflow.active_step === "save_session"', app)
         self.assertIn('completedSteps().has("save_session")', app)
         self.assertIn('completedSteps().has("generate_feedback")', app)
@@ -506,6 +555,11 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
             "session_saved",
             "feedback_generated",
             "outputs_ready",
+            "active_attention_index",
+            "override_mode_for_active_item",
+            "output_downloaded",
+            "output_step_complete",
+            "active_primary_action",
         ):
             self.assertIn(field, app)
         self.assertIn("localStorage.setItem(REVIEW_SESSION_STORAGE_KEY", app)
@@ -526,7 +580,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("Completed internal review. No public publishing occurred.", html)
         self.assertIn("Next future stage", html)
         self.assertIn("Publish Readiness Gate V1", html)
-        self.assertIn("completion.hidden = !completedSteps().has(\"generate_feedback\")", app)
+        self.assertIn("completion.hidden = !completedSteps().has(\"download_copy\")", app)
 
     def test_feedback_json_includes_guided_workflow_status(self):
         app = self.read_app()
@@ -534,16 +588,37 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertIn("guided_workflow_status", app)
         self.assertIn("completed_steps", app)
         self.assertIn("internal_review_complete", app)
+        self.assertIn("single_active_action_workflow_version", app)
+        self.assertIn("active_primary_action", app)
+        self.assertIn("output_step_complete", app)
         self.assertIn("publication_approved: false", app)
 
     def test_raw_json_stays_below_guided_workflow(self):
         html = self.read_index()
 
-        workflow_index = html.index('id="workflow-stepper"')
+        workflow_index = html.index('id="owner-active-task"')
         output_index = html.index('id="feedback-output"')
         self.assertLess(workflow_index, output_index)
         self.assertIn("Brief source and technical details", html)
         self.assertIn("<details", html)
+
+    def test_no_duplicate_primary_export_clusters_exist(self):
+        html = self.read_index()
+        app = self.read_app()
+
+        self.assertNotIn("generate-feedback-top", html)
+        self.assertNotIn("generate-feedback-sticky", html)
+        self.assertNotIn("export-action-bar", html)
+        self.assertIn("Generate Owner Feedback JSON", app)
+        self.assertEqual(html.count('data-primary-action="true"'), 1)
+
+    def test_responsive_css_avoids_obvious_metric_wrapping(self):
+        styles = STYLES.read_text(encoding="utf-8")
+
+        self.assertIn("word-break: normal", styles)
+        self.assertIn("overflow-wrap: break-word", styles)
+        self.assertIn(".owner-active-task", styles)
+        self.assertIn("grid-template-columns: repeat(2, minmax(0, 1fr))", styles)
 
     def test_guided_workflow_documentation_exists(self):
         doc = GUIDED_WORKFLOW_DOC.read_text(encoding="utf-8")
@@ -563,6 +638,33 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
             "If Owner can complete a review without external explanation, proceed to Publish Readiness Gate V1.",
         ):
             self.assertIn(phrase, doc)
+
+    def test_single_active_action_documentation_exists(self):
+        doc = SINGLE_ACTIVE_ACTION_DOC.read_text(encoding="utf-8")
+
+        for phrase in (
+            "Why The Previous Guided Workflow Still Failed",
+            "Single Active Action Rule",
+            "Active Task Header",
+            "One Primary Action Rule",
+            "Collapsed Completed Cards",
+            "Collapsed Future Cards",
+            "Auto-Handled Confirmation Behavior",
+            "Save / Feedback / Output Gating",
+            "Final Completion State",
+            "Responsive Usability Requirement",
+            "active_primary_action",
+            "If Owner can complete internal review without asking what to click next, proceed to Publish Readiness Gate V1.",
+        ):
+            self.assertIn(phrase, doc)
+
+    def test_existing_docs_reference_single_active_action_constraints(self):
+        guided = GUIDED_WORKFLOW_DOC.read_text(encoding="utf-8")
+        review_session = REVIEW_SESSION_DOC.read_text(encoding="utf-8")
+
+        self.assertIn("single active action console", guided)
+        self.assertIn("unexplained disabled buttons are product failures", guided)
+        self.assertIn("must not appear as an unstructured button cluster", review_session)
 
     def test_saved_review_session_safety_text_is_present(self):
         html = self.read_index()
@@ -599,6 +701,7 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
             + WORKFLOW_COMPRESSION_DOC.read_text(encoding="utf-8")
             + REVIEW_SESSION_DOC.read_text(encoding="utf-8")
             + GUIDED_WORKFLOW_DOC.read_text(encoding="utf-8")
+            + SINGLE_ACTIVE_ACTION_DOC.read_text(encoding="utf-8")
         )
 
         self.assertIn("does not require `OPENAI_API_KEY`", combined)


### PR DESCRIPTION
## Summary

- Fixes Owner usability failure where multiple controls, highlights, expanded cards, and export areas made the workflow unclear.
- Adds an Active Task Header that exposes exactly one primary action at a time.
- Collapses completed attention cards and future attention cards so only the active card is expanded.
- Collapses auto-handled items until their step and makes details review secondary.
- Gates save, feedback, and output actions with explanatory locked text instead of competing disabled controls.
- Removes duplicate competing export controls and keeps one output area.
- Persists single active action workflow state in the existing localStorage review session.
- Improves responsive readability for the active task panel, stepper, metric cards, and collapsed summaries.
- Preserves feedback JSON safety fields and keeps publication_approved false.

## Safety boundary

This does not implement backend APIs, database storage, server persistence, Publish Readiness Gate, public publishing, public website generation, OpenAI calls, workflow dispatch, deployment, Knowledge Graph writes, Prediction Engine work, Confidence Calibration, Multi-source Correlation, or production changes.

## Validation

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- git diff --check origin/main...HEAD
- Local route HTTP 200 on port 8092: /internal/dysonx-owner-intelligence-preview/?v=single-active-action-v1

No production deployment was performed.