### PR TITLE
fix: sanitize DysonX public launch manifest

### DIFF
--- a/docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md
+++ b/docs/DYSONX_FIRST_PUBLIC_LAUNCH_V1.md
@@ -94,7 +94,7 @@ The manifest records:
 - source pack manifest
 - source release guard report
 - pages launched
-- pages blocked
+- pages blocked count
 - release guard status
 - manual approval verification
 - Publish Readiness Gate verification
@@ -104,6 +104,8 @@ The manifest records:
 - manual external deployment flag
 - social distribution flag
 - newsletter distribution flag
+
+The public launch manifest must remain public-safe. It may expose the blocked count, but it must not expose blocked Signal titles, blocked slugs, internal blocker codes, required next actions, fixture/test language, private review state, raw article body, or non-public decision-trail details.
 
 ## 6. Hosting Boundary
 

--- a/scripts/dysonx_first_public_launch.py
+++ b/scripts/dysonx_first_public_launch.py
@@ -207,6 +207,20 @@ def verify_launch_inputs(
     return list(dict.fromkeys(blockers))
 
 
+def public_source_pack_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    public_entry: dict[str, Any] = {
+        "signal_id": signal_id(entry),
+        "title": title(entry),
+        "slug": slug(entry),
+        "source_count": entry.get("source_count", 0),
+    }
+    for key in ("summary", "agi_relevance", "quality_confidence"):
+        value = normalize_text(entry.get(key))
+        if value:
+            public_entry[key] = value
+    return public_entry
+
+
 def copy_index(production_pack_dir: pathlib.Path, public_output_root: pathlib.Path, created_at: str) -> None:
     source_index = production_pack_dir / "signals" / "index.html"
     target_index = public_output_root / "signals" / "index.html"
@@ -260,7 +274,7 @@ def generate_launch(
                 "public_url_path": f"/signals/{page_slug}/",
                 "published": True,
                 "production_publish_performed": True,
-                "source_pack_entry": entry,
+                "source_pack_entry": public_source_pack_entry(entry),
             }
         )
 
@@ -290,7 +304,6 @@ def generate_launch(
         "pages_launched": len(launched),
         "pages_blocked": len(blocked),
         "launched": launched,
-        "blocked": blocked,
         "release_guard_passed": True,
         "manual_publish_approval_verified": True,
         "publish_readiness_gate_verified": True,

--- a/signals/agent-evaluation-recovery-metric/index.html
+++ b/signals/agent-evaluation-recovery-metric/index.html
@@ -36,7 +36,7 @@
 <p>Generated at 2026-06-27T00:00:00+00:00. Published static public Signal page.</p>
 <div class="notice"><strong>Published.</strong> Explicit Owner launch authorization was provided for DysonX First Public Launch V1. Production static files were published into the repository public surface. External deployment status depends on repository hosting automation.</div>
 <p class="muted">Packaged at 2026-06-27T05:38:28.276196+00:00.</p>
-<p class="muted">Launched at 2026-06-27T05:41:36.136551+00:00. Manual external deployment was not performed by this tool.</p>
+<p class="muted">Launched at 2026-06-27T05:55:42.081565+00:00. Manual external deployment was not performed by this tool.</p>
 </main>
 </body>
 </html>

--- a/signals/index.html
+++ b/signals/index.html
@@ -34,7 +34,7 @@
 </article>
 
 <p>Generated at 2026-06-27T05:38:28.276196+00:00. Production publish pack candidate only.</p>
-<p class="muted">Launched at 2026-06-27T05:41:36.136551+00:00. Manual external deployment was not performed by this tool.</p>
+<p class="muted">Launched at 2026-06-27T05:55:42.081565+00:00. Manual external deployment was not performed by this tool.</p>
 </main>
 </body>
 </html>

--- a/signals/public_launch_manifest.json
+++ b/signals/public_launch_manifest.json
@@ -1,79 +1,5 @@
 {
-  "blocked": [
-    {
-      "blockers": [
-        "not_approved_for_production_pack",
-        "page_not_found_in_public_pages_manifest"
-      ],
-      "required_next_actions": [
-        "obtain_manual_publish_approval_before_packaging",
-        "regenerate_public_signal_pages_manifest"
-      ],
-      "signal_id": "sig_unapproved",
-      "slug": "unapproved-page",
-      "title": "Unapproved page should block"
-    },
-    {
-      "blockers": [
-        "source_html_file_missing"
-      ],
-      "required_next_actions": [
-        "provide_generated_public_signal_page_html"
-      ],
-      "signal_id": "sig_missing_source_html",
-      "slug": "missing-source-html",
-      "title": "Missing source HTML should block"
-    },
-    {
-      "blockers": [
-        "approval_published_true",
-        "manifest_published_true"
-      ],
-      "required_next_actions": [
-        "use_only_not_published_not_deployed_step_2_and_step_3_artifacts"
-      ],
-      "signal_id": "sig_published_true",
-      "slug": "published-true-page",
-      "title": "Published true page should not be packaged"
-    },
-    {
-      "blockers": [
-        "approval_production_publish_performed_true",
-        "manifest_production_publish_performed_true"
-      ],
-      "required_next_actions": [
-        "use_only_not_published_not_deployed_step_2_and_step_3_artifacts"
-      ],
-      "signal_id": "sig_production_publish_performed",
-      "slug": "production-publish-performed-page",
-      "title": "Production publish performed page should not be packaged"
-    },
-    {
-      "blockers": [
-        "approval_deployed_true",
-        "manifest_deployed_true",
-        "source_page_claims_published_or_deployed"
-      ],
-      "required_next_actions": [
-        "use_only_not_published_not_deployed_step_2_and_step_3_artifacts"
-      ],
-      "signal_id": "sig_deployed_true",
-      "slug": "deployed-true-page",
-      "title": "Deployed true page should not be packaged"
-    },
-    {
-      "blockers": [
-        "decision_not_approve_for_production_pack"
-      ],
-      "required_next_actions": [
-        "change_decision_to_approve_for_production_pack_after_owner_review"
-      ],
-      "signal_id": "sig_blocked_by_manual_approval",
-      "slug": "blocked-by-manual-approval",
-      "title": "Blocked by manual approval"
-    }
-  ],
-  "created_at": "2026-06-27T05:41:36.136551+00:00",
+  "created_at": "2026-06-27T05:55:42.081565+00:00",
   "launch_authorization": "explicit_owner_authorization_in_step_5_prompt",
   "launch_version": "first_public_launch_v1",
   "launched": [
@@ -86,17 +12,10 @@
       "slug": "agent-evaluation-recovery-metric",
       "source_pack_entry": {
         "agi_relevance": "Agents and evaluation.",
-        "approved_for_production_pack": true,
-        "deployed": false,
-        "packaged_page_path": "tmp/production_publish_pack/signals/agent-evaluation-recovery-metric/index.html",
-        "packaged_preview_path": "signals/agent-evaluation-recovery-metric/",
-        "production_publish_performed": false,
-        "published": false,
         "quality_confidence": "Quality score: 59/65; Tier: A; Confidence: high attribution confidence.",
         "signal_id": "sig_ready_agent_eval",
         "slug": "agent-evaluation-recovery-metric",
         "source_count": 2,
-        "source_page_path": "tests/fixtures/production_publish_pack_v1/public_signal_pages/signals/agent-evaluation-recovery-metric/index.html",
         "summary": "A synthetic benchmark note adds a recovery metric for agent evaluation.",
         "title": "Agent evaluation benchmark adds recovery metric"
       },

--- a/tests/fixtures/first_public_launch_v1/expected_public_launch_manifest.json
+++ b/tests/fixtures/first_public_launch_v1/expected_public_launch_manifest.json
@@ -1,7 +1,4 @@
 {
-  "blocked_slugs": [
-    "unapproved-page"
-  ],
   "launched_slugs": [
     "agent-evaluation-recovery-metric"
   ],

--- a/tests/test_dysonx_first_public_launch.py
+++ b/tests/test_dysonx_first_public_launch.py
@@ -150,13 +150,53 @@ class DysonXFirstPublicLaunchTests(unittest.TestCase):
         _, manifest, _ = self.run_launch()
 
         self.assertTrue(all(item["published"] is True for item in manifest["launched"]))
-        self.assertFalse(any(item.get("published") is True for item in manifest["blocked"]))
+        self.assertNotIn("blocked", manifest)
 
     def test_launch_manifest_sets_production_publish_performed_true_only_for_launched_pages(self):
         _, manifest, _ = self.run_launch()
 
         self.assertTrue(all(item["production_publish_performed"] is True for item in manifest["launched"]))
-        self.assertFalse(any(item.get("production_publish_performed") is True for item in manifest["blocked"]))
+        self.assertNotIn("blocked", manifest)
+
+    def test_public_launch_manifest_does_not_expose_blocked_details(self):
+        _, manifest, _ = self.run_launch()
+
+        self.assertEqual(manifest["pages_blocked"], 1)
+        self.assertNotIn("blocked", manifest)
+
+    def test_public_launch_manifest_does_not_expose_internal_blocker_codes(self):
+        _, _, output_root = self.run_launch()
+
+        text = (output_root / "signals" / "public_launch_manifest.json").read_text(encoding="utf-8")
+        self.assertNotIn("not_approved_for_production_pack", text)
+        self.assertNotIn("source_html_file_missing", text)
+        self.assertNotIn("page_not_found_in_public_pages_manifest", text)
+
+    def test_public_launch_manifest_does_not_expose_required_next_actions(self):
+        _, _, output_root = self.run_launch()
+
+        text = (output_root / "signals" / "public_launch_manifest.json").read_text(encoding="utf-8")
+        self.assertNotIn("required_next_actions", text)
+        self.assertNotIn("regenerate_public_signal_pages_manifest", text)
+
+    def test_public_launch_manifest_does_not_expose_fixture_titles(self):
+        _, _, output_root = self.run_launch()
+
+        text = (output_root / "signals" / "public_launch_manifest.json").read_text(encoding="utf-8")
+        self.assertNotIn("Unapproved page should block", text)
+        self.assertNotIn("Missing source HTML should block", text)
+        self.assertNotIn("Published true page should not be packaged", text)
+
+    def test_launched_entries_remain_public_safe(self):
+        _, manifest, _ = self.run_launch()
+
+        launched = manifest["launched"][0]
+        source_pack_entry = launched["source_pack_entry"]
+        self.assertEqual(launched["public_url_path"], "/signals/agent-evaluation-recovery-metric/")
+        self.assertNotIn("packaged_page_path", source_pack_entry)
+        self.assertNotIn("source_page_path", source_pack_entry)
+        self.assertNotIn("approved_for_production_pack", source_pack_entry)
+        self.assertNotIn("deployed", source_pack_entry)
 
     def test_launch_manifest_confirms_no_openai_call(self):
         _, manifest, _ = self.run_launch()
@@ -180,7 +220,7 @@ class DysonXFirstPublicLaunchTests(unittest.TestCase):
         self.assertEqual(manifest["pages_launched"], expected["pages_launched"])
         self.assertEqual(manifest["pages_blocked"], expected["pages_blocked"])
         self.assertEqual([item["slug"] for item in manifest["launched"]], expected["launched_slugs"])
-        self.assertEqual([item["slug"] for item in manifest["blocked"]], expected["blocked_slugs"])
+        self.assertNotIn("blocked", manifest)
         self.assertEqual(manifest["release_guard_passed"], expected["release_guard_passed"])
         self.assertEqual(manifest["openai_call_performed"], expected["openai_call_performed"])
         self.assertEqual(manifest["workflow_dispatch_performed"], expected["workflow_dispatch_performed"])


### PR DESCRIPTION
Sanitizes the public Step 5 launch manifest.\n\n- Sanitizes signals/public_launch_manifest.json.\n- Keeps public-safe launch summary and launched entries.\n- Removes blocked details, internal blocker codes, required next actions, and fixture/test language from public manifest.\n- Keeps pages_blocked count.\n- Does not change launch pipeline architecture.\n- Does not add Step 6.\n- Does not deploy.\n- Does not call OpenAI.\n- Does not dispatch workflows.\n- Does not scrape.\n- Does not add backend/database.\n\nValidation before PR:\n- python3 scripts/constitution_guard.py: PASS\n- python3 scripts/architecture_guard.py: PASS\n- python3 scripts/release_guard.py: PASS\n- python3 -m py_compile scripts/*.py: PASS\n- python3 -m unittest discover -s tests: PASS, 368 tests\n- git diff --check origin/main...HEAD: PASS\n- Manual public manifest sanitization check: PASS