### PR TITLE
feat: add DysonX Production Publish Pack V1

### DIFF
--- a/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
+++ b/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
@@ -192,6 +192,8 @@ Step 2 of the strict 5-Step Final Launch Plan is `docs/DYSONX_PUBLIC_SIGNAL_PAGE
 
 Step 3 of the strict 5-Step Final Launch Plan is `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`: Manual Publish Approval V1. This step consumes the Step 2 generator manifest plus explicit Owner approval input and emits an approval report for Step 4 Production Publish Pack. It does not publish, deploy, dispatch workflows, call OpenAI, or modify generated public HTML. `approved_for_production_pack` is not `published`; production release still requires Step 4 and Step 5.
 
+Step 4 of the strict 5-Step Final Launch Plan is `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`: Production Publish Pack V1 and Release Guard Integration V1. This step consumes Step 2 generated public pages and Step 3 manual approval, packages only approved pages, and emits release guard evidence for Step 5. It does not publish to production, deploy, dispatch workflows, call OpenAI, write to `media.energizeos.com`, or mark `published` or `production_publish_performed` true. Step 5 explicit Owner launch authorization remains required.
+
 ## 8. Owner Role
 
 Owner is a strategic decision-maker, not a daily manual editor.

--- a/docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md
+++ b/docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md
@@ -52,6 +52,8 @@ It must not set:
 
 `approved_for_production_pack` means only that Step 4 may include the approved draft page in a production publish pack candidate. Published remains false until Step 5 production launch.
 
+Production Publish Pack V1 is governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. It consumes the Step 2 generator output and this Step 3 approval report to create production-ready artifacts for Step 5. It does not publish, deploy, dispatch workflows, call OpenAI, write to `media.energizeos.com`, or mark `published` true.
+
 ## 3. CLI
 
 ```bash

--- a/docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md
+++ b/docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md
@@ -1,0 +1,158 @@
+# DysonX Production Publish Pack V1
+
+## 1. Purpose
+
+Production Publish Pack V1 is Step 4 of the strict 5-Step Final Launch Plan:
+
+```text
+Owner Review Wizard
+-> Publish Readiness Gate
+-> Public Signal Page Generator
+-> Public Signals Index
+-> Local Public Preview
+-> Manual Publish Approval
+-> Production Publish Pack
+-> media.energizeos.com
+```
+
+It creates deterministic offline production-ready artifacts for Step 5 from:
+
+- Step 2 Public Signal Page Generator output and manifest
+- Step 3 Manual Publish Approval report
+
+The pack is a launch candidate only. It is not deployment and not publication.
+
+## 2. Boundary
+
+Production Publish Pack V1 does not:
+
+- publish to production
+- deploy
+- dispatch workflows
+- call OpenAI
+- scrape or fetch sources
+- write to `media.energizeos.com`
+- write to a production site root
+- mark `published` true
+- mark `production_publish_performed` true
+- mark `deployed` true
+
+Step 5 explicit Owner launch authorization is still required before production release.
+
+## 3. CLI
+
+```bash
+python3 scripts/dysonx_production_publish_pack.py \
+  --public-pages-dir tests/fixtures/production_publish_pack_v1/public_signal_pages \
+  --public-pages-manifest tests/fixtures/production_publish_pack_v1/public_signal_pages_manifest.json \
+  --approval-report tests/fixtures/production_publish_pack_v1/manual_publish_approval_report.json \
+  --output-dir tmp/production_publish_pack
+```
+
+The CLI reads local files only and uses Python standard library modules.
+
+## 4. Packaging Rules
+
+The pack may include only pages where:
+
+- `approved_for_production_pack` is true
+- `published` is false
+- `production_publish_performed` is false
+- `deployed` is false or absent
+- the corresponding generated page exists in the Step 2 manifest
+- the corresponding HTML file exists under the provided public pages directory
+- the source page says `Draft Preview / Not Published`
+- no raw article body is detected
+- no internal review state is detected
+
+All other pages are blocked with explicit blockers and required next actions.
+
+## 5. Output Structure
+
+Default output:
+
+```text
+tmp/production_publish_pack/
+```
+
+Generated files:
+
+```text
+tmp/production_publish_pack/signals/<slug>/index.html
+tmp/production_publish_pack/signals/index.html
+tmp/production_publish_pack/production_publish_pack_manifest.json
+tmp/production_publish_pack/release_guard_report.json
+tmp/production_publish_pack/README.md
+```
+
+Packaged pages may relabel:
+
+```text
+Draft Preview / Not Published
+```
+
+to:
+
+```text
+Production Publish Candidate / Not Yet Deployed
+```
+
+They must not claim the page is published, live, deployed, or production deployed.
+
+## 6. Release Guard Report
+
+The pack includes:
+
+```text
+tmp/production_publish_pack/release_guard_report.json
+```
+
+The release guard checks:
+
+- manual approval report exists in the input set
+- only approved pages are packaged
+- no unapproved pages are packaged
+- packaged files exist
+- index is generated
+- `published` is not true before launch
+- `production_publish_performed` is not true before launch
+- `deployed` is not true
+- no raw article body is detected
+- no internal review state is detected
+- no OpenAI call is performed
+- no workflow dispatch is performed
+- no deployment is performed
+- Step 5 launch authorization remains required
+
+If any critical check fails, `release_guard_passed` must be false.
+
+## 7. Functional Publishing Priority
+
+This step supports:
+
+```text
+Functional publishing before aesthetic polish;
+quality and safety gates before public release.
+```
+
+The pack prioritizes a safe, controllable, verifiable launch path over visual polish. Quality gates, attribution, copyright safety, Manual Publish Approval, release guards, and explicit Step 5 launch authorization remain mandatory.
+
+## 8. Non-Goals
+
+This step does not implement:
+
+- Step 5 public launch
+- production deployment
+- workflow dispatch
+- OpenAI calls
+- backend APIs
+- database storage
+- scraping
+- Knowledge Graph writes
+- Prediction Engine
+- Confidence Calibration
+- Multi-source Correlation
+- social distribution
+- visual polish
+
+No production deployment is authorized by this document.

--- a/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
+++ b/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
@@ -137,6 +137,8 @@ Public Signal Page Generator V1 is governed by `docs/DYSONX_PUBLIC_SIGNAL_PAGE_G
 
 Manual Publish Approval V1 is governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`. It creates an offline approval report for Step 4 Production Publish Pack only; it does not publish, deploy, dispatch workflows, call OpenAI, or modify generated public HTML. `approved_for_production_pack` must not be treated as `published`.
 
+Production Publish Pack V1 is governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. It creates production-ready artifacts for Step 5 only. It does not write to `media.energizeos.com`, deploy, publish, dispatch workflows, call OpenAI, or mark `published` true. Step 5 explicit Owner launch authorization remains required.
+
 ## 7. Public Website Responsibility
 
 Public website is the external product surface.

--- a/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
@@ -155,6 +155,8 @@ The Step 2 manifest is the input to Step 3. Step 3 may approve generated draft p
 
 `approved_for_production_pack` is not publication. It does not change generated HTML, does not deploy, does not dispatch workflows, and does not make `published` true.
 
+Production Publish Pack V1 is governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. Step 4 consumes the Step 2 generated output plus Step 3 approval report to create production-ready artifacts for Step 5, without deployment or production publishing.
+
 ## 10. Non-Goals
 
 This step does not implement:

--- a/docs/DYSONX_SYSTEM_ARCHITECTURE.md
+++ b/docs/DYSONX_SYSTEM_ARCHITECTURE.md
@@ -134,6 +134,8 @@ Public Signal Page Generator V1 is the Step 2 static draft generator governed by
 
 Manual Publish Approval V1 is the Step 3 offline approval report governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md`. It consumes the Step 2 manifest and explicit Owner approval input for the future Production Publish Pack. `approved_for_production_pack` is not publication, does not modify generated HTML, and does not deploy.
 
+Production Publish Pack V1 is the Step 4 offline artifact pack governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. It consumes Step 2 generated pages and Step 3 approval, packages only approved pages for Step 5, emits release guard evidence, and does not publish, deploy, dispatch workflows, call OpenAI, write to `media.energizeos.com`, or mark `published` true.
+
 ## Tracker Layer
 
 Trackers are persistent intelligence surfaces for companies, people, topics, capabilities, models, papers, policies, and GitHub projects.

--- a/scripts/dysonx_production_publish_pack.py
+++ b/scripts/dysonx_production_publish_pack.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""DysonX Production Publish Pack V1.
+
+Creates a deterministic offline production publish pack candidate from Step 2
+draft public pages and Step 3 manual approval. This tool does not publish,
+deploy, call OpenAI, dispatch workflows, fetch URLs, scrape sources, write to
+media.energizeos.com, or mark any page as published.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from html import escape
+from typing import Any
+
+
+PACK_VERSION = "production_publish_pack_v1"
+RELEASE_GUARD_VERSION = "production_publish_pack_release_guard_v1"
+DEFAULT_OUTPUT_DIR = pathlib.Path("tmp/production_publish_pack")
+RAW_BODY_MARKERS = (
+    "raw article body",
+    "raw_body",
+    "article_body",
+    "scraped_text",
+    "raw copyrighted article text",
+)
+INTERNAL_STATE_MARKERS = (
+    "owner_comment",
+    "owner comments",
+    "internal decision trail",
+    "private review state",
+    "selected_owner_decision",
+    "review_session",
+)
+
+
+class PublishPackInputError(ValueError):
+    """Raised when the pack generator cannot safely process inputs."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json_object(path: str | pathlib.Path, label: str) -> dict[str, Any]:
+    input_path = pathlib.Path(path)
+    try:
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI fails closed on malformed JSON.
+        raise PublishPackInputError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PublishPackInputError(f"{label} must be a JSON object")
+    return data
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def first_present(record: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = record.get(key)
+        if value not in (None, "", []):
+            return value
+    return None
+
+
+def signal_id(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "signal_id", "canonical_signal_id", "id"))
+
+
+def slug(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "slug", "public_slug", "signal_slug"))
+
+
+def title(record: dict[str, Any]) -> str:
+    return normalize_text(first_present(record, "title", "public_title")) or "Untitled Signal"
+
+
+def safe_output_root(output_dir: pathlib.Path) -> pathlib.Path:
+    normalized = pathlib.Path(output_dir)
+    if normalized.is_absolute():
+        if not any(part == "tmp" or part.startswith("tmp") for part in normalized.parts):
+            raise PublishPackInputError("Absolute output directory must be under a temporary pack path")
+        return normalized
+    if not normalized.parts or normalized.parts[0] != "tmp":
+        raise PublishPackInputError("Output directory must be under tmp/ for production publish pack generation")
+    return normalized
+
+
+def index_manifest_pages(manifest: dict[str, Any]) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    pages = manifest.get("pages")
+    if not isinstance(pages, list):
+        raise PublishPackInputError("Public pages manifest must include a pages list")
+    by_slug: dict[str, dict[str, Any]] = {}
+    by_signal_id: dict[str, dict[str, Any]] = {}
+    for page in pages:
+        if not isinstance(page, dict):
+            continue
+        page_slug = slug(page)
+        page_signal_id = signal_id(page)
+        if page_slug:
+            by_slug[page_slug] = page
+        if page_signal_id:
+            by_signal_id[page_signal_id] = page
+    return by_slug, by_signal_id
+
+
+def lookup_manifest_page(
+    approval: dict[str, Any],
+    pages_by_slug: dict[str, dict[str, Any]],
+    pages_by_signal_id: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    approval_slug = slug(approval)
+    approval_signal_id = signal_id(approval)
+    if approval_slug and approval_slug in pages_by_slug:
+        return pages_by_slug[approval_slug]
+    if approval_signal_id and approval_signal_id in pages_by_signal_id:
+        return pages_by_signal_id[approval_signal_id]
+    return None
+
+
+def source_html_path(public_pages_dir: pathlib.Path, page: dict[str, Any], approval: dict[str, Any]) -> pathlib.Path:
+    page_slug = slug(page) or slug(approval)
+    return public_pages_dir / "signals" / page_slug / "index.html"
+
+
+def contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in markers)
+
+
+def page_text_summary(html: str, label: str) -> str:
+    pattern = re.compile(rf"<h2>{re.escape(label)}</h2>\s*<p>(.*?)</p>", re.IGNORECASE | re.DOTALL)
+    match = pattern.search(html)
+    if not match:
+        return ""
+    text = re.sub(r"<[^>]+>", "", match.group(1))
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def source_count(html: str) -> int:
+    return len(re.findall(r"<a\s+[^>]*href=", html, flags=re.IGNORECASE))
+
+
+def page_blockers(
+    approval: dict[str, Any],
+    page: dict[str, Any] | None,
+    public_pages_dir: pathlib.Path,
+    manifest: dict[str, Any],
+    approval_report: dict[str, Any],
+) -> tuple[list[str], pathlib.Path | None, str]:
+    blockers: list[str] = []
+    html = ""
+    source_path: pathlib.Path | None = None
+    if approval.get("approved_for_production_pack") is not True:
+        blockers.append("not_approved_for_production_pack")
+    if approval.get("published") is True:
+        blockers.append("approval_published_true")
+    if approval.get("production_publish_performed") is True:
+        blockers.append("approval_production_publish_performed_true")
+    if approval.get("deployed") is True:
+        blockers.append("approval_deployed_true")
+    if approval_report.get("production_publish_performed") is True:
+        blockers.append("approval_report_production_publish_performed_true")
+    if manifest.get("production_publish_performed") is True:
+        blockers.append("public_pages_manifest_production_publish_performed_true")
+    if page is None:
+        blockers.append("page_not_found_in_public_pages_manifest")
+    else:
+        if page.get("publish_readiness_gate_passed") is not True:
+            blockers.append("publish_readiness_gate_not_passed")
+        if page.get("ready_for_public_generation") is not True:
+            blockers.append("not_ready_for_public_generation")
+        if page.get("published") is True:
+            blockers.append("manifest_published_true")
+        if page.get("production_publish_performed") is True:
+            blockers.append("manifest_production_publish_performed_true")
+        if page.get("deployed") is True:
+            blockers.append("manifest_deployed_true")
+        source_path = source_html_path(public_pages_dir, page, approval)
+        if not source_path.exists():
+            blockers.append("source_html_file_missing")
+        else:
+            html = source_path.read_text(encoding="utf-8", errors="ignore")
+            if "Draft Preview / Not Published" not in html:
+                blockers.append("source_page_missing_draft_not_published_status")
+            if contains_any(html, RAW_BODY_MARKERS):
+                blockers.append("raw_article_body_detected")
+            if contains_any(html, INTERNAL_STATE_MARKERS):
+                blockers.append("internal_review_state_detected")
+            forbidden_status = ("Production deployed", "Deployed", "Live", ">Published<")
+            if any(token in html for token in forbidden_status):
+                blockers.append("source_page_claims_published_or_deployed")
+    return list(dict.fromkeys(blockers)), source_path, html
+
+
+def required_actions_for(blockers: list[str]) -> list[str]:
+    actions: list[str] = []
+    if "not_approved_for_production_pack" in blockers:
+        actions.append("obtain_manual_publish_approval_before_packaging")
+    if "page_not_found_in_public_pages_manifest" in blockers:
+        actions.append("regenerate_public_signal_pages_manifest")
+    if "source_html_file_missing" in blockers:
+        actions.append("provide_generated_public_signal_page_html")
+    if any("published_true" in blocker or "production_publish" in blocker or "deployed" in blocker for blocker in blockers):
+        actions.append("use_only_not_published_not_deployed_step_2_and_step_3_artifacts")
+    if "source_page_missing_draft_not_published_status" in blockers:
+        actions.append("regenerate_step_2_draft_preview_page")
+    if "raw_article_body_detected" in blockers:
+        actions.append("remove_raw_article_body_before_packaging")
+    if "internal_review_state_detected" in blockers:
+        actions.append("remove_internal_review_state_before_packaging")
+    return list(dict.fromkeys(actions)) or ["resolve_blockers_before_step_5_launch_pack"]
+
+
+def block_entry(record: dict[str, Any], blockers: list[str]) -> dict[str, Any]:
+    return {
+        "signal_id": signal_id(record),
+        "slug": slug(record),
+        "title": title(record),
+        "blockers": list(dict.fromkeys(blockers)),
+        "required_next_actions": required_actions_for(blockers),
+    }
+
+
+def transform_candidate_html(html: str, generated_at: str) -> str:
+    transformed = html.replace("Draft Preview / Not Published", "Production Publish Candidate / Not Yet Deployed")
+    transformed = transformed.replace(
+        "Manual Publish Approval V1 is required before production release.",
+        "Step 5 explicit Owner launch authorization is required before production release.",
+    )
+    transformed = transformed.replace(
+        "This generated page is a local static draft. It is not published, not production-approved, and not deployed.",
+        "This packaged page is a production publish candidate. It is not published, not live, and not deployed.",
+    )
+    transformed = transformed.replace(
+        "Static local draft preview only.",
+        "Production publish pack candidate only. Step 5 launch authorization required.",
+    )
+    notice = (
+        '<div class="notice"><strong>Production Publish Candidate / Not Yet Deployed.</strong> '
+        "Step 5 explicit Owner launch authorization is still required. "
+        "No production publishing or deployment has occurred.</div>"
+    )
+    transformed = transformed.replace("</main>", f"{notice}\n<p class=\"muted\">Packaged at {escape(generated_at)}.</p>\n</main>")
+    return transformed
+
+
+def render_index(packaged: list[dict[str, Any]], blocked: list[dict[str, Any]], generated_at: str) -> str:
+    items = []
+    for item in packaged:
+        items.append(
+            f"""
+<article>
+  <h2><a href="{escape(item['slug'], quote=True)}/">{escape(item['title'])}</a></h2>
+  <p><strong>Slug:</strong> <code>{escape(item['slug'])}</code></p>
+  <p><strong>Summary:</strong> {escape(item.get('summary') or 'Summary preserved in packaged Signal page.')}</p>
+  <p><strong>AGI relevance:</strong> {escape(item.get('agi_relevance') or 'AGI relevance preserved in packaged Signal page.')}</p>
+  <p><strong>Quality / confidence:</strong> {escape(item.get('quality_confidence') or 'Quality and confidence preserved in packaged Signal page.')}</p>
+  <p><strong>Sources:</strong> {item.get('source_count', 0)} source link(s) detected in packaged page.</p>
+</article>
+"""
+        )
+    list_html = "\n".join(items) if items else "<p>No Signal pages were packaged.</p>"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>DysonX Public Signals</title>
+  <style>
+    body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.55; }}
+    main {{ max-width: 920px; margin: 0 auto; padding: 28px 20px 48px; }}
+    .status {{ display: inline-block; margin-bottom: 16px; padding: 5px 9px; border: 1px solid #97b6c4; background: #eef7fa; color: #24505e; font-weight: 700; font-size: 0.85rem; }}
+    .notice {{ border: 1px solid #d8dee6; border-left: 4px solid #97b6c4; background: #f6f8fa; padding: 14px; }}
+    article {{ border-top: 1px solid #d8dee6; padding: 18px 0; }}
+    a {{ color: #0f6f8f; }}
+    code {{ background: #f6f8fa; padding: 1px 4px; }}
+  </style>
+</head>
+<body>
+<main>
+<p class="status">Production Publish Candidate / Not Yet Deployed</p>
+<h1>DysonX Public Signals</h1>
+<div class="notice">
+  Step 5 explicit Owner launch authorization is required before these artifacts can be published to production.
+  No production publishing or deployment has occurred.
+</div>
+<p><strong>Generated pages:</strong> {len(packaged)}. <strong>Blocked pages:</strong> {len(blocked)}.</p>
+{list_html}
+<p>Generated at {escape(generated_at)}. Production publish pack candidate only.</p>
+</main>
+</body>
+</html>
+"""
+
+
+def build_packaged_entry(
+    approval: dict[str, Any],
+    manifest_page: dict[str, Any],
+    source_path: pathlib.Path,
+    packaged_path: pathlib.Path,
+    html: str,
+) -> dict[str, Any]:
+    page_slug = slug(approval) or slug(manifest_page)
+    return {
+        "signal_id": signal_id(approval) or signal_id(manifest_page),
+        "title": title(approval) or title(manifest_page),
+        "slug": page_slug,
+        "source_page_path": str(source_path),
+        "packaged_page_path": str(packaged_path),
+        "packaged_preview_path": f"signals/{page_slug}/",
+        "approved_for_production_pack": True,
+        "published": False,
+        "production_publish_performed": False,
+        "deployed": False,
+        "summary": page_text_summary(html, "Summary"),
+        "agi_relevance": page_text_summary(html, "AGI Relevance"),
+        "quality_confidence": page_text_summary(html, "Quality And Confidence"),
+        "source_count": source_count(html),
+    }
+
+
+def release_guard_checks(manifest: dict[str, Any], output_dir: pathlib.Path) -> dict[str, bool]:
+    packaged = [item for item in as_list(manifest.get("packaged")) if isinstance(item, dict)]
+    all_html = ""
+    for item in packaged:
+        path = pathlib.Path(normalize_text(item.get("packaged_page_path")))
+        if path.exists():
+            all_html += "\n" + path.read_text(encoding="utf-8", errors="ignore")
+    checks = {
+        "manual_approval_report_present": bool(manifest.get("input_files", {}).get("approval_report")),
+        "only_approved_pages_packaged": all(item.get("approved_for_production_pack") is True for item in packaged),
+        "no_unapproved_pages_packaged": not any(item.get("approved_for_production_pack") is not True for item in packaged),
+        "packaged_files_exist": all(pathlib.Path(normalize_text(item.get("packaged_page_path"))).exists() for item in packaged),
+        "index_generated": (output_dir / "signals" / "index.html").exists(),
+        "no_published_true_before_launch": not any(item.get("published") is True for item in packaged),
+        "no_production_publish_performed_true": manifest.get("production_publish_performed") is False and not any(item.get("production_publish_performed") is True for item in packaged),
+        "no_deployed_true": not any(item.get("deployed") is True for item in packaged),
+        "no_raw_article_body_detected": not contains_any(all_html, RAW_BODY_MARKERS),
+        "no_internal_review_state_detected": not contains_any(all_html, INTERNAL_STATE_MARKERS),
+        "no_openai_call_performed": manifest.get("no_openai_call_performed") is True,
+        "no_workflow_dispatch_performed": manifest.get("no_workflow_dispatch_performed") is True,
+        "no_deployment_performed": manifest.get("no_deployment_performed") is True,
+        "step_5_launch_authorization_required": manifest.get("step_5_launch_authorization_required") is True,
+    }
+    return checks
+
+
+def build_release_guard_report(manifest: dict[str, Any], output_dir: pathlib.Path, created_at: str) -> dict[str, Any]:
+    checks = release_guard_checks(manifest, output_dir)
+    blockers = [name for name, passed in checks.items() if not passed]
+    warnings: list[str] = []
+    if manifest.get("pages_packaged", 0) == 0:
+        warnings.append("no_pages_packaged")
+    return {
+        "release_guard_version": RELEASE_GUARD_VERSION,
+        "created_at": created_at,
+        "checked_pack_manifest": str(output_dir / "production_publish_pack_manifest.json"),
+        "release_guard_passed": not blockers,
+        "blockers": blockers,
+        "warnings": warnings,
+        "checks": checks,
+    }
+
+
+def generate_pack(
+    public_pages_dir: pathlib.Path,
+    public_pages_manifest_path: pathlib.Path,
+    approval_report_path: pathlib.Path,
+    output_dir: pathlib.Path,
+) -> dict[str, Any]:
+    safe_root = safe_output_root(output_dir)
+    if safe_root.exists():
+        shutil.rmtree(safe_root)
+    safe_root.mkdir(parents=True, exist_ok=True)
+    created_at = utc_now()
+    manifest = read_json_object(public_pages_manifest_path, "Public Signal Page Generator manifest")
+    approval_report = read_json_object(approval_report_path, "Manual Publish Approval report")
+    pages_by_slug, pages_by_signal_id = index_manifest_pages(manifest)
+    approved_entries = [item for item in as_list(approval_report.get("approved")) if isinstance(item, dict)]
+    blocked: list[dict[str, Any]] = []
+    packaged: list[dict[str, Any]] = []
+
+    for approval in approved_entries:
+        manifest_page = lookup_manifest_page(approval, pages_by_slug, pages_by_signal_id)
+        blockers, source_path, html = page_blockers(approval, manifest_page, public_pages_dir, manifest, approval_report)
+        if blockers or manifest_page is None or source_path is None:
+            blocked.append(block_entry(approval, blockers or ["unknown_packaging_blocker"]))
+            continue
+        page_slug = slug(approval) or slug(manifest_page)
+        packaged_path = safe_root / "signals" / page_slug / "index.html"
+        packaged_path.parent.mkdir(parents=True, exist_ok=True)
+        packaged_html = transform_candidate_html(html, created_at)
+        packaged_path.write_text(packaged_html, encoding="utf-8")
+        packaged.append(build_packaged_entry(approval, manifest_page, source_path, packaged_path, html))
+
+    for approval_blocked in as_list(approval_report.get("blocked")):
+        if isinstance(approval_blocked, dict):
+            blocked.append(
+                {
+                    "signal_id": signal_id(approval_blocked),
+                    "slug": slug(approval_blocked),
+                    "title": title(approval_blocked),
+                    "blockers": as_list(approval_blocked.get("blockers")) or ["blocked_by_manual_publish_approval"],
+                    "required_next_actions": as_list(approval_blocked.get("required_next_actions")),
+                }
+            )
+
+    (safe_root / "signals").mkdir(parents=True, exist_ok=True)
+    (safe_root / "signals" / "index.html").write_text(render_index(packaged, blocked, created_at), encoding="utf-8")
+    pack_manifest = {
+        "pack_version": PACK_VERSION,
+        "created_at": created_at,
+        "input_files": {
+            "public_pages_dir": str(public_pages_dir),
+            "public_pages_manifest": str(public_pages_manifest_path),
+            "approval_report": str(approval_report_path),
+        },
+        "output_directory": str(safe_root),
+        "pages_seen": len(as_list(manifest.get("pages"))),
+        "pages_approved_for_pack": len(approved_entries),
+        "pages_packaged": len(packaged),
+        "pages_blocked": len(blocked),
+        "packaged": packaged,
+        "blocked": blocked,
+        "release_guard_passed": False,
+        "step_5_launch_authorization_required": True,
+        "no_public_publishing_performed": True,
+        "no_deployment_performed": True,
+        "no_openai_call_performed": True,
+        "no_workflow_dispatch_performed": True,
+        "production_publish_performed": False,
+    }
+    release_report = build_release_guard_report(pack_manifest, safe_root, created_at)
+    pack_manifest["release_guard_passed"] = release_report["release_guard_passed"]
+    (safe_root / "production_publish_pack_manifest.json").write_text(json.dumps(pack_manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    release_report = build_release_guard_report(pack_manifest, safe_root, created_at)
+    (safe_root / "release_guard_report.json").write_text(json.dumps(release_report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    readme = """# DysonX Production Publish Pack
+
+This directory contains a production publish pack candidate.
+
+It is not deployed. Step 5 explicit Owner launch authorization is still required.
+
+Suggested local check:
+
+```bash
+python3 -m http.server --directory tmp/production_publish_pack 8081
+```
+
+Then visit:
+
+```text
+http://localhost:8081/signals/
+```
+
+No production deployment was performed.
+"""
+    (safe_root / "README.md").write_text(readme, encoding="utf-8")
+    return pack_manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate DysonX Production Publish Pack V1.")
+    parser.add_argument("--public-pages-dir", required=True, help="Step 2 generated public Signal pages directory.")
+    parser.add_argument("--public-pages-manifest", required=True, help="Step 2 public Signal pages manifest JSON.")
+    parser.add_argument("--approval-report", required=True, help="Step 3 Manual Publish Approval report JSON.")
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR), help="Safe tmp/ output directory for the production publish pack.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        manifest = generate_pack(
+            pathlib.Path(args.public_pages_dir),
+            pathlib.Path(args.public_pages_manifest),
+            pathlib.Path(args.approval_report),
+            pathlib.Path(args.output_dir),
+        )
+    except PublishPackInputError as exc:
+        print(f"[production-publish-pack] failed: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"[production-publish-pack] failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[production-publish-pack] wrote pack: "
+        f"{manifest['output_directory']} pages_packaged={manifest['pages_packaged']} "
+        f"pages_blocked={manifest['pages_blocked']} release_guard_passed={manifest['release_guard_passed']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/production_publish_pack_v1/expected_production_publish_pack_manifest.json
+++ b/tests/fixtures/production_publish_pack_v1/expected_production_publish_pack_manifest.json
@@ -1,0 +1,17 @@
+{
+  "packaged_slugs": [
+    "agent-evaluation-recovery-metric"
+  ],
+  "pages_approved_for_pack": 6,
+  "pages_blocked": 6,
+  "pages_packaged": 1,
+  "pages_seen": 5,
+  "required_blockers": {
+    "blocked-by-manual-approval": "decision_not_approve_for_production_pack",
+    "deployed-true-page": "approval_deployed_true",
+    "missing-source-html": "source_html_file_missing",
+    "production-publish-performed-page": "approval_production_publish_performed_true",
+    "published-true-page": "approval_published_true",
+    "unapproved-page": "not_approved_for_production_pack"
+  }
+}

--- a/tests/fixtures/production_publish_pack_v1/expected_release_guard_report.json
+++ b/tests/fixtures/production_publish_pack_v1/expected_release_guard_report.json
@@ -1,0 +1,19 @@
+{
+  "checks": {
+    "index_generated": true,
+    "manual_approval_report_present": true,
+    "no_deployed_true": true,
+    "no_deployment_performed": true,
+    "no_internal_review_state_detected": true,
+    "no_openai_call_performed": true,
+    "no_production_publish_performed_true": true,
+    "no_published_true_before_launch": true,
+    "no_raw_article_body_detected": true,
+    "no_unapproved_pages_packaged": true,
+    "no_workflow_dispatch_performed": true,
+    "only_approved_pages_packaged": true,
+    "packaged_files_exist": true,
+    "step_5_launch_authorization_required": true
+  },
+  "release_guard_passed": true
+}

--- a/tests/fixtures/production_publish_pack_v1/manual_publish_approval_report.json
+++ b/tests/fixtures/production_publish_pack_v1/manual_publish_approval_report.json
@@ -1,0 +1,106 @@
+{
+  "approval_version": "manual_publish_approval_v1",
+  "approved": [
+    {
+      "approved_for_production_pack": true,
+      "decision": "approve_for_production_pack",
+      "preview_path": "signals/agent-evaluation-recovery-metric/",
+      "production_publish_performed": false,
+      "published": false,
+      "signal_id": "sig_ready_agent_eval",
+      "slug": "agent-evaluation-recovery-metric",
+      "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html",
+      "title": "Agent evaluation benchmark adds recovery metric"
+    },
+    {
+      "approved_for_production_pack": false,
+      "decision": "hold",
+      "preview_path": "signals/unapproved-page/",
+      "production_publish_performed": false,
+      "published": false,
+      "signal_id": "sig_unapproved",
+      "slug": "unapproved-page",
+      "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/unapproved-page/index.html",
+      "title": "Unapproved page should block"
+    },
+    {
+      "approved_for_production_pack": true,
+      "decision": "approve_for_production_pack",
+      "preview_path": "signals/missing-source-html/",
+      "production_publish_performed": false,
+      "published": false,
+      "signal_id": "sig_missing_source_html",
+      "slug": "missing-source-html",
+      "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/missing-source-html/index.html",
+      "title": "Missing source HTML should block"
+    },
+    {
+      "approved_for_production_pack": true,
+      "decision": "approve_for_production_pack",
+      "preview_path": "signals/published-true-page/",
+      "production_publish_performed": false,
+      "published": true,
+      "signal_id": "sig_published_true",
+      "slug": "published-true-page",
+      "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/published-true-page/index.html",
+      "title": "Published true page should not be packaged"
+    },
+    {
+      "approved_for_production_pack": true,
+      "decision": "approve_for_production_pack",
+      "preview_path": "signals/production-publish-performed-page/",
+      "production_publish_performed": true,
+      "published": false,
+      "signal_id": "sig_production_publish_performed",
+      "slug": "production-publish-performed-page",
+      "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/production-publish-performed-page/index.html",
+      "title": "Production publish performed page should not be packaged"
+    },
+    {
+      "approved_for_production_pack": true,
+      "decision": "approve_for_production_pack",
+      "deployed": true,
+      "preview_path": "signals/deployed-true-page/",
+      "production_publish_performed": false,
+      "published": false,
+      "signal_id": "sig_deployed_true",
+      "slug": "deployed-true-page",
+      "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/deployed-true-page/index.html",
+      "title": "Deployed true page should not be packaged"
+    }
+  ],
+  "approved_at": "2026-06-27T00:00:00Z",
+  "blocked": [
+    {
+      "blockers": [
+        "decision_not_approve_for_production_pack"
+      ],
+      "decision": "hold",
+      "required_next_actions": [
+        "change_decision_to_approve_for_production_pack_after_owner_review"
+      ],
+      "signal_id": "sig_blocked_by_manual_approval",
+      "slug": "blocked-by-manual-approval",
+      "title": "Blocked by manual approval"
+    }
+  ],
+  "created_at": "2026-06-27T00:00:00+00:00",
+  "input_files": {
+    "approval_input": "tests/fixtures/manual_publish_approval_v1/manual_publish_approval_input.json",
+    "manifest": "tests/fixtures/production_publish_pack_v1/public_signal_pages_manifest.json"
+  },
+  "manual_publish_approval_completed": true,
+  "no_deployment_performed": true,
+  "no_openai_call_performed": true,
+  "no_public_publishing_performed": true,
+  "no_workflow_dispatch_performed": true,
+  "owner": {
+    "name": "Andy Gong",
+    "role": "Owner"
+  },
+  "pages_approved": 6,
+  "pages_blocked": 1,
+  "pages_seen": 5,
+  "production_pack_required": true,
+  "production_publish_performed": false
+}

--- a/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html
+++ b/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Agent evaluation benchmark adds recovery metric | DysonX Draft Preview</title>
+</head>
+<body>
+<main>
+<p class="status">Draft Preview / Not Published</p>
+<h1>Agent evaluation benchmark adds recovery metric</h1>
+<div class="notice">
+  <strong>Manual Publish Approval V1 is required before production release.</strong>
+  This generated page is a local static draft. It is not published, not production-approved, and not deployed.
+</div>
+<div class="meta">
+  <div><strong>Slug</strong><br><code>agent-evaluation-recovery-metric</code></div>
+  <div><strong>Status</strong><br>Draft Preview / Not Published</div>
+</div>
+<h2>Summary</h2>
+<p>A synthetic benchmark note adds a recovery metric for agent evaluation.</p>
+<h2>Why This Matters</h2>
+<p>Recovery behavior is a practical signal for agent reliability and task completion.</p>
+<h2>AGI Relevance</h2>
+<p>Agents and evaluation.</p>
+<h2>Source Attribution</h2>
+<p>Source attributed to Synthetic Research Lab benchmark note.</p>
+<ul><li><a href="https://source.dysonx.test/research/agent-recovery-benchmark" rel="nofollow noopener">https://source.dysonx.test/research/agent-recovery-benchmark</a></li></ul>
+<h2>Quality And Confidence</h2>
+<p>Quality score: 59/65; Tier: A; Confidence: high attribution confidence.</p>
+<h2>Risk And Safety Notes</h2>
+<p>No blocking public-generation risk flags in the gate-passed record.</p>
+<h2>Watch Next</h2>
+<p>Watch whether recovery metrics become part of standard agent benchmark reporting.</p>
+<p><a href="../">Back to Public Signals Draft Preview</a></p>
+<p>Generated at 2026-06-27T00:00:00+00:00. Static local draft preview only.</p>
+</main>
+</body>
+</html>

--- a/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/deployed-true-page/index.html
+++ b/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/deployed-true-page/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en"><body><main>
+<p class="status">Draft Preview / Not Published</p>
+<h1>Deployed true page should not be packaged</h1>
+<h2>Summary</h2><p>This fixture should be blocked by metadata.</p>
+<h2>AGI Relevance</h2><p>Agents.</p>
+<h2>Quality And Confidence</h2><p>Quality score: 59/65.</p>
+</main></body></html>

--- a/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/production-publish-performed-page/index.html
+++ b/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/production-publish-performed-page/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en"><body><main>
+<p class="status">Draft Preview / Not Published</p>
+<h1>Production publish performed page should not be packaged</h1>
+<h2>Summary</h2><p>This fixture should be blocked by metadata.</p>
+<h2>AGI Relevance</h2><p>Agents.</p>
+<h2>Quality And Confidence</h2><p>Quality score: 59/65.</p>
+</main></body></html>

--- a/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/published-true-page/index.html
+++ b/tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/published-true-page/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en"><body><main>
+<p class="status">Draft Preview / Not Published</p>
+<h1>Published true page should not be packaged</h1>
+<h2>Summary</h2><p>This fixture should be blocked by metadata.</p>
+<h2>AGI Relevance</h2><p>Agents.</p>
+<h2>Quality And Confidence</h2><p>Quality score: 59/65.</p>
+</main></body></html>

--- a/tests/fixtures/production_publish_pack_v1/public_signal_pages_manifest.json
+++ b/tests/fixtures/production_publish_pack_v1/public_signal_pages_manifest.json
@@ -1,0 +1,89 @@
+{
+  "blocked": [
+    {
+      "blockers": [
+        "public_generation_blocked"
+      ],
+      "required_next_actions": [
+        "resolve_publish_readiness_gate_blockers"
+      ],
+      "signal_id": "sig_blocked_by_generator",
+      "slug": "blocked-by-generator",
+      "title": "Blocked generator Signal"
+    }
+  ],
+  "created_at": "2026-06-27T00:00:00+00:00",
+  "generator_version": "public_signal_page_generator_v1",
+  "input_files": {
+    "gate_report": "tests/fixtures/public_signal_page_generator_v1/publish_readiness_gate_report.json"
+  },
+  "manual_publish_approval_required": true,
+  "no_deployment_performed": true,
+  "no_openai_call_performed": true,
+  "no_public_publishing_performed": true,
+  "no_workflow_dispatch_performed": true,
+  "output_directory": "tests/fixtures/production_publish_pack_v1/public_signal_pages",
+  "pages": [
+    {
+      "output_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html",
+      "preview_path": "signals/agent-evaluation-recovery-metric/",
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": false,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_ready_agent_eval",
+      "slug": "agent-evaluation-recovery-metric",
+      "title": "Agent evaluation benchmark adds recovery metric"
+    },
+    {
+      "output_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/missing-source-html/index.html",
+      "preview_path": "signals/missing-source-html/",
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": false,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_missing_source_html",
+      "slug": "missing-source-html",
+      "title": "Missing source HTML should block"
+    },
+    {
+      "output_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/published-true-page/index.html",
+      "preview_path": "signals/published-true-page/",
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": true,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_published_true",
+      "slug": "published-true-page",
+      "title": "Published true page should not be packaged"
+    },
+    {
+      "output_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/production-publish-performed-page/index.html",
+      "preview_path": "signals/production-publish-performed-page/",
+      "production_publish_performed": true,
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": false,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_production_publish_performed",
+      "slug": "production-publish-performed-page",
+      "title": "Production publish performed page should not be packaged"
+    },
+    {
+      "deployed": true,
+      "output_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/deployed-true-page/index.html",
+      "preview_path": "signals/deployed-true-page/",
+      "publication_approved": false,
+      "publish_readiness_gate_passed": true,
+      "published": false,
+      "ready_for_public_generation": true,
+      "signal_id": "sig_deployed_true",
+      "slug": "deployed-true-page",
+      "title": "Deployed true page should not be packaged"
+    }
+  ],
+  "production_publish_performed": false,
+  "signals_blocked": 1,
+  "signals_generated": 5,
+  "signals_seen": 6
+}

--- a/tests/test_dysonx_production_publish_pack.py
+++ b/tests/test_dysonx_production_publish_pack.py
@@ -1,0 +1,228 @@
+import ast
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dysonx_production_publish_pack.py"
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "production_publish_pack_v1"
+PUBLIC_PAGES_DIR = FIXTURE_DIR / "public_signal_pages"
+PUBLIC_PAGES_MANIFEST = FIXTURE_DIR / "public_signal_pages_manifest.json"
+APPROVAL_REPORT = FIXTURE_DIR / "manual_publish_approval_report.json"
+EXPECTED_MANIFEST = FIXTURE_DIR / "expected_production_publish_pack_manifest.json"
+EXPECTED_GUARD = FIXTURE_DIR / "expected_release_guard_report.json"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("dysonx_production_publish_pack", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class DysonXProductionPublishPackTests(unittest.TestCase):
+    def run_pack(self, manifest=PUBLIC_PAGES_MANIFEST, approval=APPROVAL_REPORT, public_pages_dir=PUBLIC_PAGES_DIR):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        output_dir = pathlib.Path(tmpdir.name) / "production_publish_pack"
+        cmd = [
+            sys.executable,
+            str(SCRIPT),
+            "--public-pages-dir",
+            str(public_pages_dir),
+            "--public-pages-manifest",
+            str(manifest),
+            "--approval-report",
+            str(approval),
+            "--output-dir",
+            str(output_dir),
+        ]
+        result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, check=False)
+        pack_manifest_path = output_dir / "production_publish_pack_manifest.json"
+        guard_path = output_dir / "release_guard_report.json"
+        pack_manifest = json.loads(pack_manifest_path.read_text(encoding="utf-8")) if pack_manifest_path.exists() else None
+        guard = json.loads(guard_path.read_text(encoding="utf-8")) if guard_path.exists() else None
+        return result, pack_manifest, guard, output_dir
+
+    def write_json(self, data):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = pathlib.Path(tmpdir.name) / "fixture.json"
+        path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def test_approved_for_production_pack_true_packages_page(self):
+        result, manifest, _, output_dir = self.run_pack()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(manifest["pages_packaged"], 1)
+        page = output_dir / "signals" / "agent-evaluation-recovery-metric" / "index.html"
+        self.assertTrue(page.exists())
+        html = page.read_text(encoding="utf-8")
+        self.assertIn("Production Publish Candidate / Not Yet Deployed", html)
+        self.assertNotIn(">Published<", html)
+
+    def test_unapproved_page_is_blocked(self):
+        _, manifest, _, _ = self.run_pack()
+
+        blocked = next(item for item in manifest["blocked"] if item["slug"] == "unapproved-page")
+        self.assertIn("not_approved_for_production_pack", blocked["blockers"])
+
+    def test_missing_source_html_file_blocks_packaging(self):
+        _, manifest, _, _ = self.run_pack()
+
+        blocked = next(item for item in manifest["blocked"] if item["slug"] == "missing-source-html")
+        self.assertIn("source_html_file_missing", blocked["blockers"])
+
+    def test_published_true_blocks_packaging(self):
+        _, manifest, _, _ = self.run_pack()
+
+        blocked = next(item for item in manifest["blocked"] if item["slug"] == "published-true-page")
+        self.assertIn("approval_published_true", blocked["blockers"])
+
+    def test_production_publish_performed_true_blocks_packaging(self):
+        _, manifest, _, _ = self.run_pack()
+
+        blocked = next(item for item in manifest["blocked"] if item["slug"] == "production-publish-performed-page")
+        self.assertIn("approval_production_publish_performed_true", blocked["blockers"])
+
+    def test_deployed_true_blocks_packaging(self):
+        _, manifest, _, _ = self.run_pack()
+
+        blocked = next(item for item in manifest["blocked"] if item["slug"] == "deployed-true-page")
+        self.assertIn("approval_deployed_true", blocked["blockers"])
+
+    def test_no_raw_article_body_appears_in_packaged_output(self):
+        _, _, _, output_dir = self.run_pack()
+
+        html = "\n".join(path.read_text(encoding="utf-8") for path in output_dir.rglob("*.html"))
+        self.assertNotIn("This raw article body must never appear", html)
+        self.assertNotIn("raw_body", html)
+
+    def test_no_internal_review_state_appears_in_packaged_output(self):
+        _, _, _, output_dir = self.run_pack()
+
+        html = "\n".join(path.read_text(encoding="utf-8") for path in output_dir.rglob("*.html"))
+        self.assertNotIn("owner_comment", html)
+        self.assertNotIn("selected_owner_decision", html)
+        self.assertNotIn("review_session", html)
+
+    def test_production_index_is_generated(self):
+        _, manifest, _, output_dir = self.run_pack()
+
+        index = output_dir / "signals" / "index.html"
+        self.assertTrue(index.exists())
+        html = index.read_text(encoding="utf-8")
+        self.assertIn("DysonX Public Signals", html)
+        self.assertIn("Production Publish Candidate / Not Yet Deployed", html)
+        self.assertIn("Step 5 explicit Owner launch authorization", html)
+        self.assertEqual(manifest["pages_packaged"], 1)
+
+    def test_pack_manifest_includes_safety_flags(self):
+        _, manifest, _, _ = self.run_pack()
+
+        self.assertTrue(manifest["step_5_launch_authorization_required"])
+        self.assertTrue(manifest["no_public_publishing_performed"])
+        self.assertTrue(manifest["no_deployment_performed"])
+        self.assertTrue(manifest["no_openai_call_performed"])
+        self.assertTrue(manifest["no_workflow_dispatch_performed"])
+        self.assertFalse(manifest["production_publish_performed"])
+        self.assertFalse(any(item["published"] for item in manifest["packaged"]))
+        self.assertFalse(any(item["production_publish_performed"] for item in manifest["packaged"]))
+        self.assertFalse(any(item["deployed"] for item in manifest["packaged"]))
+
+    def test_release_guard_passes_for_valid_fixture(self):
+        _, manifest, guard, _ = self.run_pack()
+
+        self.assertTrue(manifest["release_guard_passed"])
+        self.assertTrue(guard["release_guard_passed"])
+        expected = json.loads(EXPECTED_GUARD.read_text(encoding="utf-8"))
+        for check, expected_value in expected["checks"].items():
+            self.assertEqual(guard["checks"][check], expected_value)
+
+    def test_release_guard_fails_if_unapproved_page_is_packaged(self):
+        module = load_module()
+        manifest = {
+            "input_files": {"approval_report": "approval.json"},
+            "packaged": [{"approved_for_production_pack": False, "packaged_page_path": "missing.html"}],
+            "no_openai_call_performed": True,
+            "no_workflow_dispatch_performed": True,
+            "no_deployment_performed": True,
+            "production_publish_performed": False,
+            "step_5_launch_authorization_required": True,
+        }
+
+        checks = module.release_guard_checks(manifest, pathlib.Path("/tmp/no-such-pack"))
+
+        self.assertFalse(checks["only_approved_pages_packaged"])
+        self.assertFalse(checks["no_unapproved_pages_packaged"])
+
+    def test_release_guard_fails_if_published_true_appears_before_launch(self):
+        module = load_module()
+        manifest = {
+            "input_files": {"approval_report": "approval.json"},
+            "packaged": [{"approved_for_production_pack": True, "published": True, "packaged_page_path": "missing.html"}],
+            "no_openai_call_performed": True,
+            "no_workflow_dispatch_performed": True,
+            "no_deployment_performed": True,
+            "production_publish_performed": False,
+            "step_5_launch_authorization_required": True,
+        }
+
+        checks = module.release_guard_checks(manifest, pathlib.Path("/tmp/no-such-pack"))
+
+        self.assertFalse(checks["no_published_true_before_launch"])
+
+    def test_release_guard_fails_if_production_publish_performed_true_before_launch(self):
+        module = load_module()
+        manifest = {
+            "input_files": {"approval_report": "approval.json"},
+            "packaged": [{"approved_for_production_pack": True, "production_publish_performed": True, "packaged_page_path": "missing.html"}],
+            "no_openai_call_performed": True,
+            "no_workflow_dispatch_performed": True,
+            "no_deployment_performed": True,
+            "production_publish_performed": True,
+            "step_5_launch_authorization_required": True,
+        }
+
+        checks = module.release_guard_checks(manifest, pathlib.Path("/tmp/no-such-pack"))
+
+        self.assertFalse(checks["no_production_publish_performed_true"])
+
+    def test_cli_output_is_deterministic_enough_for_fixture_comparison(self):
+        _, manifest, guard, _ = self.run_pack()
+        expected_manifest = json.loads(EXPECTED_MANIFEST.read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["pages_seen"], expected_manifest["pages_seen"])
+        self.assertEqual(manifest["pages_approved_for_pack"], expected_manifest["pages_approved_for_pack"])
+        self.assertEqual(manifest["pages_packaged"], expected_manifest["pages_packaged"])
+        self.assertEqual(manifest["pages_blocked"], expected_manifest["pages_blocked"])
+        self.assertEqual([item["slug"] for item in manifest["packaged"]], expected_manifest["packaged_slugs"])
+        blocked = {item["slug"]: item["blockers"] for item in manifest["blocked"]}
+        for item_slug, blocker in expected_manifest["required_blockers"].items():
+            self.assertIn(blocker, blocked[item_slug])
+        self.assertTrue(guard["release_guard_passed"])
+
+    def test_script_uses_standard_library_only(self):
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        imports = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.split(".")[0])
+
+        self.assertLessEqual(
+            imports,
+            {"__future__", "argparse", "json", "pathlib", "re", "shutil", "sys", "datetime", "html", "typing"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds deterministic offline Production Publish Pack V1.
- Consumes Public Signal Page Generator output and Manual Publish Approval report.
- Packages only approved_for_production_pack pages.
- Adds Release Guard report.
- Produces production-ready artifacts for Step 5.
- Does not publish to production.
- Does not deploy.
- Does not call OpenAI.
- Does not dispatch workflows.
- Does not mark pages as published.
- Does not mark production_publish_performed true.
- Keeps Step 5 explicit Owner launch authorization required.
- Keeps functional publishing before aesthetic polish.
- Confirms this is Step 4 of the strict 5-Step Final Launch Plan.

## Validation
- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 349 tests
- git diff --check origin/main...HEAD: PASS
- Manual CLI validation: PASS, pages_packaged=1 pages_blocked=6 release_guard_passed=True

## Safety
- No public publishing performed.
- No production publishing performed.
- No deployment performed.
- No workflow dispatch performed.
- No OpenAI call performed.
- No page is marked published.
- production_publish_performed remains false.
- Step 5 explicit Owner launch authorization is still required.