### PR TITLE
feat: add DysonX Public Signal Page Generator V1

### DIFF
--- a/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
+++ b/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
@@ -188,6 +188,8 @@ Fast progress should come from deterministic automation, concise Owner exception
 
 Fast publication progress also means automating blockers and readiness checks through `docs/DYSONX_PUBLISH_READINESS_GATE_V1.md`, not bypassing the gate.
 
+Step 2 of the strict 5-Step Final Launch Plan is `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`: Public Signal Page Generator V1, Public Signals Index V1, and Local Public Preview V1. This step creates static draft preview artifacts only; generated drafts and local preview are not publication, do not replace Manual Publish Approval V1, and must remain visually simple while preserving credibility, readability, attribution, copyright safety, and gate approval.
+
 ## 8. Owner Role
 
 Owner is a strategic decision-maker, not a daily manual editor.

--- a/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
+++ b/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
@@ -133,6 +133,8 @@ Only after Publish Readiness Gate may an item become Ready to Publish.
 
 Public Signal Page Generator V1 must only consume Signals that pass `docs/DYSONX_PUBLISH_READINESS_GATE_V1.md`. Passing that gate means ready for future public generation; it does not mean published.
 
+Public Signal Page Generator V1 is governed by `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`. It creates static draft / local preview artifacts only. Generated page drafts and local preview are not publication, and Manual Publish Approval V1 remains required before production release.
+
 ## 7. Public Website Responsibility
 
 Public website is the external product surface.

--- a/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
@@ -1,0 +1,170 @@
+# DysonX Public Signal Page Generator V1
+
+## 1. Purpose
+
+Public Signal Page Generator V1 is Step 2 of the strict 5-Step Final Launch Plan:
+
+```text
+Owner Review Wizard
+-> Publish Readiness Gate
+-> Public Signal Page Generator
+-> Public Signals Index
+-> Local Public Preview
+-> Manual Publish Approval
+-> media.energizeos.com
+```
+
+It generates static draft public Signal preview pages from Publish Readiness Gate-approved Signals.
+
+This step supports functional publishing before aesthetic polish while preserving quality and safety gates before public release.
+
+## 2. Boundary
+
+Generated page draft is not publication.
+
+Local preview is not publication.
+
+`ready_for_public_generation: true` is not publication approval.
+
+`publish_readiness_gate_passed: true` is not publication approval.
+
+Manual Publish Approval V1 is still required before production release.
+
+## 3. CLI
+
+```bash
+python3 scripts/dysonx_public_signal_page_generator.py \
+  --gate-report tests/fixtures/public_signal_page_generator_v1/publish_readiness_gate_report.json \
+  --output-dir tmp/public_signal_pages
+```
+
+The CLI reads a local Publish Readiness Gate report and writes static draft preview artifacts under:
+
+```text
+tmp/public_signal_pages/
+```
+
+It uses only Python standard library modules.
+
+## 4. Input Rule
+
+The generator may process only Signals where all are true:
+
+- `publish_readiness_gate_passed` is `true`
+- `ready_for_public_generation` is `true`
+- `public_generation_blocked` is `false`
+- `published` is `false` or absent
+- `publication_approved` is `false` or absent
+
+Any Signal outside that boundary is blocked from draft page generation.
+
+## 5. Output Structure
+
+Generated files:
+
+```text
+tmp/public_signal_pages/signals/<slug>/index.html
+tmp/public_signal_pages/signals/index.html
+tmp/public_signal_pages/public_signal_pages_manifest.json
+tmp/public_signal_pages/README.md
+```
+
+The README contains local preview instructions:
+
+```bash
+python3 -m http.server --directory tmp/public_signal_pages 8080
+```
+
+Then visit:
+
+```text
+http://localhost:8080/signals/
+```
+
+## 6. Public Signal Draft Page Requirements
+
+V1 pages may be visually simple. They must still be:
+
+- credible
+- clear
+- source-attributed
+- copyright-safe
+- readable
+- previewable
+- gate-approved
+
+Each generated Signal draft page includes:
+
+- Signal title
+- slug
+- Draft Preview / Not Published status
+- generated timestamp
+- short summary
+- why this matters
+- AGI relevance
+- source attribution
+- source URLs or source references when available
+- quality score / confidence summary
+- risk / safety notes
+- Manual Publish Approval V1 required notice
+- link back to the Signals index
+
+## 7. Forbidden Output
+
+The generator must not include:
+
+- raw article body
+- internal Owner comments
+- internal decision trail leakage
+- private review state
+- misleading published status
+- ads
+- tracking
+- external runtime JavaScript dependency
+- OpenAI calls
+- network fetches
+
+The generator must escape HTML content.
+
+## 8. Manifest
+
+The manifest records:
+
+- generator version
+- input file
+- output directory
+- generated pages
+- blocked Signals
+- safety flags
+- Manual Publish Approval V1 requirement
+
+Safety fields must state:
+
+- `no_public_publishing_performed: true`
+- `no_deployment_performed: true`
+- `no_openai_call_performed: true`
+- `no_workflow_dispatch_performed: true`
+- `manual_publish_approval_required: true`
+- `production_publish_performed: false`
+
+## 9. Non-Goals
+
+This step does not implement:
+
+- production publishing
+- production deployment
+- Manual Publish Approval V1
+- Production Publish Pack
+- workflow dispatch
+- OpenAI calls
+- scraping
+- backend APIs
+- database storage
+- Knowledge Graph writes
+- Prediction Engine
+- Confidence Calibration
+- Multi-source Correlation
+- social distribution
+- final public visual polish
+
+No production deployment is authorized by this document.

--- a/docs/DYSONX_SYSTEM_ARCHITECTURE.md
+++ b/docs/DYSONX_SYSTEM_ARCHITECTURE.md
@@ -130,6 +130,8 @@ Published Signal pages should include title, summary, source attribution, author
 
 Public-facing surfaces are governed by `docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md`.
 
+Public Signal Page Generator V1 is the Step 2 static draft generator governed by `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`. It may generate local preview HTML only after Publish Readiness Gate V1 passes, and those draft pages are not publication, production approval, deployment, or public release.
+
 ## Tracker Layer
 
 Trackers are persistent intelligence surfaces for companies, people, topics, capabilities, models, papers, policies, and GitHub projects.

--- a/scripts/dysonx_public_signal_page_generator.py
+++ b/scripts/dysonx_public_signal_page_generator.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""DysonX Public Signal Page Generator V1.
+
+Generates static draft preview pages from Publish Readiness Gate-approved
+Signals. This tool is offline, deterministic, and standard-library only. It
+does not publish, deploy, call OpenAI, dispatch workflows, fetch URLs, scrape
+sources, write production public pages, or approve publication.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from html import escape
+from typing import Any
+
+
+GENERATOR_VERSION = "public_signal_page_generator_v1"
+DEFAULT_OUTPUT_DIR = pathlib.Path("tmp/public_signal_pages")
+RAW_CONTENT_FIELDS = (
+    "raw_body",
+    "article_body",
+    "scraped_text",
+    "full_text",
+    "provider_response",
+    "raw_provider_response",
+    "raw_copyrighted_article_text",
+)
+
+
+class GeneratorInputError(ValueError):
+    """Raised when the generator cannot safely process input."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json_object(path: str | pathlib.Path, label: str) -> dict[str, Any]:
+    input_path = pathlib.Path(path)
+    try:
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI fails closed on malformed JSON.
+        raise GeneratorInputError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise GeneratorInputError(f"{label} must be a JSON object")
+    return data
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def first_present(record: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = record.get(key)
+        if value not in (None, "", []):
+            return value
+    return None
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "untitled-signal"
+
+
+def signal_id(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "signal_id", "canonical_signal_id", "id"))
+
+
+def signal_title(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_title", "title")) or "Untitled Signal"
+
+
+def signal_slug(record: dict[str, Any]) -> str:
+    return slugify(normalize_text(first_present(record, "public_slug", "slug", "signal_slug", "title")))
+
+
+def source_urls(record: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("source_url", "first_source_url", "original_source_url"):
+        value = normalize_text(record.get(key))
+        if value and value not in values:
+            values.append(value)
+    for value in as_list(record.get("source_urls")):
+        text = normalize_text(value)
+        if text and text not in values:
+            values.append(text)
+    return values
+
+
+def source_label(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_source_label", "source_title", "source_reference")) or "Source attribution provided"
+
+
+def source_attribution(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_attribution", "source_attribution", "source_authority_reasoning", "source_authority")) or source_label(record)
+
+
+def quality_summary(record: dict[str, Any]) -> str:
+    score = first_present(record, "score_normalized_to_65", "quality_score_total", "score", "total_score")
+    tier = normalize_text(first_present(record, "quality_tier", "tier"))
+    confidence = normalize_text(first_present(record, "confidence_summary", "confidence_notes", "confidence"))
+    pieces = []
+    if score not in (None, ""):
+        pieces.append(f"Quality score: {score}/65")
+    if tier:
+        pieces.append(f"Tier: {tier}")
+    if confidence:
+        pieces.append(f"Confidence: {confidence}")
+    return "; ".join(pieces) if pieces else "Quality score and confidence summary available in gate inputs."
+
+
+def risk_summary(record: dict[str, Any]) -> str:
+    risks = [normalize_text(item) for item in as_list(record.get("warnings")) if normalize_text(item)]
+    risks.extend(normalize_text(item) for item in as_list(record.get("risk_flags")) if normalize_text(item))
+    if risks:
+        return "; ".join(dict.fromkeys(risks))
+    return "No blocking public-generation risk flags in the gate-passed record."
+
+
+def public_summary(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_summary", "summary")) or "No public summary provided."
+
+
+def why_it_matters(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_why_it_matters", "why_it_matters")) or "No public why-it-matters field provided."
+
+
+def watch_next(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_watch_next", "watch_next")) or "No public watch-next field provided."
+
+
+def agi_relevance(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "public_capability_area", "specific_agi_capability", "agi_capability_affected", "agi_capability")) or "AGI capability relevance provided by gate input."
+
+
+def has_raw_content(record: dict[str, Any]) -> bool:
+    return any(record.get(field) for field in RAW_CONTENT_FIELDS)
+
+
+def is_ready_for_generation(record: dict[str, Any]) -> bool:
+    return (
+        record.get("publish_readiness_gate_passed") is True
+        and record.get("ready_for_public_generation") is True
+        and record.get("public_generation_blocked") is False
+        and record.get("published") is not True
+        and record.get("publication_approved") is not True
+        and not has_raw_content(record)
+    )
+
+
+def block_reasons(record: dict[str, Any]) -> list[str]:
+    reasons: list[str] = []
+    if record.get("publish_readiness_gate_passed") is not True:
+        reasons.append("publish_readiness_gate_not_passed")
+    if record.get("ready_for_public_generation") is not True:
+        reasons.append("not_ready_for_public_generation")
+    if record.get("public_generation_blocked") is not False:
+        reasons.append("public_generation_blocked")
+    if record.get("published") is True:
+        reasons.append("already_published_true")
+    if record.get("publication_approved") is True:
+        reasons.append("publication_approved_true_requires_later_manual_approval_step")
+    if has_raw_content(record):
+        reasons.append("raw_source_content_present")
+    for blocker in as_list(record.get("blockers")) + as_list(record.get("public_generation_blockers")):
+        text = normalize_text(blocker)
+        if text:
+            reasons.append(text)
+    return list(dict.fromkeys(reasons)) or ["insufficient_gate_fields"]
+
+
+def safe_output_root(output_dir: pathlib.Path) -> pathlib.Path:
+    normalized = pathlib.Path(output_dir)
+    if normalized.is_absolute():
+        if not any(part == "tmp" or part.startswith("tmp") for part in normalized.parts):
+            raise GeneratorInputError("Absolute output directory must be under a temporary preview path")
+        return normalized
+    if not normalized.parts or normalized.parts[0] != "tmp":
+        raise GeneratorInputError("Output directory must be under tmp/ for draft preview generation")
+    return normalized
+
+
+def render_layout(title: str, body: str, generated_at: str) -> str:
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>{escape(title)} | DysonX Draft Preview</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      --ink: #17202a;
+      --muted: #5f6f80;
+      --line: #d8dee6;
+      --panel: #f6f8fa;
+      --accent: #0f6f8f;
+      --warn: #8a4b00;
+    }}
+    body {{
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #ffffff;
+      line-height: 1.55;
+    }}
+    main {{
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 28px 20px 48px;
+    }}
+    .status {{
+      display: inline-block;
+      margin-bottom: 16px;
+      padding: 5px 9px;
+      border: 1px solid #e6c36a;
+      background: #fff7dc;
+      color: var(--warn);
+      font-weight: 700;
+      font-size: 0.85rem;
+    }}
+    h1 {{
+      margin: 0 0 10px;
+      font-size: 2rem;
+      line-height: 1.18;
+      letter-spacing: 0;
+    }}
+    h2 {{
+      margin-top: 28px;
+      padding-top: 18px;
+      border-top: 1px solid var(--line);
+      font-size: 1.1rem;
+      letter-spacing: 0;
+    }}
+    p, li {{
+      max-width: 76ch;
+    }}
+    a {{
+      color: var(--accent);
+    }}
+    .meta, .notice {{
+      background: var(--panel);
+      border: 1px solid var(--line);
+      padding: 14px;
+    }}
+    .notice {{
+      border-left: 4px solid #e6c36a;
+    }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+    }}
+    .card {{
+      border: 1px solid var(--line);
+      padding: 14px;
+      background: #fff;
+    }}
+    .muted {{
+      color: var(--muted);
+    }}
+    code {{
+      background: var(--panel);
+      padding: 1px 4px;
+    }}
+  </style>
+</head>
+<body>
+<main>
+{body}
+<p class="muted">Generated at {escape(generated_at)}. Static local draft preview only.</p>
+</main>
+</body>
+</html>
+"""
+
+
+def render_signal_page(record: dict[str, Any], generated_at: str) -> str:
+    title = signal_title(record)
+    slug = signal_slug(record)
+    source_links = source_urls(record)
+    sources_html = "".join(
+        f'<li><a href="{escape(url, quote=True)}" rel="nofollow noopener">{escape(url)}</a></li>'
+        for url in source_links
+    ) or "<li>No public source URL provided in this draft record.</li>"
+    body = f"""
+<p class="status">Draft Preview / Not Published</p>
+<h1>{escape(title)}</h1>
+<div class="notice">
+  <strong>Manual Publish Approval V1 is required before production release.</strong>
+  This generated page is a local static draft. It is not published, not production-approved, and not deployed.
+</div>
+<div class="meta grid">
+  <div><strong>Slug</strong><br><code>{escape(slug)}</code></div>
+  <div><strong>Status</strong><br>Draft Preview / Not Published</div>
+  <div><strong>Gate</strong><br>Publish Readiness Gate passed for future public generation only</div>
+</div>
+<h2>Summary</h2>
+<p>{escape(public_summary(record))}</p>
+<h2>Why This Matters</h2>
+<p>{escape(why_it_matters(record))}</p>
+<h2>AGI Relevance</h2>
+<p>{escape(agi_relevance(record))}</p>
+<h2>Source Attribution</h2>
+<p>{escape(source_attribution(record))}</p>
+<ul>{sources_html}</ul>
+<h2>Quality And Confidence</h2>
+<p>{escape(quality_summary(record))}</p>
+<h2>Risk And Safety Notes</h2>
+<p>{escape(risk_summary(record))}</p>
+<h2>Watch Next</h2>
+<p>{escape(watch_next(record))}</p>
+<p><a href="../">Back to Public Signals Draft Preview</a></p>
+"""
+    return render_layout(title, body, generated_at)
+
+
+def render_index_page(pages: list[dict[str, Any]], blocked: list[dict[str, Any]], generated_at: str) -> str:
+    items = []
+    for page in pages:
+        item = page["record"]
+        href = f"{escape(page['slug'], quote=True)}/"
+        items.append(
+            f"""
+<article class="card">
+  <h2><a href="{href}">{escape(page['title'])}</a></h2>
+  <p>{escape(public_summary(item))}</p>
+  <p><strong>AGI relevance:</strong> {escape(agi_relevance(item))}</p>
+  <p><strong>Quality / confidence:</strong> {escape(quality_summary(item))}</p>
+  <p><strong>Sources:</strong> {len(source_urls(item))} source URL(s); {escape(source_label(item))}</p>
+  <p><a href="{href}">Open draft preview</a></p>
+</article>
+"""
+        )
+    list_html = "\n".join(items) if items else "<p>No Signals were generated.</p>"
+    body = f"""
+<p class="status">Draft Preview / Not Published</p>
+<h1>DysonX Public Signals Draft Preview</h1>
+<div class="notice">
+  <strong>Manual Publish Approval V1 is required before production release.</strong>
+  These pages are local preview drafts only. They are not published and not deployed.
+</div>
+<div class="meta grid">
+  <div><strong>Generated Signals</strong><br>{len(pages)}</div>
+  <div><strong>Blocked Signals</strong><br>{len(blocked)}</div>
+  <div><strong>Status</strong><br>Draft Preview / Not Published</div>
+</div>
+{list_html}
+"""
+    return render_layout("DysonX Public Signals Draft Preview", body, generated_at)
+
+
+def write_text(path: pathlib.Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def build_manifest(
+    gate_report_path: pathlib.Path,
+    output_dir: pathlib.Path,
+    pages: list[dict[str, Any]],
+    blocked: list[dict[str, Any]],
+    signals_seen: int,
+    created_at: str,
+) -> dict[str, Any]:
+    manifest_pages = []
+    for page in pages:
+        record = page["record"]
+        manifest_pages.append(
+            {
+                "signal_id": signal_id(record),
+                "title": page["title"],
+                "slug": page["slug"],
+                "output_path": str(page["output_path"]),
+                "preview_path": page["preview_path"],
+                "ready_for_public_generation": record.get("ready_for_public_generation") is True,
+                "publish_readiness_gate_passed": record.get("publish_readiness_gate_passed") is True,
+                "publication_approved": bool(record.get("publication_approved")),
+                "published": bool(record.get("published")),
+            }
+        )
+    return {
+        "generator_version": GENERATOR_VERSION,
+        "created_at": created_at,
+        "input_files": {"gate_report": str(gate_report_path)},
+        "output_directory": str(output_dir),
+        "signals_seen": signals_seen,
+        "signals_generated": len(pages),
+        "signals_blocked": len(blocked),
+        "pages": manifest_pages,
+        "blocked": blocked,
+        "no_public_publishing_performed": True,
+        "no_deployment_performed": True,
+        "no_openai_call_performed": True,
+        "no_workflow_dispatch_performed": True,
+        "manual_publish_approval_required": True,
+        "production_publish_performed": False,
+    }
+
+
+def generate_pages(gate_report: dict[str, Any], gate_report_path: pathlib.Path, output_dir: pathlib.Path) -> dict[str, Any]:
+    evaluations = gate_report.get("evaluations")
+    if not isinstance(evaluations, list):
+        raise GeneratorInputError("Gate report must include an evaluations list")
+
+    safe_root = safe_output_root(output_dir)
+    if safe_root.exists():
+        shutil.rmtree(safe_root)
+    signals_dir = safe_root / "signals"
+    created_at = utc_now()
+    pages: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+
+    for item in evaluations:
+        if not isinstance(item, dict):
+            blocked.append({"signal_id": "", "title": "", "blockers": ["invalid_evaluation_record"], "required_next_actions": ["provide_object_evaluation_records"]})
+            continue
+        title = signal_title(item)
+        slug = signal_slug(item)
+        if is_ready_for_generation(item):
+            output_path = signals_dir / slug / "index.html"
+            write_text(output_path, render_signal_page(item, created_at))
+            pages.append(
+                {
+                    "record": item,
+                    "title": title,
+                    "slug": slug,
+                    "output_path": output_path,
+                    "preview_path": f"signals/{slug}/",
+                }
+            )
+        else:
+            blocked.append(
+                {
+                    "signal_id": signal_id(item),
+                    "slug": slug,
+                    "title": title,
+                    "blockers": block_reasons(item),
+                    "required_next_actions": [normalize_text(action) for action in as_list(item.get("required_next_actions")) if normalize_text(action)],
+                }
+            )
+
+    write_text(signals_dir / "index.html", render_index_page(pages, blocked, created_at))
+    manifest = build_manifest(gate_report_path, safe_root, pages, blocked, len(evaluations), created_at)
+    write_text(safe_root / "public_signal_pages_manifest.json", json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    readme = """# DysonX Public Signal Pages Draft Preview
+
+This directory contains local static draft preview artifacts only.
+
+Run:
+
+```bash
+python3 -m http.server --directory tmp/public_signal_pages 8080
+```
+
+Then visit:
+
+```text
+http://localhost:8080/signals/
+```
+
+Manual Publish Approval V1 is still required before production release.
+No production deployment was performed.
+"""
+    write_text(safe_root / "README.md", readme)
+    return manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate DysonX public Signal draft preview pages.")
+    parser.add_argument("--gate-report", required=True, help="Publish Readiness Gate report JSON input.")
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Safe tmp/ output directory for draft pages.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    gate_report_path = pathlib.Path(args.gate_report)
+    output_dir = pathlib.Path(args.output_dir)
+    try:
+        gate_report = read_json_object(gate_report_path, "Publish Readiness Gate report")
+        manifest = generate_pages(gate_report, gate_report_path, output_dir)
+    except GeneratorInputError as exc:
+        print(f"[public-signal-page-generator] failed: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"[public-signal-page-generator] failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[public-signal-page-generator] wrote draft preview: "
+        f"{manifest['output_directory']} signals_generated={manifest['signals_generated']} "
+        f"signals_blocked={manifest['signals_blocked']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/public_signal_page_generator_v1/publish_readiness_gate_report.json
+++ b/tests/fixtures/public_signal_page_generator_v1/publish_readiness_gate_report.json
@@ -1,0 +1,118 @@
+{
+  "gate_version": "publish_readiness_gate_v1",
+  "created_at": "2026-06-27T00:00:00+00:00",
+  "input_files": {
+    "owner_feedback": "tests/fixtures/publish_readiness_gate_v1/owner_feedback.json",
+    "brief": "tests/fixtures/publish_readiness_gate_v1/internal_brief.json",
+    "score_report": "tests/fixtures/publish_readiness_gate_v1/signal_quality_score.json"
+  },
+  "signals_evaluated": 5,
+  "ready_count": 2,
+  "blocked_count": 3,
+  "warning_count": 1,
+  "no_public_publishing_performed": true,
+  "no_deployment_performed": true,
+  "no_openai_call_performed": true,
+  "no_workflow_dispatch_performed": true,
+  "evaluations": [
+    {
+      "signal_id": "sig_ready_agent_eval",
+      "canonical_signal_id": "sig_ready_agent_eval",
+      "publication_candidate_id": "pubcand_sig_ready_agent_eval",
+      "title": "Agent evaluation benchmark adds recovery metric",
+      "public_title": "Agent evaluation benchmark adds recovery metric",
+      "public_slug": "agent-evaluation-recovery-metric",
+      "public_summary": "A synthetic benchmark update adds an explicit recovery metric for tool-use failures.",
+      "public_why_it_matters": "Recovery behavior is a concrete indicator of whether agent systems can handle failed tool calls without brittle manual intervention.",
+      "public_watch_next": "Watch whether model providers report recovery rates alongside task-completion benchmarks.",
+      "public_capability_area": "Agents",
+      "public_source_label": "Synthetic Research Lab benchmark note",
+      "public_attribution": "Source attributed to Synthetic Research Lab benchmark note.",
+      "source_url": "https://source.dysonx.test/research/agent-recovery-benchmark",
+      "source_authority": "First-party synthetic lab source for fixture validation.",
+      "source_urls": [
+        "https://source.dysonx.test/research/agent-recovery-benchmark"
+      ],
+      "score_normalized_to_65": 59,
+      "quality_tier": "Tier A: Decision-grade Signal",
+      "confidence_summary": "High confidence fixture with complete attribution.",
+      "warnings": [],
+      "publish_readiness_gate_passed": true,
+      "ready_for_public_generation": true,
+      "public_generation_blocked": false,
+      "gate_decision": "ready_for_public_generation",
+      "published": false,
+      "publication_approved": false
+    },
+    {
+      "signal_id": "sig_blocked_needs_more_sources",
+      "title": "Enterprise memory control note needs more source support",
+      "public_slug": "enterprise-memory-control-needs-more-sources",
+      "public_summary": "A useful note lacks enough source support for public generation.",
+      "public_capability_area": "Memory",
+      "source_url": "https://source.dysonx.test/product/memory-controls",
+      "quality_tier": "Tier B: Useful Signal",
+      "score_normalized_to_65": 50,
+      "publish_readiness_gate_passed": false,
+      "ready_for_public_generation": false,
+      "public_generation_blocked": true,
+      "gate_decision": "blocked_needs_more_sources",
+      "blockers": [
+        "blocked_needs_more_sources"
+      ],
+      "required_next_actions": [
+        "collect_or_attach_more_sources"
+      ],
+      "published": false,
+      "publication_approved": false
+    },
+    {
+      "signal_id": "sig_missing_gate_fields",
+      "title": "Missing gate fields should be blocked",
+      "public_slug": "missing-gate-fields",
+      "public_summary": "This record intentionally omits required gate pass fields.",
+      "published": false,
+      "publication_approved": false
+    },
+    {
+      "signal_id": "sig_published_true",
+      "title": "Published true should not generate draft",
+      "public_slug": "published-true-should-not-generate",
+      "public_summary": "This record is gate-passed but has published true.",
+      "public_why_it_matters": "It proves the generator refuses already-published records.",
+      "public_watch_next": "Keep publication flags separate from draft preview generation.",
+      "public_capability_area": "Agents",
+      "public_source_label": "Synthetic publication flag test",
+      "public_attribution": "Synthetic publication flag test source.",
+      "source_url": "https://source.dysonx.test/research/published-flag",
+      "score_normalized_to_65": 60,
+      "quality_tier": "Tier A: Decision-grade Signal",
+      "publish_readiness_gate_passed": true,
+      "ready_for_public_generation": true,
+      "public_generation_blocked": false,
+      "published": true,
+      "publication_approved": false
+    },
+    {
+      "signal_id": "sig_publication_approved_true",
+      "title": "Publication approved true should not be required",
+      "public_title": "Publication approved true should not be required",
+      "public_slug": "publication-approved-true-should-not-generate",
+      "public_summary": "Draft generation must not require or imply publication approval.",
+      "public_why_it_matters": "Manual Publish Approval V1 remains a later step.",
+      "public_watch_next": "Confirm drafts never mark approval.",
+      "public_capability_area": "Evaluation",
+      "public_source_label": "Synthetic approval boundary test",
+      "public_attribution": "Synthetic approval boundary test source.",
+      "source_url": "https://source.dysonx.test/research/approval-boundary",
+      "score_normalized_to_65": 61,
+      "quality_tier": "Tier A: Decision-grade Signal",
+      "publish_readiness_gate_passed": true,
+      "ready_for_public_generation": true,
+      "public_generation_blocked": false,
+      "published": false,
+      "publication_approved": true,
+      "article_body": "This raw article body must never appear in generated pages."
+    }
+  ]
+}

--- a/tests/test_dysonx_public_signal_page_generator.py
+++ b/tests/test_dysonx_public_signal_page_generator.py
@@ -1,0 +1,166 @@
+import ast
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dysonx_public_signal_page_generator.py"
+FIXTURE = ROOT / "tests" / "fixtures" / "public_signal_page_generator_v1" / "publish_readiness_gate_report.json"
+
+
+class DysonXPublicSignalPageGeneratorTests(unittest.TestCase):
+    def run_generator(self, gate_report=FIXTURE):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        output_dir = pathlib.Path(tmpdir.name) / "public_signal_pages"
+        cmd = [
+            sys.executable,
+            str(SCRIPT),
+            "--gate-report",
+            str(gate_report),
+            "--output-dir",
+            str(output_dir),
+        ]
+        result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, check=False)
+        manifest_path = output_dir / "public_signal_pages_manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else None
+        return result, manifest, output_dir
+
+    def test_ready_signal_generates_static_html_page(self):
+        result, manifest, output_dir = self.run_generator()
+        page = output_dir / "signals" / "agent-evaluation-recovery-metric" / "index.html"
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(page.exists())
+        html = page.read_text(encoding="utf-8")
+        self.assertIn("Agent evaluation benchmark adds recovery metric", html)
+        self.assertIn("Draft Preview / Not Published", html)
+        self.assertEqual(manifest["signals_generated"], 1)
+
+    def test_blocked_signal_does_not_generate_page(self):
+        _, manifest, output_dir = self.run_generator()
+
+        blocked_page = output_dir / "signals" / "enterprise-memory-control-needs-more-sources" / "index.html"
+        self.assertFalse(blocked_page.exists())
+        blocked_ids = {item["signal_id"] for item in manifest["blocked"]}
+        self.assertIn("sig_blocked_needs_more_sources", blocked_ids)
+
+    def test_missing_gate_fields_block_generation(self):
+        _, manifest, output_dir = self.run_generator()
+
+        self.assertFalse((output_dir / "signals" / "missing-gate-fields" / "index.html").exists())
+        missing = next(item for item in manifest["blocked"] if item["signal_id"] == "sig_missing_gate_fields")
+        self.assertIn("publish_readiness_gate_not_passed", missing["blockers"])
+        self.assertIn("not_ready_for_public_generation", missing["blockers"])
+
+    def test_published_true_blocks_draft_generation(self):
+        _, manifest, output_dir = self.run_generator()
+
+        self.assertFalse((output_dir / "signals" / "published-true-should-not-generate" / "index.html").exists())
+        blocked = next(item for item in manifest["blocked"] if item["signal_id"] == "sig_published_true")
+        self.assertIn("already_published_true", blocked["blockers"])
+
+    def test_publication_approved_true_is_not_required_and_does_not_generate(self):
+        _, manifest, output_dir = self.run_generator()
+
+        self.assertFalse((output_dir / "signals" / "publication-approved-true-should-not-generate" / "index.html").exists())
+        blocked = next(item for item in manifest["blocked"] if item["signal_id"] == "sig_publication_approved_true")
+        self.assertIn("publication_approved_true_requires_later_manual_approval_step", blocked["blockers"])
+        self.assertEqual(manifest["pages"][0]["publication_approved"], False)
+
+    def test_raw_article_body_is_not_copied(self):
+        _, _, output_dir = self.run_generator()
+
+        all_html = "\n".join(path.read_text(encoding="utf-8") for path in output_dir.rglob("*.html"))
+        self.assertNotIn("This raw article body must never appear", all_html)
+
+    def test_source_attribution_appears(self):
+        _, _, output_dir = self.run_generator()
+        html = (output_dir / "signals" / "agent-evaluation-recovery-metric" / "index.html").read_text(encoding="utf-8")
+
+        self.assertIn("Source attributed to Synthetic Research Lab benchmark note.", html)
+        self.assertIn("https://source.dysonx.test/research/agent-recovery-benchmark", html)
+
+    def test_index_page_includes_generated_signals_and_summary(self):
+        _, _, output_dir = self.run_generator()
+        index = output_dir / "signals" / "index.html"
+        html = index.read_text(encoding="utf-8")
+
+        self.assertIn("DysonX Public Signals Draft Preview", html)
+        self.assertIn("Agent evaluation benchmark adds recovery metric", html)
+        self.assertIn("Generated Signals", html)
+        self.assertIn("Blocked Signals", html)
+        self.assertIn("Manual Publish Approval V1 is required", html)
+
+    def test_manifest_includes_required_safety_flags(self):
+        _, manifest, _ = self.run_generator()
+
+        self.assertEqual(manifest["generator_version"], "public_signal_page_generator_v1")
+        self.assertTrue(manifest["no_public_publishing_performed"])
+        self.assertTrue(manifest["no_deployment_performed"])
+        self.assertTrue(manifest["no_openai_call_performed"])
+        self.assertTrue(manifest["no_workflow_dispatch_performed"])
+        self.assertTrue(manifest["manual_publish_approval_required"])
+        self.assertFalse(manifest["production_publish_performed"])
+
+    def test_local_preview_output_structure_is_correct(self):
+        _, manifest, output_dir = self.run_generator()
+
+        self.assertTrue((output_dir / "signals" / "index.html").exists())
+        self.assertTrue((output_dir / "signals" / "agent-evaluation-recovery-metric" / "index.html").exists())
+        self.assertTrue((output_dir / "public_signal_pages_manifest.json").exists())
+        self.assertTrue((output_dir / "README.md").exists())
+        self.assertEqual(manifest["pages"][0]["preview_path"], "signals/agent-evaluation-recovery-metric/")
+
+    def test_cli_is_deterministic_enough_for_tests(self):
+        _, first, _ = self.run_generator()
+        _, second, _ = self.run_generator()
+
+        for report in (first, second):
+            report.pop("created_at", None)
+            report["output_directory"] = "<output>"
+            for page in report["pages"]:
+                page["output_path"] = pathlib.Path(page["output_path"]).name
+        self.assertEqual(first, second)
+
+    def test_output_dir_must_be_under_tmp_when_relative(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = pathlib.Path("public_signal_pages_not_tmp")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--gate-report",
+                    str(FIXTURE),
+                    "--output-dir",
+                    str(output_dir),
+                ],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Output directory must be under tmp/", result.stderr)
+
+    def test_script_uses_standard_library_only(self):
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        imports = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.split(".")[0])
+
+        self.assertLessEqual(
+            imports,
+            {"__future__", "argparse", "json", "pathlib", "re", "shutil", "sys", "datetime", "html", "typing"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds deterministic offline public Signal page draft generator.
- Generates public-viewable draft pages only from Publish Readiness Gate-approved Signals.
- Adds Public Signals Index draft.
- Adds Local Public Preview artifacts/instructions.
- Does not publish to production.
- Does not deploy.
- Does not call OpenAI.
- Does not dispatch workflows.
- Does not bypass Manual Publish Approval V1.
- Keeps functional publishing before aesthetic polish.
- Keeps quality and safety gates mandatory.
- Confirms this is Step 2 of the strict 5-Step Final Launch Plan.

## Scope

- Adds `scripts/dysonx_public_signal_page_generator.py`.
- Adds generator docs in `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`.
- Adds focused tests and fixture coverage for ready, blocked, published, publication-approved, and raw-body cases.
- Minimally updates architecture and public publication governance references.

## Validation

- `python3 scripts/constitution_guard.py`: PASS
- `python3 scripts/architecture_guard.py`: PASS
- `python3 scripts/release_guard.py`: PASS
- `python3 -m py_compile scripts/*.py`: PASS
- `python3 -m unittest discover -s tests`: PASS, 319 tests
- `git diff --check origin/main...HEAD`: PASS

## Manual CLI Validation

```bash
rm -rf tmp/public_signal_pages
mkdir -p tmp
python3 scripts/dysonx_public_signal_page_generator.py 
  --gate-report tests/fixtures/public_signal_page_generator_v1/publish_readiness_gate_report.json 
  --output-dir tmp/public_signal_pages
```

Result:

- `signals_generated`: 1
- `signals_blocked`: 4
- Generated `tmp/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html`
- Generated `tmp/public_signal_pages/signals/index.html`
- Generated `tmp/public_signal_pages/public_signal_pages_manifest.json`
- Generated `tmp/public_signal_pages/README.md`

## Safety Boundary

- Draft preview only.
- Local preview is not publication.
- Manual Publish Approval V1 remains required before production release.
- No production publishing.
- No public deployment.
- No workflow dispatch.
- No OpenAI call.
- No scraping or source fetching.
- No backend API or database storage.
- No production deployment was performed.