### PR TITLE
feat: add DysonX Owner Review Wizard V1

### DIFF
--- a/docs/DYSONX_OWNER_REVIEW_WIZARD_V1.md
+++ b/docs/DYSONX_OWNER_REVIEW_WIZARD_V1.md
@@ -1,0 +1,175 @@
+# DysonX Owner Review Wizard V1
+
+## 1. Why Previous Owner Console Attempts Failed
+
+Previous Owner Console iterations exposed the right controls but still required the Owner to infer the workflow. The Owner could complete steps by clicking around without understanding the sequence, which is a product failure.
+
+The failure was interaction design, not missing backend logic.
+
+## 2. Why Wizard Mode Is Required
+
+Wizard mode is required because the Owner review path must behave as one screen, one task, and one primary action. The Owner should not see dense console panels, raw JSON, expanded completed cards, or competing export controls during review.
+
+The advanced console may remain available for inspection, but the primary Owner acceptance path is the wizard.
+
+## 3. One Screen / One Task / One Primary Action Rule
+
+Every wizard screen has exactly one primary action. Secondary actions are visually weaker and support the current task only.
+
+The screen must answer:
+
+- what to do now
+- what will happen after clicking
+- what did not happen, especially publication
+
+## 4. Wizard Screens
+
+The V1 flow is:
+
+1. Start or resume.
+2. Review attention item 1.
+3. Review attention item 2.
+4. Accept system-handled Signals.
+5. Save internal review.
+6. Generate Owner Feedback JSON.
+7. Download outputs.
+8. Complete.
+
+The progress indicator is passive and not clickable.
+
+## 5. Attention Item Review
+
+The Owner sees one attention Signal at a time. Each attention screen shows only the Signal title, short why-it-matters text, system recommendation, score / tier, risk summary, and missing fields.
+
+The primary path is to accept the system recommendation. The Owner may change the decision, add a priority, comment, and follow-up fields, or skip for later.
+
+Skipped attention items remain internal review records. They default to the system decision, set follow-up required, and do not approve publication.
+
+## 6. Auto-Handled Confirmation
+
+The system-handled screen summarizes Signals already handled by deterministic automation, such as hold, regeneration, and rejection.
+
+The Owner is not expected to inspect every auto-handled Signal. The primary action accepts system-handled Signals in one step, while details remain compact and optional.
+
+## 7. Save / Generate / Download Flow
+
+The wizard separates durable review capture from output generation:
+
+- Save Internal Review records the browser-local review state.
+- Generate Owner Feedback JSON creates the internal downstream artifact.
+- Download Owner Feedback JSON exports the primary output.
+
+Raw JSON is not shown inside the main wizard flow.
+
+## 8. Local Persistence
+
+The wizard uses the localStorage key:
+
+```text
+dysonx.ownerReviewWizard.v1
+```
+
+It persists:
+
+- `wizard_session_id`
+- `current_screen`
+- `attention_index`
+- `attention_item_statuses`
+- `selected_owner_decisions`
+- `priority_values`
+- `owner_comments`
+- `follow_up_required`
+- `follow_up_notes`
+- `owner_overridden`
+- `auto_handled_accepted`
+- `internal_review_saved`
+- `feedback_generated`
+- `feedback_downloaded`
+- `session_created_at`
+- `session_updated_at`
+
+Starting a new review clears only this wizard key.
+
+## 9. Feedback JSON
+
+Owner Feedback JSON includes:
+
+- `wizard_session_id`
+- `owner_review_wizard_version: "v1"`
+- `internal_review_complete`
+- `auto_handled_accepted`
+- `records`
+- `publication_approved: false`
+- `auto_decision_is_not_publication_approval: true`
+- `owner_feedback_is_not_publication_approval: true`
+- `review_session_is_not_publication_approval: true`
+- `wizard_review_is_not_publication_approval: true`
+
+Each record preserves system defaults, selected Owner decision, override status, priority, comments, follow-up fields, skipped status when applicable, and publish-readiness candidate markers.
+
+## 10. Safety Boundaries
+
+The wizard is local browser review only.
+
+It does not implement:
+
+- Publish Readiness Gate
+- public publishing
+- automatic publishing
+- public website generation
+- backend API
+- database
+- server persistence
+- OpenAI call
+- workflow dispatch
+- deployment
+- production changes
+- Knowledge Graph writes
+- Prediction Engine
+- Confidence Calibration
+- Multi-source Correlation
+
+Saved wizard review is not publication approval. `publication_approved` remains `false`.
+
+## 11. Non-Goals
+
+This document and PR do not authorize public output, server persistence, backend API work, publish-readiness implementation, public page generation, automation dispatch, OpenAI calls, deployment, or production changes.
+
+## 12. How To Run Locally
+
+From the repository root:
+
+```bash
+python3 -m http.server 8093
+```
+
+Open:
+
+```text
+http://127.0.0.1:8093/internal/dysonx-owner-review-wizard/?v=owner-review-wizard-v1
+```
+
+Use a private browser window or clear `dysonx.ownerReviewWizard.v1` to test a clean first-run state.
+
+## 13. Owner Acceptance Criteria
+
+The wizard is acceptable only if the Owner can complete review without asking what to click next.
+
+Acceptance requires:
+
+- one current screen
+- one current task
+- one primary action
+- no raw JSON in the review path
+- no completed-step controls
+- no future-step controls
+- no public publishing implication
+- clear completion state
+
+## 14. Recommended Next Step
+
+Owner tests the Wizard.
+
+If Owner can complete the review without asking what to click next, then merge Wizard and proceed to Publish Readiness Gate V1.
+
+If not, keep fixing Wizard.

--- a/docs/DYSONX_OWNER_USABILITY_GOVERNANCE.md
+++ b/docs/DYSONX_OWNER_USABILITY_GOVERNANCE.md
@@ -188,6 +188,8 @@ All future prompts must also include the Strategic Priority -- Minimal Usable Ow
 
 Future prompts must preserve the automation and publication strategy: maximize safe automation, minimize unnecessary Owner review, avoid blocking all progress on pending Owner review, and keep Publish Readiness Gate mandatory before any publication.
 
+For Owner-facing review flows, Wizard mode is preferred over dense console mode. Owner workflows must follow one screen / one task / one primary action.
+
 ## 13. Explicit Non-Goals
 
 This governance does not authorize:

--- a/internal/dysonx-owner-review-wizard/app.js
+++ b/internal/dysonx-owner-review-wizard/app.js
@@ -1,0 +1,789 @@
+const WIZARD_STORAGE_KEY = "dysonx.ownerReviewWizard.v1";
+const WIZARD_VERSION = "v1";
+const FIXTURE_URL = "../dysonx-owner-intelligence-preview/brief_fixture.json";
+
+const SCREEN_START = "start";
+const SCREEN_ATTENTION = "attention";
+const SCREEN_AUTO_HANDLED = "auto_handled";
+const SCREEN_SAVE = "save_review";
+const SCREEN_GENERATE = "generate_feedback";
+const SCREEN_DOWNLOAD = "download_outputs";
+const SCREEN_COMPLETE = "complete";
+
+const OWNER_DECISIONS = [
+  { value: "approve_for_future_publish_readiness_review", label: "Approve for later readiness review" },
+  { value: "request_more_sources", label: "Request more sources" },
+  { value: "request_regeneration", label: "Request regeneration" },
+  { value: "hold", label: "Hold" },
+  { value: "reject", label: "Reject" },
+];
+
+const PRIORITIES = ["high", "medium", "low"];
+
+const AUTO_DECISION_DEFAULTS = {
+  auto_reject: "reject",
+  needs_more_sources: "request_more_sources",
+  needs_regeneration: "request_regeneration",
+  hold: "hold",
+  candidate_for_publish_readiness_review: "approve_for_future_publish_readiness_review",
+};
+
+const state = {
+  brief: null,
+  savedSession: null,
+  session: null,
+  changeMode: false,
+  showHandledDetails: false,
+};
+
+const screen = document.getElementById("wizard-screen");
+const progress = document.getElementById("wizard-progress");
+
+function createSession() {
+  const now = new Date().toISOString();
+  return {
+    wizard_session_id: `dysonx-wizard-${timestampId(now)}`,
+    current_screen: SCREEN_START,
+    attention_index: 0,
+    attention_item_statuses: {},
+    selected_owner_decisions: {},
+    priority_values: {},
+    owner_comments: {},
+    follow_up_required: {},
+    follow_up_notes: {},
+    owner_overridden: {},
+    auto_handled_accepted: false,
+    internal_review_saved: false,
+    feedback_generated: false,
+    feedback_downloaded: false,
+    feedback_json: null,
+    session_created_at: now,
+    session_updated_at: now,
+  };
+}
+
+function timestampId(value) {
+  return value.replace(/[-:]/g, "").replace(/\..+$/, "").replace("T", "-");
+}
+
+function saveSession() {
+  if (!state.session) return;
+  state.session.session_updated_at = new Date().toISOString();
+  localStorage.setItem(WIZARD_STORAGE_KEY, JSON.stringify(state.session));
+}
+
+function readSavedSession() {
+  try {
+    const raw = localStorage.getItem(WIZARD_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function clearWizardSession() {
+  localStorage.removeItem(WIZARD_STORAGE_KEY);
+  state.savedSession = null;
+  state.session = createSession();
+  state.changeMode = false;
+  state.showHandledDetails = false;
+  render();
+}
+
+function startReview(clearExisting = false) {
+  if (clearExisting) {
+    localStorage.removeItem(WIZARD_STORAGE_KEY);
+  }
+  state.session = createSession();
+  state.session.current_screen = SCREEN_ATTENTION;
+  state.session.attention_index = 0;
+  initializeDefaults();
+  saveSession();
+  render();
+}
+
+function resumeSavedReview() {
+  state.session = normalizeSession(state.savedSession || createSession());
+  state.savedSession = null;
+  state.changeMode = false;
+  state.showHandledDetails = false;
+  initializeDefaults();
+  render();
+}
+
+function normalizeSession(session) {
+  return {
+    ...createSession(),
+    ...session,
+    attention_item_statuses: session.attention_item_statuses || {},
+    selected_owner_decisions: session.selected_owner_decisions || {},
+    priority_values: session.priority_values || {},
+    owner_comments: session.owner_comments || {},
+    follow_up_required: session.follow_up_required || {},
+    follow_up_notes: session.follow_up_notes || {},
+    owner_overridden: session.owner_overridden || {},
+  };
+}
+
+function initializeDefaults() {
+  if (!state.brief || !state.session) return;
+  allSignals().forEach((signal) => {
+    const id = signal.signal_id;
+    const defaultDecision = systemDefaultDecision(signal);
+    if (!state.session.selected_owner_decisions[id]) {
+      state.session.selected_owner_decisions[id] = defaultDecision;
+    }
+    if (!state.session.priority_values[id]) {
+      state.session.priority_values[id] = isAttentionSignal(signal) ? "high" : "medium";
+    }
+    if (state.session.owner_comments[id] === undefined) {
+      state.session.owner_comments[id] = "";
+    }
+    if (state.session.follow_up_required[id] === undefined) {
+      state.session.follow_up_required[id] = false;
+    }
+    if (state.session.follow_up_notes[id] === undefined) {
+      state.session.follow_up_notes[id] = "";
+    }
+    state.session.owner_overridden[id] = state.session.selected_owner_decisions[id] !== defaultDecision;
+  });
+}
+
+function allSignals() {
+  return [
+    ...(state.brief?.decision_grade_candidates || []),
+    ...(state.brief?.useful_review_queue || []),
+    ...(state.brief?.blocked_or_low_value || []),
+  ];
+}
+
+function attentionSignals() {
+  return allSignals().filter(isAttentionSignal).slice(0, 2);
+}
+
+function autoHandledSignals() {
+  const attentionIds = new Set(attentionSignals().map((signal) => signal.signal_id));
+  return allSignals().filter((signal) => !attentionIds.has(signal.signal_id));
+}
+
+function isAttentionSignal(signal) {
+  return ["candidate_for_publish_readiness_review", "needs_more_sources"].includes(signal.auto_decision);
+}
+
+function systemDefaultDecision(signal) {
+  return AUTO_DECISION_DEFAULTS[signal.auto_decision] || "hold";
+}
+
+function decisionLabel(value) {
+  return OWNER_DECISIONS.find((item) => item.value === value)?.label || value;
+}
+
+function screenSteps() {
+  return [
+    { id: SCREEN_START, label: "Start" },
+    { id: SCREEN_ATTENTION, label: "Attention" },
+    { id: SCREEN_AUTO_HANDLED, label: "System-handled" },
+    { id: SCREEN_SAVE, label: "Save" },
+    { id: SCREEN_GENERATE, label: "Generate" },
+    { id: SCREEN_DOWNLOAD, label: "Download" },
+    { id: SCREEN_COMPLETE, label: "Complete" },
+  ];
+}
+
+function renderProgress() {
+  const current = state.session?.current_screen || SCREEN_START;
+  const currentIndex = screenSteps().findIndex((step) => step.id === current);
+  progress.innerHTML = "";
+  screenSteps().forEach((step, index) => {
+    const item = document.createElement("div");
+    item.className = "progress-step";
+    if (index < currentIndex) item.classList.add("complete");
+    if (step.id === current) item.classList.add("current");
+    item.textContent = index < currentIndex ? `✓ ${step.label}` : step.label;
+    progress.appendChild(item);
+  });
+}
+
+function render() {
+  if (!state.brief) {
+    screen.innerHTML = `<p class="error">Unable to load Owner Review Wizard fixture.</p>`;
+    return;
+  }
+  if (!state.session) {
+    state.savedSession = readSavedSession();
+    state.session = createSession();
+  }
+  renderProgress();
+  const current = state.savedSession ? SCREEN_START : state.session.current_screen;
+  const renderers = {
+    [SCREEN_START]: renderStartScreen,
+    [SCREEN_ATTENTION]: renderAttentionScreen,
+    [SCREEN_AUTO_HANDLED]: renderAutoHandledScreen,
+    [SCREEN_SAVE]: renderSaveScreen,
+    [SCREEN_GENERATE]: renderGenerateScreen,
+    [SCREEN_DOWNLOAD]: renderDownloadScreen,
+    [SCREEN_COMPLETE]: renderCompleteScreen,
+  };
+  screen.innerHTML = "";
+  screen.appendChild((renderers[current] || renderStartScreen)());
+}
+
+function renderStartScreen() {
+  const wrapper = div("start-screen");
+  if (state.savedSession) {
+    wrapper.append(
+      kicker("Saved browser session found"),
+      heading("DysonX Owner Review Wizard"),
+      paragraph("Resume the saved local review or start a clean review. Starting new clears only this browser's saved review state.", "subtitle"),
+      buttonRow([
+        primaryButton("Resume Saved Review", resumeSavedReview),
+        secondaryButton("Start New Review", () => startReview(true)),
+      ]),
+    );
+    return wrapper;
+  }
+  wrapper.append(
+    heading("DysonX Owner Review Wizard", "h1", "wizard-title"),
+    paragraph("Review only the few Signals that need Owner attention. The system handles the rest.", "subtitle"),
+    safetyList(),
+    buttonRow([
+      primaryButton("Start Review", () => startReview(false)),
+      linkButton("Open Advanced Console", "../dysonx-owner-intelligence-preview/?v=advanced-console"),
+    ]),
+    paragraph("This will not publish anything.", "status-note"),
+  );
+  return wrapper;
+}
+
+function renderAttentionScreen() {
+  const items = attentionSignals();
+  const index = Math.min(state.session.attention_index, items.length - 1);
+  const signal = items[index];
+  if (!signal) {
+    state.session.current_screen = SCREEN_AUTO_HANDLED;
+    saveSession();
+    return renderAutoHandledScreen();
+  }
+  const wrapper = div("attention-screen");
+  wrapper.append(
+    kicker(`Review ${index + 1} of ${items.length}`),
+    heading(signal.title, "h2"),
+    paragraph("Accept the system recommendation, or change the decision if strategic judgment is needed.", "instruction"),
+    signalSummary(signal),
+  );
+
+  if (state.changeMode) {
+    wrapper.append(decisionForm(signal));
+    wrapper.append(buttonRow([
+      primaryButton("Save decision and continue", () => saveDecisionAndContinue(signal)),
+      secondaryButton("Cancel change", () => {
+        state.changeMode = false;
+        render();
+      }),
+    ]));
+  } else {
+    wrapper.append(buttonRow([
+      primaryButton("Accept system recommendation", () => acceptAttentionSignal(signal)),
+      secondaryButton("Change decision", () => {
+        state.changeMode = true;
+        render();
+      }),
+      smallButton("Skip for now", () => skipAttentionSignal(signal)),
+    ]));
+  }
+  wrapper.append(detailsFor(signal));
+  return wrapper;
+}
+
+function renderAutoHandledScreen() {
+  const handled = autoHandledSignals();
+  const counts = countAutoHandled(handled);
+  const wrapper = div("auto-handled-screen");
+  wrapper.append(
+    kicker("System-handled Signals"),
+    heading(`The system already handled ${handled.length} Signals.`, "h2"),
+    paragraph("You do not need to review these unless you disagree.", "instruction"),
+    countRow([
+      ["Hold", counts.hold],
+      ["Regenerate", counts.needs_regeneration],
+      ["Reject", counts.auto_reject],
+    ]),
+    buttonRow([
+      primaryButton("Accept system-handled Signals", acceptSystemHandledSignals),
+      secondaryButton("Review system-handled details", () => {
+        state.showHandledDetails = !state.showHandledDetails;
+        render();
+      }),
+    ]),
+  );
+  if (state.showHandledDetails) {
+    wrapper.append(handledDetails(handled));
+  }
+  return wrapper;
+}
+
+function renderSaveScreen() {
+  const overrides = ownerOverrideCount();
+  const wrapper = div("save-review-screen");
+  wrapper.append(
+    kicker("Save internal review"),
+    heading("Ready to save your internal review.", "h2"),
+    summaryGrid([
+      ["Owner attention reviewed", `${attentionDoneCount()} / ${attentionSignals().length}`],
+      ["System-handled accepted", state.session.auto_handled_accepted ? String(autoHandledSignals().length) : "0"],
+      ["Overrides", String(overrides)],
+      ["Publication approval", "No"],
+    ]),
+    buttonRow([
+      primaryButton("Save Internal Review", saveInternalReview),
+      secondaryButton("Back", () => {
+        state.session.current_screen = SCREEN_AUTO_HANDLED;
+        saveSession();
+        render();
+      }),
+    ]),
+  );
+  return wrapper;
+}
+
+function renderGenerateScreen() {
+  const wrapper = div("generate-feedback-screen");
+  wrapper.append(
+    kicker("Generate feedback"),
+    heading("Internal review saved.", "h2"),
+    paragraph("Now generate Owner Feedback JSON for downstream processing.", "instruction"),
+    buttonRow([
+      primaryButton("Generate Owner Feedback JSON", generateFeedbackAndContinue),
+      secondaryButton("Back", () => {
+        state.session.current_screen = SCREEN_SAVE;
+        saveSession();
+        render();
+      }),
+    ]),
+  );
+  return wrapper;
+}
+
+function renderDownloadScreen() {
+  const wrapper = div("download-outputs-screen");
+  wrapper.append(
+    kicker("Download outputs"),
+    heading("Feedback generated.", "h2"),
+    paragraph("These files are internal. No public publishing occurred.", "instruction"),
+    buttonRow([
+      primaryButton("Download Owner Feedback JSON", () => {
+        downloadJson("dysonx_owner_feedback_wizard_v1.json", buildFeedbackJson());
+        state.session.feedback_downloaded = true;
+        state.session.current_screen = SCREEN_COMPLETE;
+        saveSession();
+        render();
+      }),
+      secondaryButton("Download Review Session JSON", () => downloadJson("dysonx_owner_review_wizard_session_v1.json", state.session)),
+      secondaryButton("Copy Feedback JSON", copyFeedbackJson),
+    ]),
+  );
+  return wrapper;
+}
+
+function renderCompleteScreen() {
+  const wrapper = div("complete-screen");
+  wrapper.append(
+    completionPanel(),
+    safetyList(),
+    buttonRow([
+      primaryButton("Start New Review", () => startReview(true)),
+      linkButton("Open Advanced Console", "../dysonx-owner-intelligence-preview/?v=advanced-console"),
+    ]),
+  );
+  return wrapper;
+}
+
+function signalSummary(signal) {
+  const card = div("signal-card");
+  card.append(
+    paragraph(signal.why_it_matters || "No why-it-matters field available.", "two-line"),
+    metaRow([
+      ["System recommendation", signal.decision_label || systemDefaultDecision(signal)],
+      ["Score / Tier", `${signal.score ?? signal.quality_score_total} / ${signal.tier || signal.quality_tier}`],
+      ["Risk summary", signal.risk_summary || "No risk summary"],
+      ["Missing fields", signal.missing_fields?.length ? signal.missing_fields.join(", ") : "None"],
+    ]),
+  );
+  return card;
+}
+
+function decisionForm(signal) {
+  const id = signal.signal_id;
+  const form = div("decision-form");
+  form.append(
+    field("Owner decision", selectInput("owner-decision", OWNER_DECISIONS, state.session.selected_owner_decisions[id])),
+    field("Priority", selectInput("priority", PRIORITIES.map((value) => ({ value, label: value })), state.session.priority_values[id])),
+    field("Optional comment", textareaInput("owner-comment", state.session.owner_comments[id] || "")),
+    checkboxInput("follow-up-required", "Follow-up required", Boolean(state.session.follow_up_required[id])),
+    field("Optional follow-up note", textareaInput("follow-up-note", state.session.follow_up_notes[id] || "")),
+  );
+  return form;
+}
+
+function acceptAttentionSignal(signal) {
+  const id = signal.signal_id;
+  state.session.selected_owner_decisions[id] = systemDefaultDecision(signal);
+  state.session.owner_overridden[id] = false;
+  state.session.attention_item_statuses[id] = "accepted";
+  state.session.follow_up_required[id] = false;
+  advanceAttention();
+}
+
+function saveDecisionAndContinue(signal) {
+  const id = signal.signal_id;
+  const decision = document.getElementById("owner-decision").value;
+  state.session.selected_owner_decisions[id] = decision;
+  state.session.priority_values[id] = document.getElementById("priority").value;
+  state.session.owner_comments[id] = document.getElementById("owner-comment").value;
+  state.session.follow_up_required[id] = document.getElementById("follow-up-required").checked;
+  state.session.follow_up_notes[id] = document.getElementById("follow-up-note").value;
+  state.session.owner_overridden[id] = decision !== systemDefaultDecision(signal);
+  state.session.attention_item_statuses[id] = "changed";
+  advanceAttention();
+}
+
+function skipAttentionSignal(signal) {
+  const id = signal.signal_id;
+  state.session.selected_owner_decisions[id] = systemDefaultDecision(signal);
+  state.session.owner_overridden[id] = false;
+  state.session.attention_item_statuses[id] = "skipped";
+  state.session.follow_up_required[id] = true;
+  state.session.follow_up_notes[id] = state.session.follow_up_notes[id] || "Skipped by Owner for later follow-up.";
+  advanceAttention();
+}
+
+function advanceAttention() {
+  const next = state.session.attention_index + 1;
+  state.changeMode = false;
+  if (next >= attentionSignals().length) {
+    state.session.current_screen = SCREEN_AUTO_HANDLED;
+  } else {
+    state.session.attention_index = next;
+  }
+  saveSession();
+  render();
+}
+
+function acceptSystemHandledSignals() {
+  state.session.auto_handled_accepted = true;
+  state.session.current_screen = SCREEN_SAVE;
+  saveSession();
+  render();
+}
+
+function saveInternalReview() {
+  state.session.internal_review_saved = true;
+  state.session.current_screen = SCREEN_GENERATE;
+  saveSession();
+  render();
+}
+
+function generateFeedbackAndContinue() {
+  state.session.feedback_generated = true;
+  state.session.feedback_json = buildFeedbackJson();
+  state.session.current_screen = SCREEN_DOWNLOAD;
+  saveSession();
+  render();
+}
+
+function buildFeedbackJson() {
+  const records = allSignals().map((signal) => {
+    const id = signal.signal_id;
+    const status = state.session.attention_item_statuses[id] || (isAttentionSignal(signal) ? "pending" : "system_handled");
+    return {
+      signal_id: id,
+      title: signal.title,
+      auto_decision: signal.auto_decision,
+      system_default_owner_decision: systemDefaultDecision(signal),
+      selected_owner_decision: state.session.selected_owner_decisions[id] || systemDefaultDecision(signal),
+      owner_overridden: Boolean(state.session.owner_overridden[id]),
+      owner_review_status: status,
+      priority: state.session.priority_values[id] || "medium",
+      owner_comment: state.session.owner_comments[id] || "",
+      follow_up_required: Boolean(state.session.follow_up_required[id]),
+      follow_up_note: state.session.follow_up_notes[id] || "",
+      publish_readiness_candidate: Boolean(signal.publish_readiness_candidate),
+      publication_approved: false,
+    };
+  });
+  return {
+    wizard_session_id: state.session.wizard_session_id,
+    owner_review_wizard_version: WIZARD_VERSION,
+    created_at: state.session.session_created_at,
+    updated_at: new Date().toISOString(),
+    source_brief_title: state.brief.overall_recommendation || "DysonX internal intelligence brief",
+    internal_review_complete: state.session.feedback_downloaded || state.session.current_screen === SCREEN_COMPLETE,
+    auto_handled_accepted: Boolean(state.session.auto_handled_accepted),
+    total_signals: allSignals().length,
+    owner_attention_reviewed: attentionDoneCount(),
+    owner_overridden_count: ownerOverrideCount(),
+    records,
+    auto_decision_is_not_publication_approval: true,
+    owner_feedback_is_not_publication_approval: true,
+    review_session_is_not_publication_approval: true,
+    wizard_review_is_not_publication_approval: true,
+    publication_approved: false,
+  };
+}
+
+function downloadJson(filename, data) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+async function copyFeedbackJson() {
+  const payload = JSON.stringify(buildFeedbackJson(), null, 2);
+  await navigator.clipboard.writeText(payload);
+}
+
+function countAutoHandled(signals) {
+  return signals.reduce((counts, signal) => {
+    counts[signal.auto_decision] = (counts[signal.auto_decision] || 0) + 1;
+    return counts;
+  }, { hold: 0, needs_regeneration: 0, auto_reject: 0 });
+}
+
+function attentionDoneCount() {
+  return attentionSignals().filter((signal) => state.session.attention_item_statuses[signal.signal_id]).length;
+}
+
+function ownerOverrideCount() {
+  return Object.values(state.session.owner_overridden || {}).filter(Boolean).length;
+}
+
+function safetyList() {
+  const list = document.createElement("ul");
+  list.className = "safety-list";
+  [
+    "No public publishing",
+    "Not publication approval",
+    "No deployment",
+    "No OpenAI call",
+    "Local browser review only",
+  ].forEach((text) => {
+    const item = document.createElement("li");
+    item.textContent = text;
+    list.appendChild(item);
+  });
+  return list;
+}
+
+function completionPanel() {
+  const panel = div("completion-panel");
+  panel.append(
+    heading("Internal Review Complete", "h1"),
+    paragraph("No public publishing occurred.", "instruction"),
+    generatedList(["Owner Feedback JSON", "Review Session JSON"]),
+    paragraph("Next future stage: Publish Readiness Gate V1", "status-note"),
+  );
+  return panel;
+}
+
+function detailsFor(signal) {
+  const details = document.createElement("details");
+  const summary = document.createElement("summary");
+  summary.textContent = "View details";
+  const panel = div("details-panel");
+  panel.innerHTML = `
+    <p><strong>Signal ID:</strong> ${escapeHtml(signal.signal_id)}</p>
+    <p><strong>Source:</strong> ${escapeHtml(signal.source_url || "No source URL")}</p>
+    <p><strong>Capability:</strong> ${escapeHtml(signal.agi_capability || "Unclear")}</p>
+    <p><strong>Entities:</strong> ${escapeHtml((signal.entities || []).join(", "))}</p>
+    <p><strong>Watch next:</strong> ${escapeHtml(signal.watch_next || "No watch-next field")}</p>
+  `;
+  details.append(summary, panel);
+  return details;
+}
+
+function handledDetails(signals) {
+  const wrapper = div("handled-list");
+  signals.forEach((signal) => {
+    const item = div("handled-item");
+    item.innerHTML = `<strong>${escapeHtml(signal.title)}</strong><p>${escapeHtml(signal.decision_label || signal.auto_decision)} · ${escapeHtml(signal.risk_summary || "")}</p>`;
+    wrapper.appendChild(item);
+  });
+  return wrapper;
+}
+
+function metaRow(items) {
+  const row = div("signal-meta");
+  items.forEach(([label, value]) => {
+    const item = div("pill");
+    item.innerHTML = `<strong>${escapeHtml(label)}</strong>${escapeHtml(String(value))}`;
+    row.appendChild(item);
+  });
+  return row;
+}
+
+function summaryGrid(items) {
+  const grid = div("summary-grid");
+  items.forEach(([label, value]) => {
+    const item = div("metric");
+    item.innerHTML = `<strong>${escapeHtml(label)}</strong>${escapeHtml(value)}`;
+    grid.appendChild(item);
+  });
+  return grid;
+}
+
+function countRow(items) {
+  const row = div("handled-counts");
+  items.forEach(([label, value]) => {
+    const item = div("metric");
+    item.innerHTML = `<strong>${escapeHtml(label)}</strong>${escapeHtml(String(value))}`;
+    row.appendChild(item);
+  });
+  return row;
+}
+
+function generatedList(items) {
+  const list = document.createElement("ul");
+  list.className = "generated-list";
+  items.forEach((text) => {
+    const item = document.createElement("li");
+    item.textContent = text;
+    list.appendChild(item);
+  });
+  return list;
+}
+
+function buttonRow(buttons) {
+  const row = div("button-row");
+  buttons.forEach((button) => row.appendChild(button));
+  return row;
+}
+
+function primaryButton(text, onClick) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "primary-action";
+  button.dataset.primaryAction = "true";
+  button.textContent = text;
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function secondaryButton(text, onClick) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "secondary-action";
+  button.dataset.secondaryAction = "true";
+  button.textContent = text;
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function smallButton(text, onClick) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "small-action";
+  button.dataset.secondaryAction = "true";
+  button.textContent = text;
+  button.addEventListener("click", onClick);
+  return button;
+}
+
+function linkButton(text, href) {
+  const link = document.createElement("a");
+  link.className = "secondary-action";
+  link.dataset.secondaryAction = "true";
+  link.href = href;
+  link.textContent = text;
+  return link;
+}
+
+function field(label, input) {
+  const row = div("form-row");
+  const labelEl = document.createElement("label");
+  labelEl.textContent = label;
+  labelEl.htmlFor = input.id;
+  row.append(labelEl, input);
+  return row;
+}
+
+function selectInput(id, options, value) {
+  const select = document.createElement("select");
+  select.id = id;
+  options.forEach((option) => {
+    const item = document.createElement("option");
+    item.value = option.value;
+    item.textContent = option.label;
+    if (option.value === value) item.selected = true;
+    select.appendChild(item);
+  });
+  return select;
+}
+
+function textareaInput(id, value) {
+  const textarea = document.createElement("textarea");
+  textarea.id = id;
+  textarea.value = value;
+  return textarea;
+}
+
+function checkboxInput(id, label, checked) {
+  const row = document.createElement("label");
+  row.className = "checkbox-row";
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.id = id;
+  input.checked = checked;
+  row.append(input, document.createTextNode(label));
+  return row;
+}
+
+function heading(text, level = "h2", id = "") {
+  const el = document.createElement(level);
+  el.textContent = text;
+  if (id) el.id = id;
+  return el;
+}
+
+function kicker(text) {
+  return paragraph(text, "screen-kicker");
+}
+
+function paragraph(text, className = "") {
+  const p = document.createElement("p");
+  p.textContent = text;
+  if (className) p.className = className;
+  return p;
+}
+
+function div(className) {
+  const el = document.createElement("div");
+  if (className) el.className = className;
+  return el;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+fetch(FIXTURE_URL)
+  .then((response) => response.json())
+  .then((brief) => {
+    state.brief = brief;
+    state.savedSession = readSavedSession();
+    state.session = createSession();
+    render();
+  })
+  .catch(() => {
+    screen.innerHTML = `<p class="error">Unable to load Owner Review Wizard fixture.</p>`;
+  });

--- a/internal/dysonx-owner-review-wizard/index.html
+++ b/internal/dysonx-owner-review-wizard/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DysonX Owner Review Wizard</title>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body>
+    <main class="wizard-shell" aria-labelledby="wizard-title">
+      <section class="wizard-card" aria-live="polite">
+        <div class="wizard-topline">
+          <p class="eyebrow">Internal owner review</p>
+          <a class="secondary-link" href="../dysonx-owner-intelligence-preview/?v=advanced-console">Open Advanced Console</a>
+        </div>
+
+        <div id="wizard-progress" class="wizard-progress" aria-label="Passive review progress"></div>
+        <div id="wizard-screen" class="wizard-screen"></div>
+      </section>
+    </main>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/internal/dysonx-owner-review-wizard/styles.css
+++ b/internal/dysonx-owner-review-wizard/styles.css
@@ -1,0 +1,426 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7f9;
+  --panel: #ffffff;
+  --text: #14212b;
+  --muted: #5f6c77;
+  --line: #d9e0e7;
+  --line-strong: #b8c4cf;
+  --primary: #124c71;
+  --primary-hover: #0d3d5c;
+  --secondary: #eef3f6;
+  --warning: #7a4b00;
+  --success: #1f6b45;
+  --danger: #8a2d2d;
+  --focus: #ffd15c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  overflow-x: hidden;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.5;
+}
+
+button,
+select,
+textarea {
+  font: inherit;
+}
+
+.wizard-shell {
+  width: min(960px, calc(100vw - 32px));
+  margin: 32px auto;
+}
+
+.wizard-card {
+  min-height: calc(100vh - 64px);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel);
+  box-shadow: 0 16px 50px rgba(20, 33, 43, 0.08);
+  padding: clamp(18px, 4vw, 40px);
+}
+
+.wizard-topline,
+.button-row,
+.summary-grid,
+.signal-meta,
+.safety-list,
+.generated-list,
+.handled-counts {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.wizard-topline {
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 16px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.secondary-link {
+  color: var(--primary);
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.secondary-link:hover {
+  text-decoration: underline;
+}
+
+.wizard-progress {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+  margin: 22px 0 28px;
+}
+
+.progress-step {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 8px;
+  color: var(--muted);
+  background: #f8fafb;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-align: center;
+  overflow-wrap: anywhere;
+}
+
+.progress-step.current {
+  border-color: var(--primary);
+  color: var(--primary);
+  background: #e9f3f8;
+}
+
+.progress-step.complete {
+  border-color: #b9d8c8;
+  color: var(--success);
+  background: #eef8f2;
+}
+
+.wizard-screen {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.screen-kicker {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-weight: 800;
+}
+
+h1,
+h2 {
+  margin: 0 0 12px;
+  letter-spacing: 0;
+  line-height: 1.12;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.3rem);
+}
+
+h2 {
+  font-size: clamp(1.65rem, 4vw, 2.55rem);
+}
+
+p {
+  overflow-wrap: anywhere;
+}
+
+.subtitle,
+.instruction {
+  margin: 0 0 22px;
+  color: var(--muted);
+  font-size: clamp(1rem, 2vw, 1.18rem);
+}
+
+.signal-card,
+.details-panel,
+.summary-panel,
+.safety-panel,
+.completion-panel {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fbfcfd;
+  padding: 18px;
+}
+
+.signal-card {
+  margin: 20px 0;
+}
+
+.signal-title {
+  margin: 0 0 10px;
+  font-size: clamp(1.35rem, 3vw, 2rem);
+}
+
+.two-line {
+  display: -webkit-box;
+  margin: 0 0 14px;
+  color: var(--muted);
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.signal-meta,
+.summary-grid,
+.handled-counts {
+  margin: 14px 0;
+}
+
+.pill,
+.metric {
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px 12px;
+  overflow-wrap: anywhere;
+}
+
+.pill strong,
+.metric strong {
+  display: block;
+  font-size: 0.74rem;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.metric {
+  flex: 1 1 150px;
+}
+
+.missing {
+  color: var(--warning);
+  font-weight: 700;
+}
+
+.button-row {
+  align-items: center;
+  margin-top: 22px;
+}
+
+.button-row.single {
+  justify-content: flex-start;
+}
+
+.primary-action,
+.secondary-action,
+.small-action {
+  border: 0;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 800;
+}
+
+.primary-action {
+  background: var(--primary);
+  color: #fff;
+  min-height: 48px;
+  padding: 0 22px;
+  box-shadow: 0 8px 18px rgba(18, 76, 113, 0.22);
+}
+
+.primary-action:hover {
+  background: var(--primary-hover);
+}
+
+.secondary-action {
+  background: var(--secondary);
+  color: var(--text);
+  min-height: 42px;
+  padding: 0 18px;
+}
+
+.small-action {
+  background: transparent;
+  color: var(--muted);
+  min-height: 38px;
+  padding: 0 8px;
+  text-decoration: underline;
+}
+
+.primary-action:focus-visible,
+.secondary-action:focus-visible,
+.small-action:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.safety-list {
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.safety-list li {
+  border: 1px solid #d6e5dc;
+  border-radius: 8px;
+  background: #f2f9f5;
+  color: var(--success);
+  padding: 9px 11px;
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.decision-form {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.form-row {
+  display: grid;
+  gap: 6px;
+}
+
+.form-row label,
+.checkbox-row {
+  color: var(--text);
+  font-weight: 700;
+}
+
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--text);
+  padding: 10px 12px;
+}
+
+textarea {
+  min-height: 84px;
+  resize: vertical;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+details {
+  margin-top: 14px;
+}
+
+summary {
+  cursor: pointer;
+  color: var(--primary);
+  font-weight: 800;
+}
+
+.details-panel {
+  margin-top: 10px;
+  color: var(--muted);
+}
+
+.handled-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.handled-item {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #fff;
+  padding: 12px;
+}
+
+.handled-item p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+
+.summary-panel {
+  margin: 18px 0;
+}
+
+.completion-panel {
+  border-color: #b9d8c8;
+  background: #f2f9f5;
+}
+
+.generated-list {
+  padding: 0;
+  list-style: none;
+}
+
+.generated-list li {
+  flex: 1 1 180px;
+  border: 1px solid #cfe1d7;
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px 12px;
+  font-weight: 800;
+}
+
+.status-note {
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.error {
+  color: var(--danger);
+  font-weight: 800;
+}
+
+@media (max-width: 720px) {
+  .wizard-shell {
+    width: min(100vw - 20px, 960px);
+    margin: 10px auto;
+  }
+
+  .wizard-card {
+    min-height: calc(100vh - 20px);
+    padding: 16px;
+  }
+
+  .wizard-progress {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .button-row,
+  .button-row.single {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .primary-action,
+  .secondary-action,
+  .small-action {
+    width: 100%;
+  }
+}

--- a/tests/test_dysonx_minimal_internal_frontend_preview.py
+++ b/tests/test_dysonx_minimal_internal_frontend_preview.py
@@ -15,6 +15,11 @@ LAUNCH_PLAN = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_LAUNCH_PLAN.md"
 WORKFLOW_COMPRESSION_DOC = ROOT / "docs" / "DYSONX_OWNER_CONSOLE_WORKFLOW_COMPRESSION_V2.md"
 REVIEW_SESSION_DOC = ROOT / "docs" / "DYSONX_REVIEW_SESSION_SAVE_V1.md"
 GUIDED_WORKFLOW_DOC = ROOT / "docs" / "DYSONX_OWNER_GUIDED_REVIEW_WORKFLOW_V1.md"
+WIZARD = ROOT / "internal" / "dysonx-owner-review-wizard"
+WIZARD_INDEX = WIZARD / "index.html"
+WIZARD_APP = WIZARD / "app.js"
+WIZARD_STYLES = WIZARD / "styles.css"
+WIZARD_DOC = ROOT / "docs" / "DYSONX_OWNER_REVIEW_WIZARD_V1.md"
 
 
 class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
@@ -26,6 +31,12 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
 
     def load_fixture(self) -> dict:
         return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+    def read_wizard_index(self) -> str:
+        return WIZARD_INDEX.read_text(encoding="utf-8")
+
+    def read_wizard_app(self) -> str:
+        return WIZARD_APP.read_text(encoding="utf-8")
 
     def test_preview_fixture_can_be_loaded(self):
         fixture = self.load_fixture()
@@ -640,6 +651,232 @@ class DysonXMinimalInternalFrontendPreviewTests(unittest.TestCase):
         self.assertTrue(relative.startswith("internal/"))
         self.assertFalse(relative.startswith("static/"))
         self.assertFalse(relative.startswith("downloads/"))
+
+    def test_owner_review_wizard_route_exists(self):
+        html = self.read_wizard_index()
+
+        self.assertTrue(WIZARD_INDEX.exists())
+        self.assertTrue(WIZARD_APP.exists())
+        self.assertTrue(WIZARD_STYLES.exists())
+        self.assertIn("DysonX Owner Review Wizard", html)
+        self.assertIn("wizard-screen", html)
+        self.assertIn("owner-review-wizard-v1", "/internal/dysonx-owner-review-wizard/?v=owner-review-wizard-v1")
+
+    def test_owner_review_wizard_start_screen_is_simple(self):
+        app = self.read_wizard_app()
+
+        self.assertIn("DysonX Owner Review Wizard", app)
+        self.assertIn("Review only the few Signals that need Owner attention. The system handles the rest.", app)
+        self.assertIn("Start Review", app)
+        self.assertIn("Open Advanced Console", app)
+        self.assertIn("This will not publish anything.", app)
+        self.assertIn("Resume Saved Review", app)
+        self.assertIn("Start New Review", app)
+        self.assertIn("Starting new clears only this browser's saved review state.", app)
+
+    def test_owner_review_wizard_attention_screens_are_single_signal(self):
+        app = self.read_wizard_app()
+
+        self.assertIn("Review ${index + 1} of ${items.length}", app)
+        self.assertIn("Accept system recommendation", app)
+        self.assertIn("Change decision", app)
+        self.assertIn("Skip for now", app)
+        self.assertIn("Save decision and continue", app)
+        self.assertIn("Cancel change", app)
+        self.assertIn("function renderAttentionScreen", app)
+        self.assertIn("attentionSignals().length", app)
+        self.assertNotIn("renderAllSignals", app)
+
+    def test_owner_review_wizard_decision_form_only_appears_in_change_mode(self):
+        app = self.read_wizard_app()
+
+        self.assertIn("if (state.changeMode)", app)
+        self.assertIn("decisionForm(signal)", app)
+        self.assertIn("Owner decision", app)
+        self.assertIn("Priority", app)
+        self.assertIn("Optional comment", app)
+        self.assertIn("Follow-up required", app)
+        self.assertIn("Optional follow-up note", app)
+
+    def test_owner_review_wizard_auto_handled_confirmation_exists(self):
+        app = self.read_wizard_app()
+
+        self.assertIn("The system already handled ${handled.length} Signals.", app)
+        self.assertIn("You do not need to review these unless you disagree.", app)
+        self.assertIn("Accept system-handled Signals", app)
+        self.assertIn("Review system-handled details", app)
+        self.assertIn("function acceptSystemHandledSignals", app)
+        self.assertIn("Hold", app)
+        self.assertIn("Regenerate", app)
+        self.assertIn("Reject", app)
+
+    def test_owner_review_wizard_save_generate_download_complete_screens_exist(self):
+        app = self.read_wizard_app()
+
+        for phrase in (
+            "Ready to save your internal review.",
+            "Save Internal Review",
+            "Internal review saved.",
+            "Generate Owner Feedback JSON",
+            "Feedback generated.",
+            "Download Owner Feedback JSON",
+            "Download Review Session JSON",
+            "Copy Feedback JSON",
+            "Internal Review Complete",
+            "No public publishing occurred.",
+            "Next future stage: Publish Readiness Gate V1",
+        ):
+            self.assertIn(phrase, app)
+
+    def test_owner_review_wizard_local_storage_and_state_fields_exist(self):
+        app = self.read_wizard_app()
+
+        self.assertIn('const WIZARD_STORAGE_KEY = "dysonx.ownerReviewWizard.v1"', app)
+        for field in (
+            "wizard_session_id",
+            "current_screen",
+            "attention_index",
+            "attention_item_statuses",
+            "selected_owner_decisions",
+            "priority_values",
+            "owner_comments",
+            "follow_up_required",
+            "follow_up_notes",
+            "owner_overridden",
+            "auto_handled_accepted",
+            "internal_review_saved",
+            "feedback_generated",
+            "feedback_downloaded",
+            "session_created_at",
+            "session_updated_at",
+        ):
+            self.assertIn(field, app)
+        self.assertIn("localStorage.setItem(WIZARD_STORAGE_KEY", app)
+        self.assertIn("localStorage.getItem(WIZARD_STORAGE_KEY", app)
+        self.assertIn("localStorage.removeItem(WIZARD_STORAGE_KEY", app)
+
+    def test_owner_review_wizard_feedback_json_has_required_safety_fields(self):
+        app = self.read_wizard_app()
+
+        for field in (
+            "owner_review_wizard_version",
+            "internal_review_complete",
+            "auto_handled_accepted",
+            "records",
+            "auto_decision_is_not_publication_approval: true",
+            "owner_feedback_is_not_publication_approval: true",
+            "review_session_is_not_publication_approval: true",
+            "wizard_review_is_not_publication_approval: true",
+            "publication_approved: false",
+        ):
+            self.assertIn(field, app)
+        self.assertNotIn("publication_approved: true", app)
+
+    def test_owner_review_wizard_one_primary_action_pattern(self):
+        app = self.read_wizard_app()
+
+        self.assertIn('button.dataset.primaryAction = "true"', app)
+        self.assertIn('link.dataset.secondaryAction = "true"', app)
+        self.assertIn('button.dataset.secondaryAction = "true"', app)
+        for renderer in (
+            "renderStartScreen",
+            "renderAttentionScreen",
+            "renderAutoHandledScreen",
+            "renderSaveScreen",
+            "renderGenerateScreen",
+            "renderDownloadScreen",
+            "renderCompleteScreen",
+        ):
+            start = app.index(f"function {renderer}")
+            end = app.find("\nfunction ", start + 1)
+            block = app[start:] if end == -1 else app[start:end]
+            self.assertIn("primaryButton(", block)
+            self.assertLessEqual(block.count("primaryButton("), 2 if renderer in {"renderStartScreen", "renderAttentionScreen"} else 1)
+        self.assertLessEqual(app.count("secondaryButton("), 12)
+
+    def test_owner_review_wizard_screens_have_no_more_than_three_actions(self):
+        app = self.read_wizard_app()
+
+        for renderer in (
+            "renderStartScreen",
+            "renderAttentionScreen",
+            "renderAutoHandledScreen",
+            "renderSaveScreen",
+            "renderGenerateScreen",
+            "renderDownloadScreen",
+            "renderCompleteScreen",
+        ):
+            start = app.index(f"function {renderer}")
+            end = app.find("\nfunction ", start + 1)
+            block = app[start:] if end == -1 else app[start:end]
+            action_count = block.count("primaryButton(") + block.count("secondaryButton(") + block.count("smallButton(") + block.count("linkButton(")
+            self.assertLessEqual(action_count, 5 if renderer == "renderAttentionScreen" else 4 if renderer == "renderStartScreen" else 3)
+
+    def test_owner_review_wizard_safety_text_and_advanced_console_separation(self):
+        html = self.read_wizard_index()
+        app = self.read_wizard_app()
+
+        for phrase in (
+            "No public publishing",
+            "Not publication approval",
+            "No deployment",
+            "No OpenAI call",
+            "Local browser review only",
+        ):
+            self.assertIn(phrase, app)
+        self.assertIn("../dysonx-owner-intelligence-preview/?v=advanced-console", html)
+        self.assertIn("../dysonx-owner-intelligence-preview/?v=advanced-console", app)
+        self.assertTrue(INDEX.exists())
+
+    def test_owner_review_wizard_keeps_raw_json_out_of_main_flow(self):
+        app = self.read_wizard_app()
+        html = self.read_wizard_index()
+
+        self.assertNotIn("<pre", html)
+        self.assertNotIn("feedback-output", html)
+        self.assertNotIn("screen.appendChild(JSON.stringify", app)
+        self.assertNotIn("innerHTML = JSON.stringify", app)
+        self.assertIn("downloadJson", app)
+        self.assertIn("View details", app)
+
+    def test_owner_review_wizard_no_external_effects_or_public_publishing_behavior(self):
+        app = self.read_wizard_app()
+        html = self.read_wizard_index()
+
+        combined = app + html
+        self.assertIn("No public publishing occurred.", app)
+        self.assertNotIn("XMLHttpRequest", combined)
+        self.assertNotIn("axios", combined)
+        self.assertNotIn("OPENAI" + "_API_KEY", combined)
+        self.assertNotIn("gh workflow", combined)
+        self.assertNotIn("deploy", combined.lower().replace("no deployment", ""))
+        self.assertNotIn("publishSignal", combined)
+        self.assertNotIn("publicPage", combined)
+
+    def test_owner_review_wizard_documentation_exists(self):
+        doc = WIZARD_DOC.read_text(encoding="utf-8")
+
+        for phrase in (
+            "Why Previous Owner Console Attempts Failed",
+            "Why Wizard Mode Is Required",
+            "One Screen / One Task / One Primary Action Rule",
+            "Wizard Screens",
+            "Attention Item Review",
+            "Auto-Handled Confirmation",
+            "Save / Generate / Download Flow",
+            "Local Persistence",
+            "Feedback JSON",
+            "Safety Boundaries",
+            "Owner Acceptance Criteria",
+            "If Owner can complete the review without asking what to click next, then merge Wizard and proceed to Publish Readiness Gate V1.",
+        ):
+            self.assertIn(phrase, doc)
+
+    def test_owner_usability_governance_prefers_wizard_mode(self):
+        doc = (ROOT / "docs" / "DYSONX_OWNER_USABILITY_GOVERNANCE.md").read_text(encoding="utf-8")
+
+        self.assertIn("Wizard mode is preferred over dense console mode", doc)
+        self.assertIn("one screen / one task / one primary action", doc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds a new simplified Owner Review Wizard route.
- Uses one screen / one task / one primary action.
- Keeps advanced console separate.
- Owner reviews only attention items.
- Auto-handled Signals are accepted in one action.
- No raw JSON appears in the main wizard flow.
- Adds local wizard persistence under dysonx.ownerReviewWizard.v1.
- Generates internal Owner Feedback JSON with publication_approved false.
- Keeps public publishing blocked.
- Does not implement backend APIs, database, server persistence, Publish Readiness Gate, public publishing, public website generation, OpenAI calls, workflow dispatch, deployment, or production changes.
- Keeps PR #70 draft / not merged.

## Validation

- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- git diff --check origin/main...HEAD
- local route HTTP 200: /internal/dysonx-owner-review-wizard/?v=owner-review-wizard-v1

## Safety

No public publishing, automatic publishing, public website generation, Publish Readiness Gate, OpenAI call, workflow dispatch, deployment, production change, Knowledge Graph write, Prediction Engine, Confidence Calibration, or Multi-source Correlation is implemented.