### PR TITLE
fix: correct DysonX first public launch pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
           </div>
           <div class="status-item">
             <span class="status-label">Publishing</span>
-            <span class="status-value pending">Real publishing not enabled yet</span>
+            <span class="status-value ready">First public Signal published</span>
           </div>
           <div class="status-item">
             <span class="status-label">Canonical language</span>
@@ -311,7 +311,7 @@
     <footer>
       <div class="footer-inner">
         <span>DysonX Intelligence OS</span>
-        <span>No real publishing, social posting, or external provider integration is enabled in V1.</span>
+        <span>First public Signals launch complete; social posting and external provider integration remain disabled in V1.</span>
       </div>
     </footer>
   </div>

--- a/scripts/dysonx_first_public_launch.py
+++ b/scripts/dysonx_first_public_launch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import pathlib
+import re
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -115,6 +116,29 @@ def transform_launched_html(html: str, created_at: str) -> str:
     launched = html.replace("Production Publish Candidate / Not Yet Deployed", "Published")
     launched = launched.replace("Draft Preview / Not Published", "Published")
     launched = launched.replace('  <meta name="robots" content="noindex,nofollow">\n', "")
+    if "</head>" in launched and "<style>" not in launched:
+        launched = launched.replace(
+            "</head>",
+            """  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.6; background: #ffffff; }
+    main { max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }
+    h1 { margin: 0 0 16px; font-size: clamp(2rem, 5vw, 3.25rem); line-height: 1.05; }
+    h2 { margin-top: 28px; font-size: 1.05rem; }
+    a { color: #0f6f8f; }
+    code { background: #f6f8fa; padding: 1px 4px; }
+    .status { display: inline-block; margin-bottom: 16px; padding: 5px 9px; border: 1px solid #97b6c4; background: #eef7fa; color: #24505e; font-weight: 700; font-size: 0.85rem; }
+    .notice { border: 1px solid #d8dee6; border-left: 4px solid #97b6c4; background: #f6f8fa; padding: 14px; }
+    .meta { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin: 20px 0; }
+    .muted { color: #667085; font-size: 0.9rem; }
+  </style>
+</head>""",
+        )
+    launched = re.sub(
+        r"<ul><li><a[^>]+href=\"https?://[^\"]+\.test/[^\"]*\"[^>]*>.*?</a></li></ul>",
+        "<p>Source attribution retained in launch metadata; external source URL omitted for this V1 launch sample.</p>",
+        launched,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
     launched = launched.replace(
         "Step 5 explicit Owner launch authorization is required before production release.",
         "Published through DysonX First Public Launch V1 after explicit Owner launch authorization.",
@@ -136,11 +160,18 @@ def transform_launched_html(html: str, created_at: str) -> str:
         "Published static public Signal page.",
     )
     launched = launched.replace(
+        "Production publish pack candidate only.",
+        "First public launch complete.",
+    )
+    launched = launched.replace(
         "This packaged page is a production publish candidate. It is not published, not live, and not deployed.",
         "This page is a published DysonX public Signal. External deployment status depends on repository hosting automation.",
     )
     launched = launched.replace("DysonX Draft Preview", "DysonX Public Signal")
     launched = launched.replace("Back to Public Signals Draft Preview", "Back to Public Signals")
+    launched = launched.replace('href="../"', 'href="/signals/"')
+    if 'href="/signals/"' not in launched and "</main>" in launched:
+        launched = launched.replace("</main>", '<p><a href="/signals/">Back to Public Signals</a></p>\n</main>')
     if "</main>" in launched:
         launched = launched.replace(
             "</main>",

--- a/scripts/dysonx_static_preview_check.py
+++ b/scripts/dysonx_static_preview_check.py
@@ -131,7 +131,7 @@ def check_identity_and_language_placeholder(parser: IndexMetadataParser) -> None
         "AGI Map",
         "EN",
         "中文",
-        "Real publishing not enabled yet",
+        "First public Signal published",
     )
     missing = [token for token in required_tokens if token not in text]
     if missing:

--- a/signals/agent-evaluation-recovery-metric/index.html
+++ b/signals/agent-evaluation-recovery-metric/index.html
@@ -4,6 +4,18 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Agent evaluation benchmark adds recovery metric | DysonX Public Signal</title>
+  <style>
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.6; background: #ffffff; }
+    main { max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }
+    h1 { margin: 0 0 16px; font-size: clamp(2rem, 5vw, 3.25rem); line-height: 1.05; }
+    h2 { margin-top: 28px; font-size: 1.05rem; }
+    a { color: #0f6f8f; }
+    code { background: #f6f8fa; padding: 1px 4px; }
+    .status { display: inline-block; margin-bottom: 16px; padding: 5px 9px; border: 1px solid #97b6c4; background: #eef7fa; color: #24505e; font-weight: 700; font-size: 0.85rem; }
+    .notice { border: 1px solid #d8dee6; border-left: 4px solid #97b6c4; background: #f6f8fa; padding: 14px; }
+    .meta { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin: 20px 0; }
+    .muted { color: #667085; font-size: 0.9rem; }
+  </style>
 </head>
 <body>
 <main>
@@ -25,18 +37,18 @@
 <p>Agents and evaluation.</p>
 <h2>Source Attribution</h2>
 <p>Source attributed to Synthetic Research Lab benchmark note.</p>
-<ul><li><a href="https://source.dysonx.test/research/agent-recovery-benchmark" rel="nofollow noopener">https://source.dysonx.test/research/agent-recovery-benchmark</a></li></ul>
+<p>Source attribution retained in launch metadata; external source URL omitted for this V1 launch sample.</p>
 <h2>Quality And Confidence</h2>
 <p>Quality score: 59/65; Tier: A; Confidence: high attribution confidence.</p>
 <h2>Risk And Safety Notes</h2>
 <p>No blocking public-generation risk flags in the gate-passed record.</p>
 <h2>Watch Next</h2>
 <p>Watch whether recovery metrics become part of standard agent benchmark reporting.</p>
-<p><a href="../">Back to Public Signals</a></p>
+<p><a href="/signals/">Back to Public Signals</a></p>
 <p>Generated at 2026-06-27T00:00:00+00:00. Published static public Signal page.</p>
 <div class="notice"><strong>Published.</strong> Explicit Owner launch authorization was provided for DysonX First Public Launch V1. Production static files were published into the repository public surface. External deployment status depends on repository hosting automation.</div>
-<p class="muted">Packaged at 2026-06-27T05:38:28.276196+00:00.</p>
-<p class="muted">Launched at 2026-06-27T05:55:42.081565+00:00. Manual external deployment was not performed by this tool.</p>
+<p class="muted">Packaged at 2026-06-27T06:05:59.777236+00:00.</p>
+<p class="muted">Launched at 2026-06-27T06:07:12.218225+00:00. Manual external deployment was not performed by this tool.</p>
 </main>
 </body>
 </html>

--- a/signals/index.html
+++ b/signals/index.html
@@ -33,8 +33,9 @@
   <p><strong>Sources:</strong> 2 source link(s) detected in packaged page.</p>
 </article>
 
-<p>Generated at 2026-06-27T05:38:28.276196+00:00. Production publish pack candidate only.</p>
-<p class="muted">Launched at 2026-06-27T05:55:42.081565+00:00. Manual external deployment was not performed by this tool.</p>
+<p>Generated at 2026-06-27T06:05:59.777236+00:00. First public launch complete.</p>
+<p><a href="/signals/">Back to Public Signals</a></p>
+<p class="muted">Launched at 2026-06-27T06:07:12.218225+00:00. Manual external deployment was not performed by this tool.</p>
 </main>
 </body>
 </html>

--- a/signals/public_launch_manifest.json
+++ b/signals/public_launch_manifest.json
@@ -1,5 +1,5 @@
 {
-  "created_at": "2026-06-27T05:55:42.081565+00:00",
+  "created_at": "2026-06-27T06:07:12.218225+00:00",
   "launch_authorization": "explicit_owner_authorization_in_step_5_prompt",
   "launch_version": "first_public_launch_v1",
   "launched": [

--- a/tests/test_dysonx_first_public_launch.py
+++ b/tests/test_dysonx_first_public_launch.py
@@ -74,6 +74,9 @@ class DysonXFirstPublicLaunchTests(unittest.TestCase):
         self.assertIn("Published", html)
         self.assertNotIn("Production Publish Candidate / Not Yet Deployed", html)
         self.assertNotIn("noindex,nofollow", html)
+        self.assertNotIn("source.dysonx.test", html)
+        self.assertNotIn(".test/", html)
+        self.assertIn('href="/signals/"', html)
 
     def test_missing_owner_launch_authorization_blocks_launch(self):
         result, manifest, output_root = self.run_launch(authorization="missing")
@@ -238,6 +241,7 @@ class DysonXFirstPublicLaunchTests(unittest.TestCase):
                 imports.add(node.module.split(".")[0])
 
         allowed = {"__future__", "argparse", "json", "pathlib", "shutil", "sys", "datetime", "typing"}
+        allowed.add("re")
         self.assertLessEqual(imports, allowed)
 
 

--- a/tests/test_dysonx_identity_landing.py
+++ b/tests/test_dysonx_identity_landing.py
@@ -47,7 +47,8 @@ class DysonXIdentityLandingTests(unittest.TestCase):
         for nav_item in ("Signals", "Trackers", "AGI Map", "Companies", "People", "Research", "Reports"):
             self.assertIn(nav_item, html)
         self.assertIn("V1 dry-run pipeline available", html)
-        self.assertIn("Real publishing not enabled yet", html)
+        self.assertIn("First public Signal published", html)
+        self.assertNotIn("Real publishing not enabled yet", html)
         self.assertIn("EN", html)
         self.assertIn("中文", html)
 

--- a/tests/test_dysonx_public_launch_correctness.py
+++ b/tests/test_dysonx_public_launch_correctness.py
@@ -1,0 +1,46 @@
+import json
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+INDEX = ROOT / "index.html"
+SIGNAL_PAGE = ROOT / "signals" / "agent-evaluation-recovery-metric" / "index.html"
+LAUNCH_MANIFEST = ROOT / "signals" / "public_launch_manifest.json"
+
+
+class DysonXPublicLaunchCorrectnessTests(unittest.TestCase):
+    def test_homepage_status_reflects_first_public_launch(self):
+        html = INDEX.read_text(encoding="utf-8")
+
+        self.assertIn("First public Signal published", html)
+        self.assertNotIn("Real publishing not enabled yet", html)
+
+    def test_public_signal_page_has_basic_trust_markers(self):
+        html = SIGNAL_PAGE.read_text(encoding="utf-8")
+
+        self.assertIn("Published", html)
+        self.assertIn('href="/signals/"', html)
+        self.assertIn("max-width", html)
+
+    def test_public_signal_page_does_not_expose_test_source_url(self):
+        html = SIGNAL_PAGE.read_text(encoding="utf-8")
+
+        self.assertNotIn("source.dysonx.test", html)
+        self.assertNotIn(".test/", html)
+
+    def test_public_launch_manifest_remains_sanitized(self):
+        text = LAUNCH_MANIFEST.read_text(encoding="utf-8")
+        data = json.loads(text)
+
+        self.assertEqual(data["pages_launched"], 1)
+        self.assertEqual(data["pages_blocked"], 6)
+        self.assertNotIn("blocked", data)
+        self.assertNotIn("source.dysonx.test", text)
+        self.assertNotIn(".test/", text)
+        self.assertNotIn("required_next_actions", text)
+        self.assertNotIn("not_approved_for_production_pack", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Narrow post-launch public correctness hotfix.\n\n- Corrects homepage status now that First Public Launch is complete.\n- Improves public Signal page minimum readability/trust without starting a UI polish sprint.\n- Removes fake .test source URL exposure from public pages.\n- Keeps public launch manifest sanitized.\n- Does not add Step 6.\n- Does not add new features.\n- Does not call OpenAI.\n- Does not scrape.\n- Does not dispatch workflows.\n- Does not manually deploy.\n- Does not add backend/database.\n\nValidation before PR:\n- python3 scripts/constitution_guard.py: PASS\n- python3 scripts/architecture_guard.py: PASS\n- python3 scripts/release_guard.py: PASS\n- python3 -m py_compile scripts/*.py: PASS\n- python3 -m unittest discover -s tests: PASS, 372 tests\n- git diff --check origin/main...HEAD: PASS\n- Public grep checks: PASS