### PR TITLE
feat: add DysonX Manual Publish Approval V1

### DIFF
--- a/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
+++ b/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
@@ -190,6 +190,8 @@ Fast publication progress also means automating blockers and readiness checks th
 
 Step 2 of the strict 5-Step Final Launch Plan is `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`: Public Signal Page Generator V1, Public Signals Index V1, and Local Public Preview V1. This step creates static draft preview artifacts only; generated drafts and local preview are not publication, do not replace Manual Publish Approval V1, and must remain visually simple while preserving credibility, readability, attribution, copyright safety, and gate approval.
 
+Step 3 of the strict 5-Step Final Launch Plan is `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`: Manual Publish Approval V1. This step consumes the Step 2 generator manifest plus explicit Owner approval input and emits an approval report for Step 4 Production Publish Pack. It does not publish, deploy, dispatch workflows, call OpenAI, or modify generated public HTML. `approved_for_production_pack` is not `published`; production release still requires Step 4 and Step 5.
+
 ## 8. Owner Role
 
 Owner is a strategic decision-maker, not a daily manual editor.

--- a/docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md
+++ b/docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md
@@ -1,0 +1,163 @@
+# DysonX Manual Publish Approval V1
+
+## 1. Purpose
+
+Manual Publish Approval V1 is Step 3 of the strict 5-Step Final Launch Plan:
+
+```text
+Owner Review Wizard
+-> Publish Readiness Gate
+-> Public Signal Page Generator
+-> Public Signals Index
+-> Local Public Preview
+-> Manual Publish Approval
+-> media.energizeos.com
+```
+
+It creates a deterministic offline approval report from Step 2 Public Signal Page Generator V1 manifest output and an explicit Owner approval input.
+
+The report is an input for Step 4 Production Publish Pack. It is not publication.
+
+## 2. Boundary
+
+Manual Publish Approval V1 does not:
+
+- publish
+- deploy
+- dispatch workflows
+- call OpenAI
+- scrape or fetch sources
+- modify generated public HTML
+- write production public pages
+- mark any page as published
+- perform production release
+
+It may set:
+
+```json
+{
+  "approved_for_production_pack": true
+}
+```
+
+It must not set:
+
+```json
+{
+  "published": true,
+  "production_publish_performed": true,
+  "deployed": true
+}
+```
+
+`approved_for_production_pack` means only that Step 4 may include the approved draft page in a production publish pack candidate. Published remains false until Step 5 production launch.
+
+## 3. CLI
+
+```bash
+python3 scripts/dysonx_manual_publish_approval.py \
+  --manifest tests/fixtures/manual_publish_approval_v1/public_signal_pages_manifest.json \
+  --approval-input tests/fixtures/manual_publish_approval_v1/manual_publish_approval_input.json \
+  --output tmp/manual_publish_approval_report.json
+```
+
+The CLI reads local JSON only and uses Python standard library modules.
+
+## 4. Approval Input
+
+The approval input must include:
+
+- `approval_version`
+- `owner.name`
+- `owner.role`
+- `approved_at`
+- `decisions`
+
+Allowed decisions:
+
+- `approve_for_production_pack`
+- `hold`
+- `reject`
+
+Only `approve_for_production_pack` can create an approved entry. `hold` and `reject` are recorded as blocked from Step 4 packaging.
+
+## 5. Approval Rules
+
+The tool approves only pages that:
+
+- exist in the Step 2 manifest `pages` list
+- were generated from Publish Readiness Gate-approved Signals
+- are ready for public generation
+- have `published` false or absent
+- have no `production_publish_performed` marker
+- come from a manifest where `manual_publish_approval_required` is true
+- have source page and preview paths
+- receive explicit Owner decision `approve_for_production_pack`
+- include Owner identity and approval timestamp
+
+The tool blocks:
+
+- missing page entries
+- generator-blocked Signals
+- missing Owner identity
+- missing approval timestamp
+- missing or unsupported decisions
+- `hold` and `reject`
+- `published: true`
+- `production_publish_performed: true`
+- manifests that do not require manual publish approval
+
+## 6. Output Report
+
+The report includes:
+
+- approval metadata
+- input files
+- Owner identity
+- approved timestamp
+- pages seen / approved / blocked counts
+- approved entries
+- blocked entries
+- safety flags
+
+Safety fields must state:
+
+- `manual_publish_approval_completed: true`
+- `no_public_publishing_performed: true`
+- `no_deployment_performed: true`
+- `no_openai_call_performed: true`
+- `no_workflow_dispatch_performed: true`
+- `production_publish_performed: false`
+- `production_pack_required: true`
+
+## 7. Functional Publishing Priority
+
+This step supports:
+
+```text
+Functional publishing before aesthetic polish;
+quality and safety gates before public release.
+```
+
+Manual approval is mandatory before production release. Public page visual polish remains a later sprint unless trust, safety, attribution, basic readability, or publication clarity is broken.
+
+## 8. Non-Goals
+
+This step does not implement:
+
+- Production Publish Pack
+- production deployment
+- public release
+- workflow dispatch
+- OpenAI calls
+- backend APIs
+- database storage
+- scraping
+- Knowledge Graph writes
+- Prediction Engine
+- Confidence Calibration
+- Multi-source Correlation
+- social distribution
+- final public visual polish
+
+No production deployment is authorized by this document.

--- a/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
+++ b/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
@@ -135,6 +135,8 @@ Public Signal Page Generator V1 must only consume Signals that pass `docs/DYSONX
 
 Public Signal Page Generator V1 is governed by `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`. It creates static draft / local preview artifacts only. Generated page drafts and local preview are not publication, and Manual Publish Approval V1 remains required before production release.
 
+Manual Publish Approval V1 is governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`. It creates an offline approval report for Step 4 Production Publish Pack only; it does not publish, deploy, dispatch workflows, call OpenAI, or modify generated public HTML. `approved_for_production_pack` must not be treated as `published`.
+
 ## 7. Public Website Responsibility
 
 Public website is the external product surface.

--- a/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
@@ -147,7 +147,15 @@ Safety fields must state:
 - `manual_publish_approval_required: true`
 - `production_publish_performed: false`
 
-## 9. Non-Goals
+## 9. Manual Publish Approval Handoff
+
+Manual Publish Approval V1 is governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`.
+
+The Step 2 manifest is the input to Step 3. Step 3 may approve generated draft pages for a future Production Publish Pack only after explicit Owner approval.
+
+`approved_for_production_pack` is not publication. It does not change generated HTML, does not deploy, does not dispatch workflows, and does not make `published` true.
+
+## 10. Non-Goals
 
 This step does not implement:
 

--- a/docs/DYSONX_SYSTEM_ARCHITECTURE.md
+++ b/docs/DYSONX_SYSTEM_ARCHITECTURE.md
@@ -132,6 +132,8 @@ Public-facing surfaces are governed by `docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES
 
 Public Signal Page Generator V1 is the Step 2 static draft generator governed by `docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md`. It may generate local preview HTML only after Publish Readiness Gate V1 passes, and those draft pages are not publication, production approval, deployment, or public release.
 
+Manual Publish Approval V1 is the Step 3 offline approval report governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`. It consumes the Step 2 manifest and explicit Owner approval input for the future Production Publish Pack. `approved_for_production_pack` is not publication, does not modify generated HTML, and does not deploy.
+
 ## Tracker Layer
 
 Trackers are persistent intelligence surfaces for companies, people, topics, capabilities, models, papers, policies, and GitHub projects.

--- a/scripts/dysonx_manual_publish_approval.py
+++ b/scripts/dysonx_manual_publish_approval.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""DysonX Manual Publish Approval V1.
+
+Consumes a Public Signal Page Generator manifest and an Owner manual approval
+input, then writes an approval report for a future Production Publish Pack.
+This tool is offline, deterministic, and standard-library only. It does not
+publish, deploy, call OpenAI, dispatch workflows, fetch URLs, scrape sources,
+modify generated pages, write production public pages, or approve production
+release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+
+APPROVAL_VERSION = "manual_publish_approval_v1"
+APPROVE_DECISION = "approve_for_production_pack"
+ALLOWED_DECISIONS = {APPROVE_DECISION, "hold", "reject"}
+
+
+class ApprovalInputError(ValueError):
+    """Raised when the approval tool cannot safely process input."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json_object(path: str | pathlib.Path, label: str) -> dict[str, Any]:
+    input_path = pathlib.Path(path)
+    try:
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI fails closed on malformed JSON.
+        raise ApprovalInputError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ApprovalInputError(f"{label} must be a JSON object")
+    return data
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def first_present(record: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = record.get(key)
+        if value not in (None, "", []):
+            return value
+    return None
+
+
+def page_signal_id(page: dict[str, Any]) -> str:
+    return normalize_text(first_present(page, "signal_id", "canonical_signal_id", "id"))
+
+
+def page_slug(page: dict[str, Any]) -> str:
+    return normalize_text(first_present(page, "slug", "public_slug", "signal_slug"))
+
+
+def decision_key(decision: dict[str, Any]) -> str:
+    return normalize_text(first_present(decision, "slug", "signal_id", "id"))
+
+
+def owner_is_valid(owner: Any) -> bool:
+    if not isinstance(owner, dict):
+        return False
+    return bool(normalize_text(owner.get("name")) and normalize_text(owner.get("role")))
+
+
+def index_pages(manifest: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    pages = manifest.get("pages")
+    if not isinstance(pages, list):
+        raise ApprovalInputError("Public Signal Page Generator manifest must include a pages list")
+    by_slug: dict[str, dict[str, Any]] = {}
+    by_signal_id: dict[str, dict[str, Any]] = {}
+    for page in pages:
+        if not isinstance(page, dict):
+            continue
+        slug = page_slug(page)
+        signal_id = page_signal_id(page)
+        if slug:
+            by_slug[slug] = page
+        if signal_id:
+            by_signal_id[signal_id] = page
+    return by_slug, by_signal_id
+
+
+def blocked_manifest_entries(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    blocked: dict[str, dict[str, Any]] = {}
+    for entry in as_list(manifest.get("blocked")):
+        if not isinstance(entry, dict):
+            continue
+        for key in (page_slug(entry), page_signal_id(entry)):
+            if key:
+                blocked[key] = entry
+    return blocked
+
+
+def lookup_page(
+    decision: dict[str, Any],
+    pages_by_slug: dict[str, dict[str, Any]],
+    pages_by_signal_id: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    slug = normalize_text(decision.get("slug"))
+    signal_id = normalize_text(first_present(decision, "signal_id", "id"))
+    if slug and slug in pages_by_slug:
+        return pages_by_slug[slug]
+    if signal_id and signal_id in pages_by_signal_id:
+        return pages_by_signal_id[signal_id]
+    return None
+
+
+def page_blockers(page: dict[str, Any], manifest: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if page.get("publish_readiness_gate_passed") is not True:
+        blockers.append("publish_readiness_gate_not_passed")
+    if page.get("ready_for_public_generation") is not True:
+        blockers.append("not_ready_for_public_generation")
+    if page.get("published") is True:
+        blockers.append("published_true_blocks_manual_approval")
+    if page.get("production_publish_performed") is True:
+        blockers.append("page_production_publish_performed_true")
+    if manifest.get("production_publish_performed") is True:
+        blockers.append("manifest_production_publish_performed_true")
+    if manifest.get("manual_publish_approval_required") is not True:
+        blockers.append("manual_publish_approval_required_not_true")
+    if not normalize_text(page.get("output_path")):
+        blockers.append("missing_source_page_path")
+    if not normalize_text(page.get("preview_path")):
+        blockers.append("missing_preview_path")
+    return blockers
+
+
+def required_actions_for(blockers: list[str], decision: str | None = None) -> list[str]:
+    actions: list[str] = []
+    if "missing_owner_identity" in blockers:
+        actions.append("provide_owner_name_and_role")
+    if "missing_approved_at" in blockers:
+        actions.append("provide_manual_approval_timestamp")
+    if "missing_approval_decision" in blockers:
+        actions.append("provide_approval_decision")
+    if "unsupported_decision" in blockers:
+        actions.append("use_approve_for_production_pack_hold_or_reject")
+    if "decision_not_approve_for_production_pack" in blockers:
+        actions.append("change_decision_to_approve_for_production_pack_after_owner_review")
+    if "page_not_found_in_generator_manifest" in blockers:
+        actions.append("regenerate_or_select_a_manifest_page")
+    if "signal_was_blocked_by_generator" in blockers:
+        actions.append("resolve_generator_blockers_before_manual_approval")
+    if any("published" in blocker or "production_publish" in blocker for blocker in blockers):
+        actions.append("use_only_unpublished_draft_preview_pages")
+    if any("publish_readiness" in blocker or "ready_for_public_generation" in blocker for blocker in blockers):
+        actions.append("rerun_publish_readiness_gate_and_public_signal_page_generator")
+    if "manual_publish_approval_required_not_true" in blockers:
+        actions.append("use_a_step_2_manifest_that_requires_manual_publish_approval")
+    if decision in {"hold", "reject"} and not actions:
+        actions.append("resolve_manual_publish_decision_before_step_4")
+    return list(dict.fromkeys(actions)) or ["resolve_blockers_before_step_4_production_pack"]
+
+
+def blocked_entry(
+    decision: dict[str, Any],
+    page: dict[str, Any] | None,
+    blockers: list[str],
+    manifest_blocked: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    source = page or manifest_blocked or decision
+    signal_id = normalize_text(first_present(decision, "signal_id", "id", "slug")) or page_signal_id(source)
+    slug = normalize_text(decision.get("slug")) or page_slug(source)
+    entry: dict[str, Any] = {
+        "signal_id": signal_id,
+        "slug": slug,
+        "title": normalize_text(first_present(source, "title", "public_title")),
+        "decision": normalize_text(decision.get("decision")),
+        "blockers": list(dict.fromkeys(blockers)),
+        "required_next_actions": required_actions_for(blockers, normalize_text(decision.get("decision"))),
+    }
+    return entry
+
+
+def approved_entry(page: dict[str, Any], decision: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "signal_id": page_signal_id(page),
+        "title": normalize_text(page.get("title")),
+        "slug": page_slug(page),
+        "source_page_path": normalize_text(page.get("output_path")),
+        "preview_path": normalize_text(page.get("preview_path")),
+        "decision": normalize_text(decision.get("decision")),
+        "approved_for_production_pack": True,
+        "published": False,
+        "production_publish_performed": False,
+    }
+
+
+def build_approval_report(
+    manifest: dict[str, Any],
+    approval_input: dict[str, Any],
+    manifest_path: pathlib.Path,
+    approval_input_path: pathlib.Path,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    pages_by_slug, pages_by_signal_id = index_pages(manifest)
+    blocked_by_key = blocked_manifest_entries(manifest)
+    owner = approval_input.get("owner")
+    approved_at = normalize_text(approval_input.get("approved_at"))
+    owner_blockers: list[str] = []
+    if not owner_is_valid(owner):
+        owner_blockers.append("missing_owner_identity")
+    if not approved_at:
+        owner_blockers.append("missing_approved_at")
+
+    decisions = approval_input.get("decisions")
+    if not isinstance(decisions, list):
+        raise ApprovalInputError("Approval input must include a decisions list")
+
+    approved: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+
+    for decision in decisions:
+        if not isinstance(decision, dict):
+            blocked.append(
+                {
+                    "signal_id": "",
+                    "slug": "",
+                    "title": "",
+                    "decision": "",
+                    "blockers": ["invalid_decision_record"],
+                    "required_next_actions": ["provide_object_decision_records"],
+                }
+            )
+            continue
+
+        blockers = list(owner_blockers)
+        decision_value = normalize_text(decision.get("decision"))
+        if not decision_value:
+            blockers.append("missing_approval_decision")
+        elif decision_value not in ALLOWED_DECISIONS:
+            blockers.append("unsupported_decision")
+        elif decision_value != APPROVE_DECISION:
+            blockers.append("decision_not_approve_for_production_pack")
+
+        page = lookup_page(decision, pages_by_slug, pages_by_signal_id)
+        manifest_blocked = blocked_by_key.get(decision_key(decision))
+        if page is None:
+            if manifest_blocked is not None:
+                blockers.append("signal_was_blocked_by_generator")
+            else:
+                blockers.append("page_not_found_in_generator_manifest")
+        else:
+            blockers.extend(page_blockers(page, manifest))
+
+        if blockers:
+            blocked.append(blocked_entry(decision, page, blockers, manifest_blocked))
+        else:
+            approved.append(approved_entry(page, decision))
+
+    return {
+        "approval_version": APPROVAL_VERSION,
+        "created_at": created_at or utc_now(),
+        "input_files": {
+            "manifest": str(manifest_path),
+            "approval_input": str(approval_input_path),
+        },
+        "owner": owner if isinstance(owner, dict) else {},
+        "approved_at": approved_at,
+        "pages_seen": len(as_list(manifest.get("pages"))),
+        "pages_approved": len(approved),
+        "pages_blocked": len(blocked),
+        "approved": approved,
+        "blocked": blocked,
+        "manual_publish_approval_completed": True,
+        "no_public_publishing_performed": True,
+        "no_deployment_performed": True,
+        "no_openai_call_performed": True,
+        "no_workflow_dispatch_performed": True,
+        "production_publish_performed": False,
+        "production_pack_required": True,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create DysonX Manual Publish Approval V1 report.")
+    parser.add_argument("--manifest", required=True, help="Public Signal Page Generator manifest JSON input.")
+    parser.add_argument("--approval-input", required=True, help="Owner manual approval input JSON.")
+    parser.add_argument("--output", required=True, help="Output approval report JSON path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest_path = pathlib.Path(args.manifest)
+    approval_input_path = pathlib.Path(args.approval_input)
+    output_path = pathlib.Path(args.output)
+    try:
+        manifest = read_json_object(manifest_path, "Public Signal Page Generator manifest")
+        approval_input = read_json_object(approval_input_path, "Manual publish approval input")
+        report = build_approval_report(manifest, approval_input, manifest_path, approval_input_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    except ApprovalInputError as exc:
+        print(f"[manual-publish-approval] failed: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"[manual-publish-approval] failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[manual-publish-approval] wrote approval report: "
+        f"{output_path} pages_approved={report['pages_approved']} pages_blocked={report['pages_blocked']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/manual_publish_approval_v1/expected_manual_publish_approval_report.json
+++ b/tests/fixtures/manual_publish_approval_v1/expected_manual_publish_approval_report.json
@@ -1,0 +1,16 @@
+{
+  "approved_slugs": [
+    "agent-evaluation-recovery-metric"
+  ],
+  "blocked_expectations": {
+    "agent-evaluation-recovery-metric:hold": "decision_not_approve_for_production_pack",
+    "agent-evaluation-recovery-metric:reject": "decision_not_approve_for_production_pack",
+    "blocked-by-generator:approve_for_production_pack": "signal_was_blocked_by_generator",
+    "production-publish-performed-page:approve_for_production_pack": "page_production_publish_performed_true",
+    "published-true-page:approve_for_production_pack": "published_true_blocks_manual_approval",
+    "unknown-slug:approve_for_production_pack": "page_not_found_in_generator_manifest"
+  },
+  "pages_approved": 1,
+  "pages_blocked": 6,
+  "pages_seen": 3
+}

--- a/tests/fixtures/manual_publish_approval_v1/manual_publish_approval_input.json
+++ b/tests/fixtures/manual_publish_approval_v1/manual_publish_approval_input.json
@@ -1,0 +1,45 @@
+{
+  "approval_version": "manual_publish_approval_v1",
+  "approved_at": "2026-06-27T00:00:00Z",
+  "decisions": [
+    {
+      "decision": "approve_for_production_pack",
+      "notes": "Approved after local public preview.",
+      "slug": "agent-evaluation-recovery-metric"
+    },
+    {
+      "decision": "hold",
+      "notes": "Hold for later review.",
+      "slug": "agent-evaluation-recovery-metric"
+    },
+    {
+      "decision": "reject",
+      "notes": "Reject for this production pack.",
+      "slug": "agent-evaluation-recovery-metric"
+    },
+    {
+      "decision": "approve_for_production_pack",
+      "notes": "Unknown slug should block.",
+      "slug": "unknown-slug"
+    },
+    {
+      "decision": "approve_for_production_pack",
+      "notes": "Published true must block.",
+      "slug": "published-true-page"
+    },
+    {
+      "decision": "approve_for_production_pack",
+      "notes": "Production publish performed must block.",
+      "slug": "production-publish-performed-page"
+    },
+    {
+      "decision": "approve_for_production_pack",
+      "notes": "Blocked generator Signal must block.",
+      "slug": "blocked-by-generator"
+    }
+  ],
+  "owner": {
+    "name": "Andy Gong",
+    "role": "Owner"
+  }
+}

--- a/tests/fixtures/manual_publish_approval_v1/public_signal_pages_manifest.json
+++ b/tests/fixtures/manual_publish_approval_v1/public_signal_pages_manifest.json
@@ -1,0 +1,66 @@
+{
+  "blocked": [
+    {
+      "blockers": [
+        "public_generation_blocked"
+      ],
+      "required_next_actions": [
+        "resolve_publish_readiness_gate_blockers"
+      ],
+      "signal_id": "sig_blocked_by_generator",
+      "slug": "blocked-by-generator",
+      "title": "Blocked generator Signal"
+    }
+  ],
+  "created_at": "2026-06-27T00:00:00+00:00",
+  "generator_version": "public_signal_page_generator_v1",
+  "input_files": {
+    "gate_report": "tests/fixtures/public_signal_page_generator_v1/publish_readiness_gate_report.json"
+  },
+  "manual_publish_approval_required": true,
+  "no_deployment_performed": true,
+  "no_openai_call_performed": true,
+  "no_public_publishing_performed": true,
+  "no_workflow_dispatch_performed": true,
+  "output_directory": "tmp/public_signal_pages",
+  "pages": [
+    {
+      "output_path": "tmp/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html",
+      "preview_path": "signals/agent-evaluation-recovery-metric/",
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": false,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_ready_agent_eval",
+      "slug": "agent-evaluation-recovery-metric",
+      "title": "Agent evaluation benchmark adds recovery metric"
+    },
+    {
+      "output_path": "tmp/public_signal_pages/signals/published-true-page/index.html",
+      "preview_path": "signals/published-true-page/",
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": true,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_published_true",
+      "slug": "published-true-page",
+      "title": "Published true page should not be approved"
+    },
+    {
+      "output_path": "tmp/public_signal_pages/signals/production-publish-performed-page/index.html",
+      "preview_path": "signals/production-publish-performed-page/",
+      "production_publish_performed": true,
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": false,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_production_publish_performed",
+      "slug": "production-publish-performed-page",
+      "title": "Production publish performed page should not be approved"
+    }
+  ],
+  "production_publish_performed": false,
+  "signals_blocked": 1,
+  "signals_generated": 3,
+  "signals_seen": 4
+}

--- a/tests/test_dysonx_manual_publish_approval.py
+++ b/tests/test_dysonx_manual_publish_approval.py
@@ -1,0 +1,158 @@
+import ast
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dysonx_manual_publish_approval.py"
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "manual_publish_approval_v1"
+MANIFEST = FIXTURE_DIR / "public_signal_pages_manifest.json"
+APPROVAL_INPUT = FIXTURE_DIR / "manual_publish_approval_input.json"
+EXPECTED = FIXTURE_DIR / "expected_manual_publish_approval_report.json"
+
+
+class DysonXManualPublishApprovalTests(unittest.TestCase):
+    def run_approval(self, manifest=MANIFEST, approval_input=APPROVAL_INPUT):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        output = pathlib.Path(tmpdir.name) / "manual_publish_approval_report.json"
+        cmd = [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest),
+            "--approval-input",
+            str(approval_input),
+            "--output",
+            str(output),
+        ]
+        result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, check=False)
+        report = json.loads(output.read_text(encoding="utf-8")) if output.exists() else None
+        return result, report
+
+    def write_fixture(self, data):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = pathlib.Path(tmpdir.name) / "input.json"
+        path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def test_valid_generated_draft_page_approve_creates_approved_entry(self):
+        result, report = self.run_approval()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(report["pages_approved"], 1)
+        approved = report["approved"][0]
+        self.assertEqual(approved["slug"], "agent-evaluation-recovery-metric")
+        self.assertTrue(approved["approved_for_production_pack"])
+        self.assertFalse(approved["published"])
+        self.assertFalse(approved["production_publish_performed"])
+
+    def test_hold_decision_blocks_approval(self):
+        _, report = self.run_approval()
+
+        hold = next(item for item in report["blocked"] if item["slug"] == "agent-evaluation-recovery-metric" and item["decision"] == "hold")
+        self.assertIn("decision_not_approve_for_production_pack", hold["blockers"])
+
+    def test_reject_decision_blocks_approval(self):
+        _, report = self.run_approval()
+
+        rejected = next(item for item in report["blocked"] if item["slug"] == "agent-evaluation-recovery-metric" and item["decision"] == "reject")
+        self.assertIn("decision_not_approve_for_production_pack", rejected["blockers"])
+
+    def test_unknown_slug_blocks_approval(self):
+        _, report = self.run_approval()
+
+        unknown = next(item for item in report["blocked"] if item["slug"] == "unknown-slug")
+        self.assertIn("page_not_found_in_generator_manifest", unknown["blockers"])
+
+    def test_missing_owner_identity_blocks_approval(self):
+        data = json.loads(APPROVAL_INPUT.read_text(encoding="utf-8"))
+        data["owner"] = {"name": "", "role": "Owner"}
+
+        _, report = self.run_approval(approval_input=self.write_fixture(data))
+
+        self.assertEqual(report["pages_approved"], 0)
+        self.assertTrue(all("missing_owner_identity" in item["blockers"] for item in report["blocked"]))
+
+    def test_missing_approved_at_blocks_approval(self):
+        data = json.loads(APPROVAL_INPUT.read_text(encoding="utf-8"))
+        data["approved_at"] = ""
+
+        _, report = self.run_approval(approval_input=self.write_fixture(data))
+
+        self.assertEqual(report["pages_approved"], 0)
+        self.assertTrue(all("missing_approved_at" in item["blockers"] for item in report["blocked"]))
+
+    def test_published_true_blocks_approval(self):
+        _, report = self.run_approval()
+
+        blocked = next(item for item in report["blocked"] if item["slug"] == "published-true-page")
+        self.assertIn("published_true_blocks_manual_approval", blocked["blockers"])
+
+    def test_production_publish_performed_true_blocks_approval(self):
+        _, report = self.run_approval()
+
+        blocked = next(item for item in report["blocked"] if item["slug"] == "production-publish-performed-page")
+        self.assertIn("page_production_publish_performed_true", blocked["blockers"])
+
+    def test_approval_report_never_sets_published_true(self):
+        _, report = self.run_approval()
+
+        self.assertFalse(any(item.get("published") is True for item in report["approved"]))
+        self.assertFalse(report["production_publish_performed"])
+
+    def test_approval_report_never_sets_production_publish_performed_true(self):
+        _, report = self.run_approval()
+
+        self.assertFalse(any(item.get("production_publish_performed") is True for item in report["approved"]))
+        self.assertFalse(report["production_publish_performed"])
+
+    def test_report_includes_required_safety_flags(self):
+        _, report = self.run_approval()
+
+        self.assertEqual(report["approval_version"], "manual_publish_approval_v1")
+        self.assertTrue(report["manual_publish_approval_completed"])
+        self.assertTrue(report["no_public_publishing_performed"])
+        self.assertTrue(report["no_deployment_performed"])
+        self.assertTrue(report["no_openai_call_performed"])
+        self.assertTrue(report["no_workflow_dispatch_performed"])
+        self.assertFalse(report["production_publish_performed"])
+        self.assertTrue(report["production_pack_required"])
+
+    def test_cli_output_matches_expected_fixture_without_timestamp_paths(self):
+        _, report = self.run_approval()
+        expected = json.loads(EXPECTED.read_text(encoding="utf-8"))
+
+        self.assertEqual(report["pages_seen"], expected["pages_seen"])
+        self.assertEqual(report["pages_approved"], expected["pages_approved"])
+        self.assertEqual(report["pages_blocked"], expected["pages_blocked"])
+        self.assertEqual([item["slug"] for item in report["approved"]], expected["approved_slugs"])
+        blocked = {f"{item['slug']}:{item['decision']}": item["blockers"] for item in report["blocked"]}
+        for key, blocker in expected["blocked_expectations"].items():
+            self.assertIn(blocker, blocked[key])
+
+    def test_blocked_generator_signal_cannot_be_approved(self):
+        _, report = self.run_approval()
+
+        blocked = next(item for item in report["blocked"] if item["slug"] == "blocked-by-generator")
+        self.assertIn("signal_was_blocked_by_generator", blocked["blockers"])
+
+    def test_script_uses_standard_library_only(self):
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        imports = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.split(".")[0])
+
+        self.assertLessEqual(imports, {"__future__", "argparse", "json", "pathlib", "sys", "datetime", "typing"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds deterministic offline Manual Publish Approval V1.
- Consumes Public Signal Page Generator manifest.
- Consumes Owner manual approval input.
- Produces approval report for Step 4 Production Publish Pack.
- Allows approved_for_production_pack only after explicit Owner approval.
- Does not publish to production.
- Does not deploy.
- Does not call OpenAI.
- Does not dispatch workflows.
- Does not modify generated public pages.
- Keeps Manual Publish Approval mandatory before production release.
- Keeps functional publishing before aesthetic polish.
- Confirms this is Step 3 of the strict 5-Step Final Launch Plan.

## Validation
- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 333 tests
- git diff --check origin/main...HEAD: PASS
- Manual CLI validation: PASS, pages_approved=1 pages_blocked=6

## Safety
- No public publishing performed.
- No production publishing performed.
- No deployment performed.
- No workflow dispatch performed.
- No OpenAI call performed.
- approved_for_production_pack does not mean published.
- Step 4 Production Publish Pack is still required.