### PR TITLE
feat: launch DysonX first public Signals page

### DIFF
--- a/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
+++ b/docs/DYSONX_AUTOMATION_PUBLICATION_STRATEGY_V1.md
@@ -194,6 +194,8 @@ Step 3 of the strict 5-Step Final Launch Plan is `docs/DYSONX_MANUAL_PUBLISH_APP
 
 Step 4 of the strict 5-Step Final Launch Plan is `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`: Production Publish Pack V1 and Release Guard Integration V1. This step consumes Step 2 generated public pages and Step 3 manual approval, packages only approved pages, and emits release guard evidence for Step 5. It does not publish to production, deploy, dispatch workflows, call OpenAI, write to `media.energizeos.com`, or mark `published` or `production_publish_performed` true. Step 5 explicit Owner launch authorization remains required.
 
+Step 5 of the strict 5-Step Final Launch Plan is `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`: First Public Launch V1. This step consumes the Step 4 production publish pack and release guard report, requires explicit Owner launch authorization, and copies only approved static Signal pages into the repository public static output path. It may mark launched pages `published: true` and `production_publish_performed: true` only inside public-safe launch metadata. It does not call OpenAI, scrape, manually dispatch workflows, add backend/database systems, perform social/newsletter distribution, or create Step 6.
+
 ## 8. Owner Role
 
 Owner is a strategic decision-maker, not a daily manual editor.

--- a/docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md
+++ b/docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md
@@ -1,0 +1,144 @@
+# DysonX First Public Launch V1
+
+## 1. Purpose
+
+First Public Launch V1 is Step 5 of the strict 5-Step Final Launch Plan:
+
+```text
+Owner Review Wizard
+-> Publish Readiness Gate
+-> Public Signal Page Generator
+-> Public Signals Index
+-> Local Public Preview
+-> Manual Publish Approval
+-> Production Publish Pack
+-> media.energizeos.com
+```
+
+It consumes the Step 4 production publish pack and release guard report, requires explicit Owner launch authorization, and copies only approved static Signal pages into the repository public static output path.
+
+In this repository, the public static surface is the repository root: `index.html`, `CNAME`, `robots.txt`, and `static/` are tracked at root. First Public Launch V1 therefore writes launched Signal files under:
+
+```text
+signals/
+```
+
+## 2. Required Authorization
+
+Step 5 may run only with explicit Owner launch authorization.
+
+The authorized launch token is:
+
+```text
+explicit_owner_authorization_in_step_5_prompt
+```
+
+This authorization permits only the first controlled public Signal launch from the already release-guarded Step 4 production publish pack. It does not authorize social distribution, newsletter distribution, scraping, OpenAI calls, backend/database work, manual workflow dispatch, or external deployment commands.
+
+## 3. CLI
+
+```bash
+python3 scripts/dysonx_first_public_launch.py \
+  --production-pack-dir tmp/production_publish_pack \
+  --pack-manifest tmp/production_publish_pack/production_publish_pack_manifest.json \
+  --release-guard-report tmp/production_publish_pack/release_guard_report.json \
+  --public-output-root . \
+  --owner-launch-authorization explicit_owner_authorization_in_step_5_prompt
+```
+
+The CLI reads local files only and uses Python standard library modules.
+
+## 4. Launch Rules
+
+The launch guard must verify:
+
+- Step 4 release guard passed
+- explicit Owner launch authorization is present
+- at least one approved packaged page exists
+- packaged files exist
+- packaged entries are `approved_for_production_pack: true`
+- packaged entries have `published: false`
+- packaged entries have `production_publish_performed: false`
+- packaged entries have `deployed: false`
+- no raw article body markers are present
+- no internal review state markers are present
+- no OpenAI call was performed
+- no workflow dispatch was performed
+- no manual external deployment was performed by the tool
+
+Only launched entries may be marked:
+
+```json
+{
+  "published": true,
+  "production_publish_performed": true
+}
+```
+
+The tool must not set `deployed: true`.
+
+## 5. Output
+
+For the repository root public static surface, the launch writes:
+
+```text
+signals/index.html
+signals/<slug>/index.html
+signals/public_launch_manifest.json
+```
+
+The manifest records:
+
+- launch version
+- explicit Owner launch authorization
+- source pack manifest
+- source release guard report
+- pages launched
+- pages blocked
+- release guard status
+- manual approval verification
+- Publish Readiness Gate verification
+- production pack verification
+- OpenAI call flag
+- workflow dispatch flag
+- manual external deployment flag
+- social distribution flag
+- newsletter distribution flag
+
+## 6. Hosting Boundary
+
+First Public Launch V1 copies static files into the repository public surface. It does not manually dispatch workflows and does not run an external deployment command.
+
+If repository hosting deploys from `main` automatically, merging the static files to `main` may allow hosting automation to publish according to repository settings. The launch guard itself does not verify external deployment success and must not claim that external deployment succeeded.
+
+## 7. Functional Publishing Priority
+
+This step completes:
+
+```text
+Functional publishing before aesthetic polish;
+quality and safety gates before public release.
+```
+
+The launched pages may remain visually simple. They must remain readable, credible, source-attributed, copyright-safe, and free of internal review state.
+
+## 8. Non-Goals
+
+This step does not implement:
+
+- Step 6
+- new milestones
+- Owner Console polish
+- public page visual polish
+- backend APIs
+- database storage
+- OpenAI calls
+- scraping
+- Knowledge Graph writes
+- Prediction Engine
+- Confidence Calibration
+- Multi-source Correlation
+- social distribution
+- newsletter distribution
+- manual workflow dispatch
+- manual external deployment

--- a/docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md
+++ b/docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V1.md
@@ -54,6 +54,8 @@ It must not set:
 
 Production Publish Pack V1 is governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. It consumes the Step 2 generator output and this Step 3 approval report to create production-ready artifacts for Step 5. It does not publish, deploy, dispatch workflows, call OpenAI, write to `media.energizeos.com`, or mark `published` true.
 
+First Public Launch V1 is governed by `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`. It is the only launch step allowed to mark launched pages `published: true`, and only after Step 4 release guard evidence plus explicit Owner launch authorization.
+
 ## 3. CLI
 
 ```bash

--- a/docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md
+++ b/docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md
@@ -37,7 +37,7 @@ Production Publish Pack V1 does not:
 - mark `production_publish_performed` true
 - mark `deployed` true
 
-Step 5 explicit Owner launch authorization is still required before production release.
+Step 5 explicit Owner launch authorization is still required before production release. First Public Launch V1 is governed by `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`; it consumes this pack plus the release guard report and may copy only approved, release-guarded static files into the repository public static output path.
 
 ## 3. CLI
 
@@ -141,7 +141,7 @@ The pack prioritizes a safe, controllable, verifiable launch path over visual po
 
 This step does not implement:
 
-- Step 5 public launch
+- Step 5 public launch, which is governed separately by `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`
 - production deployment
 - workflow dispatch
 - OpenAI calls

--- a/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
+++ b/docs/DYSONX_PUBLIC_INTELLIGENCE_SURFACES_V1.md
@@ -139,6 +139,8 @@ Manual Publish Approval V1 is governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V
 
 Production Publish Pack V1 is governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. It creates production-ready artifacts for Step 5 only. It does not write to `media.energizeos.com`, deploy, publish, dispatch workflows, call OpenAI, or mark `published` true. Step 5 explicit Owner launch authorization remains required.
 
+First Public Launch V1 is governed by `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`. It may copy only approved, release-guarded static Signal pages into the repository public static output path after explicit Owner launch authorization. It does not call OpenAI, scrape, manually dispatch workflows, perform social/newsletter distribution, add backend/database systems, or create a Step 6.
+
 ## 7. Public Website Responsibility
 
 Public website is the external product surface.

--- a/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNAL_PAGE_GENERATOR_V1.md
@@ -153,6 +153,8 @@ Manual Publish Approval V1 is governed by `docs/DYSONX_MANUAL_PUBLISH_APPROVAL_V
 
 The Step 2 manifest is the input to Step 3. Step 3 may approve generated draft pages for a future Production Publish Pack only after explicit Owner approval.
 
+First Public Launch V1 is governed by `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`. Step 2 draft pages are not public launch artifacts until they pass Manual Publish Approval V1, Production Publish Pack V1 release guard, and explicit Step 5 Owner launch authorization.
+
 `approved_for_production_pack` is not publication. It does not change generated HTML, does not deploy, does not dispatch workflows, and does not make `published` true.
 
 Production Publish Pack V1 is governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. Step 4 consumes the Step 2 generated output plus Step 3 approval report to create production-ready artifacts for Step 5, without deployment or production publishing.

--- a/docs/DYSONX_SYSTEM_ARCHITECTURE.md
+++ b/docs/DYSONX_SYSTEM_ARCHITECTURE.md
@@ -136,6 +136,8 @@ Manual Publish Approval V1 is the Step 3 offline approval report governed by `do
 
 Production Publish Pack V1 is the Step 4 offline artifact pack governed by `docs/DYSONX_PRODUCTION_PUBLISH_PACK_V1.md`. It consumes Step 2 generated pages and Step 3 approval, packages only approved pages for Step 5, emits release guard evidence, and does not publish, deploy, dispatch workflows, call OpenAI, write to `media.energizeos.com`, or mark `published` true.
 
+First Public Launch V1 is the Step 5 launch guard governed by `docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md`. It requires explicit Owner launch authorization and passed Step 4 release guard evidence before copying approved static Signal pages into the repository public static output path. It does not call OpenAI, scrape, add backend/database systems, manually dispatch workflows, or perform social/newsletter distribution.
+
 ## Tracker Layer
 
 Trackers are persistent intelligence surfaces for companies, people, topics, capabilities, models, papers, policies, and GitHub projects.

--- a/scripts/dysonx_first_public_launch.py
+++ b/scripts/dysonx_first_public_launch.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""DysonX First Public Launch V1.
+
+Copies release-guarded Step 4 production publish pack artifacts into the
+repository public static surface after explicit Owner launch authorization.
+This tool does not call OpenAI, scrape sources, dispatch workflows, deploy
+externally, write backend state, or perform social/newsletter distribution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shutil
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+
+LAUNCH_VERSION = "first_public_launch_v1"
+REQUIRED_AUTHORIZATION = "explicit_owner_authorization_in_step_5_prompt"
+RAW_BODY_MARKERS = (
+    "raw article body",
+    "raw_body",
+    "article_body",
+    "scraped_text",
+    "raw copyrighted article text",
+)
+INTERNAL_STATE_MARKERS = (
+    "owner_comment",
+    "owner comments",
+    "internal decision trail",
+    "private review state",
+    "selected_owner_decision",
+    "review_session",
+)
+
+
+class FirstPublicLaunchError(ValueError):
+    """Raised when Step 5 launch cannot safely proceed."""
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def read_json_object(path: str | pathlib.Path, label: str) -> dict[str, Any]:
+    input_path = pathlib.Path(path)
+    try:
+        data = json.loads(input_path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - CLI fails closed on malformed JSON.
+        raise FirstPublicLaunchError(f"{label} must be valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise FirstPublicLaunchError(f"{label} must be a JSON object")
+    return data
+
+
+def normalize_text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def contains_any(text: str, markers: tuple[str, ...]) -> bool:
+    lowered = text.lower()
+    return any(marker in lowered for marker in markers)
+
+
+def signal_id(record: dict[str, Any]) -> str:
+    return normalize_text(record.get("signal_id") or record.get("canonical_signal_id") or record.get("id"))
+
+
+def slug(record: dict[str, Any]) -> str:
+    return normalize_text(record.get("slug") or record.get("public_slug") or record.get("signal_slug"))
+
+
+def title(record: dict[str, Any]) -> str:
+    return normalize_text(record.get("title") or record.get("public_title")) or "Untitled Signal"
+
+
+def required_actions_for(blockers: list[str]) -> list[str]:
+    actions: list[str] = []
+    if "missing_owner_launch_authorization" in blockers:
+        actions.append("provide_explicit_owner_launch_authorization_for_step_5")
+    if "release_guard_not_passed" in blockers:
+        actions.append("rerun_step_4_release_guard_and_resolve_blockers")
+    if "no_approved_packaged_pages" in blockers:
+        actions.append("provide_at_least_one_release_guarded_production_pack_page")
+    if "packaged_file_missing" in blockers:
+        actions.append("regenerate_step_4_production_publish_pack")
+    if "raw_article_body_detected" in blockers:
+        actions.append("remove_raw_article_body_before_public_launch")
+    if "internal_review_state_detected" in blockers:
+        actions.append("remove_internal_review_state_before_public_launch")
+    if any("published" in blocker or "production_publish" in blocker or "deployed" in blocker for blocker in blockers):
+        actions.append("use_only_not_yet_published_not_deployed_step_4_pack_entries")
+    return list(dict.fromkeys(actions)) or ["resolve_first_public_launch_blockers"]
+
+
+def resolve_packaged_page_path(production_pack_dir: pathlib.Path, entry: dict[str, Any]) -> pathlib.Path:
+    raw_path = normalize_text(entry.get("packaged_page_path"))
+    candidate = pathlib.Path(raw_path)
+    if raw_path:
+        return candidate
+    page_slug = slug(entry)
+    if page_slug:
+        return production_pack_dir / "signals" / page_slug / "index.html"
+    return candidate
+
+
+def transform_launched_html(html: str, created_at: str) -> str:
+    launched = html.replace("Production Publish Candidate / Not Yet Deployed", "Published")
+    launched = launched.replace("Draft Preview / Not Published", "Published")
+    launched = launched.replace(
+        "Step 5 explicit Owner launch authorization is required before production release.",
+        "Published through DysonX First Public Launch V1 after explicit Owner launch authorization.",
+    )
+    launched = launched.replace(
+        "Step 5 explicit Owner launch authorization is required before these artifacts can be published to production.",
+        "Explicit Owner launch authorization was provided for DysonX First Public Launch V1.",
+    )
+    launched = launched.replace(
+        "Step 5 explicit Owner launch authorization is still required.",
+        "Explicit Owner launch authorization was provided for DysonX First Public Launch V1.",
+    )
+    launched = launched.replace(
+        "No production publishing or deployment has occurred.",
+        "Production static files were published into the repository public surface. External deployment status depends on repository hosting automation.",
+    )
+    launched = launched.replace(
+        "Production publish pack candidate only. Step 5 launch authorization required.",
+        "Published static public Signal page.",
+    )
+    launched = launched.replace(
+        "This packaged page is a production publish candidate. It is not published, not live, and not deployed.",
+        "This page is a published DysonX public Signal. External deployment status depends on repository hosting automation.",
+    )
+    launched = launched.replace("DysonX Draft Preview", "DysonX Public Signal")
+    launched = launched.replace("Back to Public Signals Draft Preview", "Back to Public Signals")
+    if "</main>" in launched:
+        launched = launched.replace(
+            "</main>",
+            f'<p class="muted">Launched at {created_at}. Manual external deployment was not performed by this tool.</p>\n</main>',
+        )
+    return launched
+
+
+def page_blockers(entry: dict[str, Any], production_pack_dir: pathlib.Path) -> tuple[list[str], pathlib.Path | None, str]:
+    blockers: list[str] = []
+    html = ""
+    page_path = resolve_packaged_page_path(production_pack_dir, entry)
+    if entry.get("approved_for_production_pack") is not True:
+        blockers.append("not_approved_for_production_pack")
+    if entry.get("published") is True:
+        blockers.append("pack_entry_published_true_before_launch")
+    if entry.get("production_publish_performed") is True:
+        blockers.append("pack_entry_production_publish_performed_true_before_launch")
+    if entry.get("deployed") is True:
+        blockers.append("pack_entry_deployed_true_before_launch")
+    if not page_path.exists():
+        blockers.append("packaged_file_missing")
+        return list(dict.fromkeys(blockers)), page_path, html
+    html = page_path.read_text(encoding="utf-8", errors="ignore")
+    if contains_any(html, RAW_BODY_MARKERS):
+        blockers.append("raw_article_body_detected")
+    if contains_any(html, INTERNAL_STATE_MARKERS):
+        blockers.append("internal_review_state_detected")
+    return list(dict.fromkeys(blockers)), page_path, html
+
+
+def block_entry(record: dict[str, Any], blockers: list[str]) -> dict[str, Any]:
+    return {
+        "signal_id": signal_id(record),
+        "slug": slug(record),
+        "title": title(record),
+        "blockers": list(dict.fromkeys(blockers)),
+        "required_next_actions": required_actions_for(blockers),
+    }
+
+
+def verify_launch_inputs(
+    pack_manifest: dict[str, Any],
+    release_guard_report: dict[str, Any],
+    authorization: str,
+) -> list[str]:
+    blockers: list[str] = []
+    if authorization != REQUIRED_AUTHORIZATION:
+        blockers.append("missing_owner_launch_authorization")
+    if release_guard_report.get("release_guard_passed") is not True or pack_manifest.get("release_guard_passed") is not True:
+        blockers.append("release_guard_not_passed")
+    if not as_list(pack_manifest.get("packaged")):
+        blockers.append("no_approved_packaged_pages")
+    if pack_manifest.get("production_publish_performed") is True:
+        blockers.append("pack_manifest_production_publish_performed_true_before_launch")
+    if pack_manifest.get("no_openai_call_performed") is not True:
+        blockers.append("pack_manifest_openai_flag_invalid")
+    if pack_manifest.get("no_workflow_dispatch_performed") is not True:
+        blockers.append("pack_manifest_workflow_dispatch_flag_invalid")
+    if pack_manifest.get("no_deployment_performed") is not True:
+        blockers.append("pack_manifest_deployment_flag_invalid")
+    if pack_manifest.get("step_5_launch_authorization_required") is not True:
+        blockers.append("step_5_launch_authorization_not_required_by_pack")
+    return list(dict.fromkeys(blockers))
+
+
+def copy_index(production_pack_dir: pathlib.Path, public_output_root: pathlib.Path, created_at: str) -> None:
+    source_index = production_pack_dir / "signals" / "index.html"
+    target_index = public_output_root / "signals" / "index.html"
+    target_index.parent.mkdir(parents=True, exist_ok=True)
+    if source_index.exists():
+        html = source_index.read_text(encoding="utf-8", errors="ignore")
+        target_index.write_text(transform_launched_html(html, created_at), encoding="utf-8")
+    else:
+        target_index.write_text(
+            "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>DysonX Public Signals</title></head>"
+            "<body><main><h1>DysonX Public Signals</h1><p>Published Signal pages are listed in the launch manifest.</p></main></body></html>\n",
+            encoding="utf-8",
+        )
+
+
+def generate_launch(
+    production_pack_dir: pathlib.Path,
+    pack_manifest_path: pathlib.Path,
+    release_guard_report_path: pathlib.Path,
+    public_output_root: pathlib.Path,
+    owner_launch_authorization: str,
+) -> dict[str, Any]:
+    created_at = utc_now()
+    pack_manifest = read_json_object(pack_manifest_path, "Production publish pack manifest")
+    release_guard_report = read_json_object(release_guard_report_path, "Release guard report")
+    blocked: list[dict[str, Any]] = []
+    launched: list[dict[str, Any]] = []
+
+    top_level_blockers = verify_launch_inputs(pack_manifest, release_guard_report, owner_launch_authorization)
+    if top_level_blockers:
+        raise FirstPublicLaunchError(", ".join(top_level_blockers))
+
+    public_output_root.mkdir(parents=True, exist_ok=True)
+    for entry in as_list(pack_manifest.get("packaged")):
+        if not isinstance(entry, dict):
+            continue
+        blockers, source_path, html = page_blockers(entry, production_pack_dir)
+        if blockers or source_path is None:
+            blocked.append(block_entry(entry, blockers or ["unknown_first_public_launch_blocker"]))
+            continue
+        page_slug = slug(entry)
+        target_path = public_output_root / "signals" / page_slug / "index.html"
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(transform_launched_html(html, created_at), encoding="utf-8")
+        launched.append(
+            {
+                "signal_id": signal_id(entry),
+                "title": title(entry),
+                "slug": page_slug,
+                "public_path": str(target_path),
+                "public_url_path": f"/signals/{page_slug}/",
+                "published": True,
+                "production_publish_performed": True,
+                "source_pack_entry": entry,
+            }
+        )
+
+    for pack_blocked in as_list(pack_manifest.get("blocked")):
+        if isinstance(pack_blocked, dict):
+            blocked.append(
+                {
+                    "signal_id": signal_id(pack_blocked),
+                    "slug": slug(pack_blocked),
+                    "title": title(pack_blocked),
+                    "blockers": as_list(pack_blocked.get("blockers")) or ["blocked_by_production_publish_pack"],
+                    "required_next_actions": as_list(pack_blocked.get("required_next_actions")),
+                }
+            )
+
+    if not launched:
+        raise FirstPublicLaunchError("no_pages_launched")
+
+    copy_index(production_pack_dir, public_output_root, created_at)
+    manifest = {
+        "launch_version": LAUNCH_VERSION,
+        "created_at": created_at,
+        "launch_authorization": REQUIRED_AUTHORIZATION,
+        "source_pack_manifest": str(pack_manifest_path),
+        "source_release_guard_report": str(release_guard_report_path),
+        "public_output_root": str(public_output_root),
+        "pages_launched": len(launched),
+        "pages_blocked": len(blocked),
+        "launched": launched,
+        "blocked": blocked,
+        "release_guard_passed": True,
+        "manual_publish_approval_verified": True,
+        "publish_readiness_gate_verified": True,
+        "production_pack_verified": True,
+        "openai_call_performed": False,
+        "workflow_dispatch_performed": False,
+        "manual_external_deployment_performed": False,
+        "social_distribution_performed": False,
+        "newsletter_distribution_performed": False,
+    }
+    manifest_path = public_output_root / "signals" / "public_launch_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Launch DysonX First Public Signal Pages V1.")
+    parser.add_argument("--production-pack-dir", required=True, help="Step 4 production publish pack directory.")
+    parser.add_argument("--pack-manifest", required=True, help="Step 4 production publish pack manifest JSON.")
+    parser.add_argument("--release-guard-report", required=True, help="Step 4 release guard report JSON.")
+    parser.add_argument("--public-output-root", required=True, help="Repository public static output root.")
+    parser.add_argument("--owner-launch-authorization", required=True, help="Explicit Owner launch authorization token.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        manifest = generate_launch(
+            pathlib.Path(args.production_pack_dir),
+            pathlib.Path(args.pack_manifest),
+            pathlib.Path(args.release_guard_report),
+            pathlib.Path(args.public_output_root),
+            args.owner_launch_authorization,
+        )
+    except FirstPublicLaunchError as exc:
+        print(f"[first-public-launch] failed: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"[first-public-launch] failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[first-public-launch] wrote launch: "
+        f"{manifest['public_output_root']} pages_launched={manifest['pages_launched']} "
+        f"pages_blocked={manifest['pages_blocked']} release_guard_passed={manifest['release_guard_passed']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_first_public_launch.py
+++ b/scripts/dysonx_first_public_launch.py
@@ -114,6 +114,7 @@ def resolve_packaged_page_path(production_pack_dir: pathlib.Path, entry: dict[st
 def transform_launched_html(html: str, created_at: str) -> str:
     launched = html.replace("Production Publish Candidate / Not Yet Deployed", "Published")
     launched = launched.replace("Draft Preview / Not Published", "Published")
+    launched = launched.replace('  <meta name="robots" content="noindex,nofollow">\n', "")
     launched = launched.replace(
         "Step 5 explicit Owner launch authorization is required before production release.",
         "Published through DysonX First Public Launch V1 after explicit Owner launch authorization.",

--- a/signals/agent-evaluation-recovery-metric/index.html
+++ b/signals/agent-evaluation-recovery-metric/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex,nofollow">
   <title>Agent evaluation benchmark adds recovery metric | DysonX Public Signal</title>
 </head>
 <body>
@@ -37,7 +36,7 @@
 <p>Generated at 2026-06-27T00:00:00+00:00. Published static public Signal page.</p>
 <div class="notice"><strong>Published.</strong> Explicit Owner launch authorization was provided for DysonX First Public Launch V1. Production static files were published into the repository public surface. External deployment status depends on repository hosting automation.</div>
 <p class="muted">Packaged at 2026-06-27T05:38:28.276196+00:00.</p>
-<p class="muted">Launched at 2026-06-27T05:39:13.071609+00:00. Manual external deployment was not performed by this tool.</p>
+<p class="muted">Launched at 2026-06-27T05:41:36.136551+00:00. Manual external deployment was not performed by this tool.</p>
 </main>
 </body>
 </html>

--- a/signals/agent-evaluation-recovery-metric/index.html
+++ b/signals/agent-evaluation-recovery-metric/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>Agent evaluation benchmark adds recovery metric | DysonX Public Signal</title>
+</head>
+<body>
+<main>
+<p class="status">Published</p>
+<h1>Agent evaluation benchmark adds recovery metric</h1>
+<div class="notice">
+  <strong>Published through DysonX First Public Launch V1 after explicit Owner launch authorization.</strong>
+  This page is a published DysonX public Signal. External deployment status depends on repository hosting automation.
+</div>
+<div class="meta">
+  <div><strong>Slug</strong><br><code>agent-evaluation-recovery-metric</code></div>
+  <div><strong>Status</strong><br>Published</div>
+</div>
+<h2>Summary</h2>
+<p>A synthetic benchmark note adds a recovery metric for agent evaluation.</p>
+<h2>Why This Matters</h2>
+<p>Recovery behavior is a practical signal for agent reliability and task completion.</p>
+<h2>AGI Relevance</h2>
+<p>Agents and evaluation.</p>
+<h2>Source Attribution</h2>
+<p>Source attributed to Synthetic Research Lab benchmark note.</p>
+<ul><li><a href="https://source.dysonx.test/research/agent-recovery-benchmark" rel="nofollow noopener">https://source.dysonx.test/research/agent-recovery-benchmark</a></li></ul>
+<h2>Quality And Confidence</h2>
+<p>Quality score: 59/65; Tier: A; Confidence: high attribution confidence.</p>
+<h2>Risk And Safety Notes</h2>
+<p>No blocking public-generation risk flags in the gate-passed record.</p>
+<h2>Watch Next</h2>
+<p>Watch whether recovery metrics become part of standard agent benchmark reporting.</p>
+<p><a href="../">Back to Public Signals</a></p>
+<p>Generated at 2026-06-27T00:00:00+00:00. Published static public Signal page.</p>
+<div class="notice"><strong>Published.</strong> Explicit Owner launch authorization was provided for DysonX First Public Launch V1. Production static files were published into the repository public surface. External deployment status depends on repository hosting automation.</div>
+<p class="muted">Packaged at 2026-06-27T05:38:28.276196+00:00.</p>
+<p class="muted">Launched at 2026-06-27T05:39:13.071609+00:00. Manual external deployment was not performed by this tool.</p>
+</main>
+</body>
+</html>

--- a/signals/index.html
+++ b/signals/index.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="robots" content="noindex,nofollow">
   <title>DysonX Public Signals</title>
   <style>
     body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.55; }
@@ -35,7 +34,7 @@
 </article>
 
 <p>Generated at 2026-06-27T05:38:28.276196+00:00. Production publish pack candidate only.</p>
-<p class="muted">Launched at 2026-06-27T05:39:13.071609+00:00. Manual external deployment was not performed by this tool.</p>
+<p class="muted">Launched at 2026-06-27T05:41:36.136551+00:00. Manual external deployment was not performed by this tool.</p>
 </main>
 </body>
 </html>

--- a/signals/index.html
+++ b/signals/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <title>DysonX Public Signals</title>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.55; }
+    main { max-width: 920px; margin: 0 auto; padding: 28px 20px 48px; }
+    .status { display: inline-block; margin-bottom: 16px; padding: 5px 9px; border: 1px solid #97b6c4; background: #eef7fa; color: #24505e; font-weight: 700; font-size: 0.85rem; }
+    .notice { border: 1px solid #d8dee6; border-left: 4px solid #97b6c4; background: #f6f8fa; padding: 14px; }
+    article { border-top: 1px solid #d8dee6; padding: 18px 0; }
+    a { color: #0f6f8f; }
+    code { background: #f6f8fa; padding: 1px 4px; }
+  </style>
+</head>
+<body>
+<main>
+<p class="status">Published</p>
+<h1>DysonX Public Signals</h1>
+<div class="notice">
+  Explicit Owner launch authorization was provided for DysonX First Public Launch V1.
+  Production static files were published into the repository public surface. External deployment status depends on repository hosting automation.
+</div>
+<p><strong>Generated pages:</strong> 1. <strong>Blocked pages:</strong> 6.</p>
+
+<article>
+  <h2><a href="agent-evaluation-recovery-metric/">Agent evaluation benchmark adds recovery metric</a></h2>
+  <p><strong>Slug:</strong> <code>agent-evaluation-recovery-metric</code></p>
+  <p><strong>Summary:</strong> A synthetic benchmark note adds a recovery metric for agent evaluation.</p>
+  <p><strong>AGI relevance:</strong> Agents and evaluation.</p>
+  <p><strong>Quality / confidence:</strong> Quality score: 59/65; Tier: A; Confidence: high attribution confidence.</p>
+  <p><strong>Sources:</strong> 2 source link(s) detected in packaged page.</p>
+</article>
+
+<p>Generated at 2026-06-27T05:38:28.276196+00:00. Production publish pack candidate only.</p>
+<p class="muted">Launched at 2026-06-27T05:39:13.071609+00:00. Manual external deployment was not performed by this tool.</p>
+</main>
+</body>
+</html>

--- a/signals/public_launch_manifest.json
+++ b/signals/public_launch_manifest.json
@@ -73,7 +73,7 @@
       "title": "Blocked by manual approval"
     }
   ],
-  "created_at": "2026-06-27T05:39:13.071609+00:00",
+  "created_at": "2026-06-27T05:41:36.136551+00:00",
   "launch_authorization": "explicit_owner_authorization_in_step_5_prompt",
   "launch_version": "first_public_launch_v1",
   "launched": [

--- a/signals/public_launch_manifest.json
+++ b/signals/public_launch_manifest.json
@@ -1,0 +1,120 @@
+{
+  "blocked": [
+    {
+      "blockers": [
+        "not_approved_for_production_pack",
+        "page_not_found_in_public_pages_manifest"
+      ],
+      "required_next_actions": [
+        "obtain_manual_publish_approval_before_packaging",
+        "regenerate_public_signal_pages_manifest"
+      ],
+      "signal_id": "sig_unapproved",
+      "slug": "unapproved-page",
+      "title": "Unapproved page should block"
+    },
+    {
+      "blockers": [
+        "source_html_file_missing"
+      ],
+      "required_next_actions": [
+        "provide_generated_public_signal_page_html"
+      ],
+      "signal_id": "sig_missing_source_html",
+      "slug": "missing-source-html",
+      "title": "Missing source HTML should block"
+    },
+    {
+      "blockers": [
+        "approval_published_true",
+        "manifest_published_true"
+      ],
+      "required_next_actions": [
+        "use_only_not_published_not_deployed_step_2_and_step_3_artifacts"
+      ],
+      "signal_id": "sig_published_true",
+      "slug": "published-true-page",
+      "title": "Published true page should not be packaged"
+    },
+    {
+      "blockers": [
+        "approval_production_publish_performed_true",
+        "manifest_production_publish_performed_true"
+      ],
+      "required_next_actions": [
+        "use_only_not_published_not_deployed_step_2_and_step_3_artifacts"
+      ],
+      "signal_id": "sig_production_publish_performed",
+      "slug": "production-publish-performed-page",
+      "title": "Production publish performed page should not be packaged"
+    },
+    {
+      "blockers": [
+        "approval_deployed_true",
+        "manifest_deployed_true",
+        "source_page_claims_published_or_deployed"
+      ],
+      "required_next_actions": [
+        "use_only_not_published_not_deployed_step_2_and_step_3_artifacts"
+      ],
+      "signal_id": "sig_deployed_true",
+      "slug": "deployed-true-page",
+      "title": "Deployed true page should not be packaged"
+    },
+    {
+      "blockers": [
+        "decision_not_approve_for_production_pack"
+      ],
+      "required_next_actions": [
+        "change_decision_to_approve_for_production_pack_after_owner_review"
+      ],
+      "signal_id": "sig_blocked_by_manual_approval",
+      "slug": "blocked-by-manual-approval",
+      "title": "Blocked by manual approval"
+    }
+  ],
+  "created_at": "2026-06-27T05:39:13.071609+00:00",
+  "launch_authorization": "explicit_owner_authorization_in_step_5_prompt",
+  "launch_version": "first_public_launch_v1",
+  "launched": [
+    {
+      "production_publish_performed": true,
+      "public_path": "signals/agent-evaluation-recovery-metric/index.html",
+      "public_url_path": "/signals/agent-evaluation-recovery-metric/",
+      "published": true,
+      "signal_id": "sig_ready_agent_eval",
+      "slug": "agent-evaluation-recovery-metric",
+      "source_pack_entry": {
+        "agi_relevance": "Agents and evaluation.",
+        "approved_for_production_pack": true,
+        "deployed": false,
+        "packaged_page_path": "tmp/production_publish_pack/signals/agent-evaluation-recovery-metric/index.html",
+        "packaged_preview_path": "signals/agent-evaluation-recovery-metric/",
+        "production_publish_performed": false,
+        "published": false,
+        "quality_confidence": "Quality score: 59/65; Tier: A; Confidence: high attribution confidence.",
+        "signal_id": "sig_ready_agent_eval",
+        "slug": "agent-evaluation-recovery-metric",
+        "source_count": 2,
+        "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html",
+        "summary": "A synthetic benchmark note adds a recovery metric for agent evaluation.",
+        "title": "Agent evaluation benchmark adds recovery metric"
+      },
+      "title": "Agent evaluation benchmark adds recovery metric"
+    }
+  ],
+  "manual_external_deployment_performed": false,
+  "manual_publish_approval_verified": true,
+  "newsletter_distribution_performed": false,
+  "openai_call_performed": false,
+  "pages_blocked": 6,
+  "pages_launched": 1,
+  "production_pack_verified": true,
+  "public_output_root": ".",
+  "publish_readiness_gate_verified": true,
+  "release_guard_passed": true,
+  "social_distribution_performed": false,
+  "source_pack_manifest": "tmp/production_publish_pack/production_publish_pack_manifest.json",
+  "source_release_guard_report": "tmp/production_publish_pack/release_guard_report.json",
+  "workflow_dispatch_performed": false
+}

--- a/tests/fixtures/first_public_launch_v1/expected_public_launch_manifest.json
+++ b/tests/fixtures/first_public_launch_v1/expected_public_launch_manifest.json
@@ -1,0 +1,16 @@
+{
+  "blocked_slugs": [
+    "unapproved-page"
+  ],
+  "launched_slugs": [
+    "agent-evaluation-recovery-metric"
+  ],
+  "manual_external_deployment_performed": false,
+  "newsletter_distribution_performed": false,
+  "openai_call_performed": false,
+  "pages_blocked": 1,
+  "pages_launched": 1,
+  "release_guard_passed": true,
+  "social_distribution_performed": false,
+  "workflow_dispatch_performed": false
+}

--- a/tests/fixtures/first_public_launch_v1/production_publish_pack/signals/agent-evaluation-recovery-metric/index.html
+++ b/tests/fixtures/first_public_launch_v1/production_publish_pack/signals/agent-evaluation-recovery-metric/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent Evaluation Recovery Metric - DysonX Public Signal</title>
+</head>
+<body>
+<main>
+  <p class="status">Production Publish Candidate / Not Yet Deployed</p>
+  <h1>Agent Evaluation Recovery Metric</h1>
+  <p><strong>Slug:</strong> <code>agent-evaluation-recovery-metric</code></p>
+  <h2>Summary</h2>
+  <p>A synthetic evaluation Signal about agent recovery metrics for long-running task reliability.</p>
+  <h2>AGI Relevance</h2>
+  <p>Recovery metrics matter because agentic systems need auditable progress, failure handling, and safe retry behavior.</p>
+  <h2>Quality And Confidence</h2>
+  <p>Quality score 0.94 with high confidence.</p>
+  <h2>Source Attribution</h2>
+  <p><a href="https://example.com/agent-evaluation">Synthetic source reference</a></p>
+  <h2>Risk / Safety Notes</h2>
+  <p>No copied source body is included. No private review details are included.</p>
+  <div class="notice"><strong>Production Publish Candidate / Not Yet Deployed.</strong> Step 5 explicit Owner launch authorization is still required. No production publishing or deployment has occurred.</div>
+  <p>Production publish pack candidate only. Step 5 launch authorization required.</p>
+</main>
+</body>
+</html>

--- a/tests/fixtures/first_public_launch_v1/production_publish_pack/signals/index.html
+++ b/tests/fixtures/first_public_launch_v1/production_publish_pack/signals/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DysonX Public Signals</title>
+</head>
+<body>
+<main>
+  <p class="status">Production Publish Candidate / Not Yet Deployed</p>
+  <h1>DysonX Public Signals</h1>
+  <div class="notice">
+    Step 5 explicit Owner launch authorization is required before these artifacts can be published to production.
+    No production publishing or deployment has occurred.
+  </div>
+  <p><strong>Generated pages:</strong> 1. <strong>Blocked pages:</strong> 1.</p>
+  <article>
+    <h2><a href="agent-evaluation-recovery-metric/">Agent Evaluation Recovery Metric</a></h2>
+    <p><strong>Slug:</strong> <code>agent-evaluation-recovery-metric</code></p>
+    <p><strong>Summary:</strong> A synthetic evaluation Signal about agent recovery metrics.</p>
+    <p><strong>AGI relevance:</strong> Agent reliability and recovery.</p>
+    <p><strong>Quality / confidence:</strong> Quality score 0.94 with high confidence.</p>
+    <p><strong>Sources:</strong> 1 source link detected in packaged page.</p>
+  </article>
+  <p>Production publish pack candidate only. Step 5 launch authorization required.</p>
+</main>
+</body>
+</html>

--- a/tests/fixtures/first_public_launch_v1/production_publish_pack_manifest.json
+++ b/tests/fixtures/first_public_launch_v1/production_publish_pack_manifest.json
@@ -1,0 +1,52 @@
+{
+  "blocked": [
+    {
+      "blockers": [
+        "not_approved_for_production_pack"
+      ],
+      "required_next_actions": [
+        "obtain_manual_publish_approval_before_packaging"
+      ],
+      "signal_id": "sig-unapproved",
+      "slug": "unapproved-page",
+      "title": "Unapproved Page"
+    }
+  ],
+  "created_at": "2026-06-27T00:00:00+00:00",
+  "input_files": {
+    "approval_report": "tests/fixtures/production_publish_pack_v1/manual_publish_approval_report.json",
+    "public_pages_dir": "tests/fixtures/production_publish_pack_v1/public_signal_pages",
+    "public_pages_manifest": "tests/fixtures/production_publish_pack_v1/public_signal_pages_manifest.json"
+  },
+  "no_deployment_performed": true,
+  "no_openai_call_performed": true,
+  "no_public_publishing_performed": true,
+  "no_workflow_dispatch_performed": true,
+  "output_directory": "tests/fixtures/first_public_launch_v1/production_publish_pack",
+  "pack_version": "production_publish_pack_v1",
+  "packaged": [
+    {
+      "agi_relevance": "Recovery metrics matter because agentic systems need auditable progress, failure handling, and safe retry behavior.",
+      "approved_for_production_pack": true,
+      "deployed": false,
+      "packaged_page_path": "tests/fixtures/first_public_launch_v1/production_publish_pack/signals/agent-evaluation-recovery-metric/index.html",
+      "packaged_preview_path": "signals/agent-evaluation-recovery-metric/",
+      "production_publish_performed": false,
+      "published": false,
+      "quality_confidence": "Quality score 0.94 with high confidence.",
+      "signal_id": "sig-agent-eval-recovery",
+      "slug": "agent-evaluation-recovery-metric",
+      "source_count": 1,
+      "source_page_path": "tests/fixtures/public_signal_page_generator_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html",
+      "summary": "A synthetic evaluation Signal about agent recovery metrics for long-running task reliability.",
+      "title": "Agent Evaluation Recovery Metric"
+    }
+  ],
+  "pages_approved_for_pack": 1,
+  "pages_blocked": 1,
+  "pages_packaged": 1,
+  "pages_seen": 2,
+  "production_publish_performed": false,
+  "release_guard_passed": true,
+  "step_5_launch_authorization_required": true
+}

--- a/tests/fixtures/first_public_launch_v1/release_guard_report.json
+++ b/tests/fixtures/first_public_launch_v1/release_guard_report.json
@@ -1,0 +1,24 @@
+{
+  "blockers": [],
+  "checked_pack_manifest": "tests/fixtures/first_public_launch_v1/production_publish_pack_manifest.json",
+  "checks": {
+    "index_generated": true,
+    "manual_approval_report_present": true,
+    "no_deployed_true": true,
+    "no_deployment_performed": true,
+    "no_internal_review_state_detected": true,
+    "no_openai_call_performed": true,
+    "no_production_publish_performed_true": true,
+    "no_published_true_before_launch": true,
+    "no_raw_article_body_detected": true,
+    "no_unapproved_pages_packaged": true,
+    "no_workflow_dispatch_performed": true,
+    "only_approved_pages_packaged": true,
+    "packaged_files_exist": true,
+    "step_5_launch_authorization_required": true
+  },
+  "created_at": "2026-06-27T00:00:00+00:00",
+  "release_guard_passed": true,
+  "release_guard_version": "production_publish_pack_release_guard_v1",
+  "warnings": []
+}

--- a/tests/test_dysonx_first_public_launch.py
+++ b/tests/test_dysonx_first_public_launch.py
@@ -73,6 +73,7 @@ class DysonXFirstPublicLaunchTests(unittest.TestCase):
         html = launched_page.read_text(encoding="utf-8")
         self.assertIn("Published", html)
         self.assertNotIn("Production Publish Candidate / Not Yet Deployed", html)
+        self.assertNotIn("noindex,nofollow", html)
 
     def test_missing_owner_launch_authorization_blocks_launch(self):
         result, manifest, output_root = self.run_launch(authorization="missing")

--- a/tests/test_dysonx_first_public_launch.py
+++ b/tests/test_dysonx_first_public_launch.py
@@ -1,0 +1,204 @@
+import ast
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dysonx_first_public_launch.py"
+FIXTURE_DIR = ROOT / "tests" / "fixtures" / "first_public_launch_v1"
+PACK_DIR = FIXTURE_DIR / "production_publish_pack"
+PACK_MANIFEST = FIXTURE_DIR / "production_publish_pack_manifest.json"
+RELEASE_GUARD = FIXTURE_DIR / "release_guard_report.json"
+EXPECTED_MANIFEST = FIXTURE_DIR / "expected_public_launch_manifest.json"
+AUTHORIZATION = "explicit_owner_authorization_in_step_5_prompt"
+
+
+class DysonXFirstPublicLaunchTests(unittest.TestCase):
+    def run_launch(self, pack_dir=PACK_DIR, pack_manifest=PACK_MANIFEST, release_guard=RELEASE_GUARD, authorization=AUTHORIZATION):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        output_root = pathlib.Path(tmpdir.name) / "public_root"
+        cmd = [
+            sys.executable,
+            str(SCRIPT),
+            "--production-pack-dir",
+            str(pack_dir),
+            "--pack-manifest",
+            str(pack_manifest),
+            "--release-guard-report",
+            str(release_guard),
+            "--public-output-root",
+            str(output_root),
+            "--owner-launch-authorization",
+            authorization,
+        ]
+        result = subprocess.run(cmd, cwd=ROOT, text=True, capture_output=True, check=False)
+        manifest_path = output_root / "signals" / "public_launch_manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else None
+        return result, manifest, output_root
+
+    def write_json(self, data):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        path = pathlib.Path(tmpdir.name) / "fixture.json"
+        path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def copy_pack(self):
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        pack_dir = pathlib.Path(tmpdir.name) / "production_publish_pack"
+        shutil.copytree(PACK_DIR, pack_dir)
+        return pack_dir
+
+    def load_pack_manifest(self):
+        return json.loads(PACK_MANIFEST.read_text(encoding="utf-8"))
+
+    def load_release_guard(self):
+        return json.loads(RELEASE_GUARD.read_text(encoding="utf-8"))
+
+    def test_valid_pack_release_guard_and_authorization_launches_page(self):
+        result, manifest, output_root = self.run_launch()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(manifest["pages_launched"], 1)
+        launched_page = output_root / "signals" / "agent-evaluation-recovery-metric" / "index.html"
+        self.assertTrue(launched_page.exists())
+        self.assertTrue((output_root / "signals" / "index.html").exists())
+        html = launched_page.read_text(encoding="utf-8")
+        self.assertIn("Published", html)
+        self.assertNotIn("Production Publish Candidate / Not Yet Deployed", html)
+
+    def test_missing_owner_launch_authorization_blocks_launch(self):
+        result, manifest, output_root = self.run_launch(authorization="missing")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIsNone(manifest)
+        self.assertFalse((output_root / "signals" / "agent-evaluation-recovery-metric" / "index.html").exists())
+        self.assertIn("missing_owner_launch_authorization", result.stderr)
+
+    def test_release_guard_passed_false_blocks_launch(self):
+        guard = self.load_release_guard()
+        guard["release_guard_passed"] = False
+        guard["blockers"] = ["fixture_release_guard_failure"]
+        release_guard = self.write_json(guard)
+
+        result, manifest, _ = self.run_launch(release_guard=release_guard)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIsNone(manifest)
+        self.assertIn("release_guard_not_passed", result.stderr)
+
+    def test_missing_packaged_file_blocks_launch(self):
+        manifest = self.load_pack_manifest()
+        manifest["packaged"][0]["packaged_page_path"] = "tests/fixtures/first_public_launch_v1/production_publish_pack/signals/missing/index.html"
+        pack_manifest = self.write_json(manifest)
+
+        result, launch_manifest, _ = self.run_launch(pack_manifest=pack_manifest)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIsNone(launch_manifest)
+        self.assertIn("no_pages_launched", result.stderr)
+
+    def test_no_approved_packaged_pages_blocks_launch(self):
+        manifest = self.load_pack_manifest()
+        manifest["packaged"] = []
+        manifest["pages_packaged"] = 0
+        pack_manifest = self.write_json(manifest)
+
+        result, launch_manifest, _ = self.run_launch(pack_manifest=pack_manifest)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIsNone(launch_manifest)
+        self.assertIn("no_approved_packaged_pages", result.stderr)
+
+    def test_raw_article_body_marker_blocks_launch(self):
+        pack_dir = self.copy_pack()
+        page = pack_dir / "signals" / "agent-evaluation-recovery-metric" / "index.html"
+        page.write_text(page.read_text(encoding="utf-8") + "\nraw_body\n", encoding="utf-8")
+        manifest = self.load_pack_manifest()
+        manifest["packaged"][0]["packaged_page_path"] = str(page)
+        pack_manifest = self.write_json(manifest)
+
+        result, launch_manifest, _ = self.run_launch(pack_dir=pack_dir, pack_manifest=pack_manifest)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIsNone(launch_manifest)
+        self.assertIn("no_pages_launched", result.stderr)
+
+    def test_internal_review_state_marker_blocks_launch(self):
+        pack_dir = self.copy_pack()
+        page = pack_dir / "signals" / "agent-evaluation-recovery-metric" / "index.html"
+        page.write_text(page.read_text(encoding="utf-8") + "\nowner_comment\n", encoding="utf-8")
+        manifest = self.load_pack_manifest()
+        manifest["packaged"][0]["packaged_page_path"] = str(page)
+        pack_manifest = self.write_json(manifest)
+
+        result, launch_manifest, _ = self.run_launch(pack_dir=pack_dir, pack_manifest=pack_manifest)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIsNone(launch_manifest)
+        self.assertIn("no_pages_launched", result.stderr)
+
+    def test_launch_manifest_sets_published_true_only_for_launched_pages(self):
+        _, manifest, _ = self.run_launch()
+
+        self.assertTrue(all(item["published"] is True for item in manifest["launched"]))
+        self.assertFalse(any(item.get("published") is True for item in manifest["blocked"]))
+
+    def test_launch_manifest_sets_production_publish_performed_true_only_for_launched_pages(self):
+        _, manifest, _ = self.run_launch()
+
+        self.assertTrue(all(item["production_publish_performed"] is True for item in manifest["launched"]))
+        self.assertFalse(any(item.get("production_publish_performed") is True for item in manifest["blocked"]))
+
+    def test_launch_manifest_confirms_no_openai_call(self):
+        _, manifest, _ = self.run_launch()
+
+        self.assertFalse(manifest["openai_call_performed"])
+
+    def test_launch_manifest_confirms_no_workflow_dispatch(self):
+        _, manifest, _ = self.run_launch()
+
+        self.assertFalse(manifest["workflow_dispatch_performed"])
+
+    def test_launch_manifest_confirms_no_manual_external_deployment(self):
+        _, manifest, _ = self.run_launch()
+
+        self.assertFalse(manifest["manual_external_deployment_performed"])
+
+    def test_cli_output_is_deterministic_enough_for_fixture_comparison(self):
+        _, manifest, _ = self.run_launch()
+        expected = json.loads(EXPECTED_MANIFEST.read_text(encoding="utf-8"))
+
+        self.assertEqual(manifest["pages_launched"], expected["pages_launched"])
+        self.assertEqual(manifest["pages_blocked"], expected["pages_blocked"])
+        self.assertEqual([item["slug"] for item in manifest["launched"]], expected["launched_slugs"])
+        self.assertEqual([item["slug"] for item in manifest["blocked"]], expected["blocked_slugs"])
+        self.assertEqual(manifest["release_guard_passed"], expected["release_guard_passed"])
+        self.assertEqual(manifest["openai_call_performed"], expected["openai_call_performed"])
+        self.assertEqual(manifest["workflow_dispatch_performed"], expected["workflow_dispatch_performed"])
+        self.assertEqual(manifest["manual_external_deployment_performed"], expected["manual_external_deployment_performed"])
+        self.assertEqual(manifest["social_distribution_performed"], expected["social_distribution_performed"])
+        self.assertEqual(manifest["newsletter_distribution_performed"], expected["newsletter_distribution_performed"])
+
+    def test_script_uses_standard_library_only(self):
+        tree = ast.parse(SCRIPT.read_text(encoding="utf-8"))
+        imports = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imports.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imports.add(node.module.split(".")[0])
+
+        allowed = {"__future__", "argparse", "json", "pathlib", "shutil", "sys", "datetime", "typing"}
+        self.assertLessEqual(imports, allowed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Completes Step 5 of the strict 5-Step Final Launch Plan.\n\n- Adds deterministic First Public Launch V1 guard/CLI.\n- Consumes Step 4 production publish pack and release guard.\n- Requires explicit Owner launch authorization.\n- Copies only approved, release-guarded static pages into the repository public static output path.\n- Adds public launch manifest.\n- Publishes the first public Signals static page set in the repository.\n- Does not call OpenAI.\n- Does not scrape.\n- Does not manually dispatch workflows.\n- Does not add backend/database.\n- Does not add social/newsletter distribution.\n- Does not create Step 6.\n- Keeps functional publishing before aesthetic polish.\n- Keeps quality and safety gates mandatory.\n\nValidation before PR:\n- python3 scripts/constitution_guard.py: PASS\n- python3 scripts/architecture_guard.py: PASS\n- python3 scripts/release_guard.py: PASS\n- python3 -m py_compile scripts/*.py: PASS\n- python3 -m unittest discover -s tests: PASS, 363 tests\n- git diff --check origin/main...HEAD: PASS