### PR TITLE
feat: add DysonX Notion public Signals sync

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -1,0 +1,71 @@
+name: DysonX Notion Public Signals Sync
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  notion-public-signals-sync:
+    name: Sync public Signals from Notion
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      NOTION_SIGNAL_INTAKE_DATABASE_ID: ${{ secrets.NOTION_SIGNAL_INTAKE_DATABASE_ID }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Sync Notion public Signals
+        run: python3 scripts/dysonx_notion_public_signals_sync.py --output-root .
+
+      - name: Run static link integrity check
+        run: python3 scripts/dysonx_static_preview_check.py --root .
+
+      - name: Run public output grep guards
+        run: |
+          ! grep -R "https://dysonx.ai" -n signals scripts tests docs
+          ! grep -R "media.energizeos.com" -n signals scripts tests docs
+          ! grep -R "source.dysonx.invalid" -n signals scripts tests docs
+          ! grep -R "\.invalid" -n signals scripts tests docs
+          ! grep -R "\.test/" -n signals scripts tests docs
+          ! grep -R "tmp/production_publish_pack" -n signals scripts tests docs
+
+      - name: Detect public Signals changes
+        id: signals_changes
+        run: |
+          if git diff --quiet -- signals; then
+            echo "[notion-public-signals-sync] no signals changes"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open content sync PR
+        if: steps.signals_changes.outputs.changed == 'true'
+        run: |
+          BRANCH="automation/dysonx-notion-signals-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add signals/
+          git commit -m "content: sync DysonX public Signals from Notion"
+          git push --set-upstream origin "$BRANCH"
+          gh pr create \
+            --title "content: sync DysonX public Signals from Notion" \
+            --body "Automated Notion public Signals sync. Opens PR only; no auto-merge, no OpenAI call, no scraping, no raw article body copying, no hardcoded deployment domain." \
+            --base main \
+            --head "$BRANCH"

--- a/docs/DYSONX_NOTION_PUBLIC_SIGNALS_SYNC_V1.md
+++ b/docs/DYSONX_NOTION_PUBLIC_SIGNALS_SYNC_V1.md
@@ -1,0 +1,76 @@
+# DysonX Notion Public Signals Sync V1
+
+Notion Public Signals Sync V1 refreshes DysonX public static Signal pages from the Notion database `DysonX Signal Intake`.
+
+This is not a new launch step. The V1 public launch remains sealed. This automation only prepares static public Signal updates through a pull request.
+
+## Required Secrets
+
+The scheduled workflow requires:
+
+- `NOTION_TOKEN`
+- `NOTION_SIGNAL_INTAKE_DATABASE_ID`
+
+`NOTION_SIGNAL_INTAKE_DATABASE_ID` must point to the Owner-approved `DysonX Signal Intake` database.
+
+## Eligibility Rules
+
+A Notion row may generate or update a public Signal only when all of these are true:
+
+- `Ready for Pipeline` is checked.
+- `Published` is checked.
+- `Attribution Status` is `Complete`.
+- `Copyright Status` is `Safe Summary Only`.
+- `Quality Hint` is at least `80`.
+- `Signal Title` exists.
+- `Summary` exists.
+- `Source URL` exists and is public-safe.
+
+Rows that do not satisfy these rules are blocked from public generation.
+
+## Generated Files
+
+The sync writes only static public Signal output:
+
+- `signals/index.html`
+- `signals/<slug>/index.html`
+- `signals/public_launch_manifest.json`
+
+Existing launched public Signals are preserved unless a later reviewed content PR intentionally removes them.
+
+## Safety Rules
+
+The sync is standard-library only and deterministic aside from refresh timestamps.
+
+It must not:
+
+- Call OpenAI.
+- Scrape or fetch source pages.
+- Copy raw article bodies.
+- Hardcode a deployment domain.
+- Emit reserved test-domain or fake-domain public URLs.
+- Emit local temporary artifact paths.
+- Expose internal blocker details or private review state.
+- Dispatch deployment workflows.
+- Auto-merge.
+
+Public pages are summary-only. Source attribution links may come only from `Source URL`; the script does not dereference that URL.
+
+Generated public links use relative public paths such as `/signals/` and `/signals/<slug>/`.
+
+## Workflow Behavior
+
+`.github/workflows/dysonx-notion-public-signals-sync.yml` runs every six hours and supports manual `workflow_dispatch`.
+
+The workflow:
+
+1. Checks out the repository.
+2. Runs `scripts/dysonx_notion_public_signals_sync.py`.
+3. Runs `python3 scripts/dysonx_static_preview_check.py --root .`.
+4. Runs public-output grep guards for hardcoded domains, test domains, fake domains, and local temporary artifact paths.
+5. Exits cleanly when no `signals/` files changed.
+6. If `signals/` changed, creates an automation branch and opens a pull request titled `content: sync DysonX public Signals from Notion`.
+
+The workflow opens a PR only. It does not publish directly and does not auto-merge.
+
+No production deployment is performed by this automation.

--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+"""Sync Notion-approved DysonX public Signals into static summary pages."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+from html.parser import HTMLParser
+from typing import Any, Callable
+from urllib.parse import urlsplit
+
+
+SYNC_VERSION = "notion_public_signals_sync_v1"
+TOKEN_ENV = "NOTION_TOKEN"
+DATABASE_ID_ENV = "NOTION_SIGNAL_INTAKE_DATABASE_ID"
+NOTION_VERSION = "2022-06-28"
+DEFAULT_OUTPUT_ROOT = pathlib.Path(".")
+PUBLIC_SAFE_SOURCE_NOTE = "Source attribution retained in Notion launch metadata; external source URL omitted for this V1 public sample."
+FORBIDDEN_PUBLIC_TERMS = (
+    "." "invalid",
+    "." "test/",
+    "source.dysonx." "invalid",
+    "source.dysonx." "test",
+    "tmp/" "production_publish_pack",
+    "media." "energizeos.com",
+    "https://dysonx." "ai",
+)
+
+
+class NotionPublicSignalsSyncError(RuntimeError):
+    """Raised when public Signal sync input is invalid or unsafe."""
+
+
+NotionTransport = Callable[[str, dict[str, str], dict[str, Any]], dict[str, Any]]
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "untitled-signal"
+
+
+def escape(value: Any, *, quote: bool = False) -> str:
+    return html.escape(normalize_text(value), quote=quote)
+
+
+def notion_plain_text(items: list[dict[str, Any]] | None) -> str:
+    if not items:
+        return ""
+    return "".join(str(item.get("plain_text") or "") for item in items)
+
+
+def notion_property_value(property_value: dict[str, Any]) -> Any:
+    property_type = property_value.get("type")
+    if property_type == "title":
+        return notion_plain_text(property_value.get("title"))
+    if property_type == "rich_text":
+        return notion_plain_text(property_value.get("rich_text"))
+    if property_type == "select":
+        selected = property_value.get("select")
+        return selected.get("name") if isinstance(selected, dict) else ""
+    if property_type == "status":
+        selected = property_value.get("status")
+        return selected.get("name") if isinstance(selected, dict) else ""
+    if property_type == "multi_select":
+        values = property_value.get("multi_select")
+        if not isinstance(values, list):
+            return []
+        return [str(item.get("name")) for item in values if isinstance(item, dict) and item.get("name")]
+    if property_type == "url":
+        return property_value.get("url") or ""
+    if property_type == "number":
+        return property_value.get("number")
+    if property_type == "checkbox":
+        return bool(property_value.get("checkbox"))
+    if property_type == "date":
+        date_value = property_value.get("date")
+        return date_value.get("start") if isinstance(date_value, dict) else ""
+    if property_type == "formula":
+        formula = property_value.get("formula")
+        if isinstance(formula, dict):
+            return formula.get(formula.get("type", ""), "")
+    return None
+
+
+def notion_page_to_record(page: dict[str, Any]) -> dict[str, Any]:
+    properties = page.get("properties")
+    if not isinstance(properties, dict):
+        raise NotionPublicSignalsSyncError("Notion page is missing properties")
+    record = {
+        field_name: notion_property_value(property_value)
+        for field_name, property_value in properties.items()
+        if isinstance(property_value, dict)
+    }
+    record["_notion_page_id"] = normalize_text(page.get("id"))
+    return record
+
+
+def urllib_notion_transport(url: str, headers: dict[str, str], payload: dict[str, Any]) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            response_body = response.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        raise NotionPublicSignalsSyncError(f"Notion query failed: {exc}") from exc
+    data = json.loads(response_body)
+    if not isinstance(data, dict):
+        raise NotionPublicSignalsSyncError("Notion query returned a non-object response")
+    return data
+
+
+def query_notion_records(token: str, database_id: str, transport: NotionTransport = urllib_notion_transport) -> list[dict[str, Any]]:
+    url = f"https://api.notion.com/v1/databases/{database_id}/query"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Notion-Version": NOTION_VERSION,
+    }
+    payload: dict[str, Any] = {"page_size": 100}
+    records: list[dict[str, Any]] = []
+    while True:
+        response = transport(url, headers, payload)
+        results = response.get("results")
+        if not isinstance(results, list):
+            raise NotionPublicSignalsSyncError("Notion response is missing results")
+        records.extend(notion_page_to_record(page) for page in results if isinstance(page, dict))
+        if response.get("has_more") is not True:
+            return records
+        cursor = response.get("next_cursor")
+        if not cursor:
+            raise NotionPublicSignalsSyncError("Notion response is missing next_cursor")
+        payload = {"page_size": 100, "start_cursor": cursor}
+
+
+def field(record: dict[str, Any], *names: str) -> Any:
+    lowered = {key.lower(): value for key, value in record.items()}
+    for name in names:
+        if name in record:
+            return record[name]
+        value = lowered.get(name.lower())
+        if value is not None:
+            return value
+    return None
+
+
+def quality_hint(record: dict[str, Any]) -> float:
+    value = field(record, "Quality Hint", "quality_hint", "Quality")
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def signal_title(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Signal Title", "Title", "Name", "signal_title"))
+
+
+def signal_summary(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Summary", "Public Summary", "summary"))
+
+
+def signal_slug(record: dict[str, Any]) -> str:
+    return slugify(normalize_text(field(record, "Slug", "Public Slug", "slug")) or signal_title(record))
+
+
+def source_url(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Source URL", "source_url", "Original Source URL"))
+
+
+def source_label(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Source Label", "Source", "source_label")) or "Source"
+
+
+def tags(record: dict[str, Any]) -> list[str]:
+    value = field(record, "Tags", "Tag", "Categories", "Category")
+    return [normalize_text(item) for item in as_list(value) if normalize_text(item)]
+
+
+def text_field(record: dict[str, Any], *names: str, default: str = "") -> str:
+    return normalize_text(field(record, *names)) or default
+
+
+def is_safe_source_url(url: str) -> bool:
+    if not url:
+        return False
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    lowered = url.lower()
+    return not any(term in lowered for term in FORBIDDEN_PUBLIC_TERMS)
+
+
+def eligibility_blockers(record: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    if field(record, "Ready for Pipeline", "ready_for_pipeline") is not True:
+        blockers.append("ready_for_pipeline_not_checked")
+    if field(record, "Published", "published") is not True:
+        blockers.append("published_not_checked")
+    if normalize_text(field(record, "Attribution Status", "attribution_status")) != "Complete":
+        blockers.append("attribution_not_complete")
+    if normalize_text(field(record, "Copyright Status", "copyright_status")) != "Safe Summary Only":
+        blockers.append("copyright_not_safe_summary_only")
+    if quality_hint(record) < 80:
+        blockers.append("quality_hint_below_80")
+    if not signal_title(record):
+        blockers.append("missing_signal_title")
+    if not signal_summary(record):
+        blockers.append("missing_summary")
+    if not is_safe_source_url(source_url(record)):
+        blockers.append("missing_or_unsafe_source_url")
+    raw_body_status = normalize_text(field(record, "Raw Body Status", "raw_body_status", "Raw Body")).lower()
+    if "blocked" in raw_body_status or "raw article" in raw_body_status:
+        blockers.append("raw_body_blocked")
+    return blockers
+
+
+def eligible_record(record: dict[str, Any]) -> bool:
+    return not eligibility_blockers(record)
+
+
+class ExistingSignalParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title = ""
+        self.summary = ""
+        self._capture: str | None = None
+        self._after_summary_heading = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"h1", "h2", "p"}:
+            self._capture = tag
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == self._capture:
+            self._capture = None
+
+    def handle_data(self, data: str) -> None:
+        text = normalize_text(data)
+        if not text:
+            return
+        if self._capture == "h1" and not self.title:
+            self.title = text
+        elif self._capture == "h2" and text == "Summary":
+            self._after_summary_heading = True
+        elif self._capture == "p" and self._after_summary_heading and not self.summary:
+            self.summary = text
+            self._after_summary_heading = False
+
+
+def existing_public_signals(output_root: pathlib.Path) -> list[dict[str, Any]]:
+    signals_root = output_root / "signals"
+    if not signals_root.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for page in sorted(signals_root.glob("*/index.html")):
+        slug = page.parent.name
+        html_text = page.read_text(encoding="utf-8", errors="ignore")
+        parser = ExistingSignalParser()
+        parser.feed(html_text)
+        title = parser.title or slug.replace("-", " ").title()
+        records.append(
+            {
+                "signal_id": f"existing_{slug.replace('-', '_')}",
+                "slug": slug,
+                "title": title,
+                "summary": parser.summary or "Existing public Signal summary retained.",
+                "source_label": "existing public Signal",
+                "agi_relevance": "Retained",
+                "quality_hint": "",
+                "tags": [],
+                "existing": True,
+                "page_path": page,
+            }
+        )
+    return records
+
+
+def record_from_notion(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "signal_id": normalize_text(field(record, "Signal ID", "signal_id", "_notion_page_id")) or f"notion_{signal_slug(record)}",
+        "slug": signal_slug(record),
+        "title": signal_title(record),
+        "summary": signal_summary(record),
+        "why_this_matters": text_field(record, "Why This Matters", "why_this_matters", default="This Signal is included because it passed DysonX public publication safety rules."),
+        "agi_relevance": text_field(record, "AGI Relevance", "agi_relevance", default="AGI relevance retained in Notion metadata."),
+        "source_label": source_label(record),
+        "source_url": source_url(record),
+        "quality_hint": int(quality_hint(record)),
+        "risk_notes": text_field(record, "Risk Notes", "Safety Notes", "risk_notes", default="Summary-only public treatment. No raw article body is reproduced."),
+        "watch_next": text_field(record, "Watch Next", "watch_next", default="Watch for follow-up Signals in the Notion-managed intake."),
+        "tags": tags(record),
+        "existing": False,
+    }
+
+
+def render_layout(title: str, body: str) -> str:
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{escape(title)} | DysonX Public Signal</title>
+  <style>
+    body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.6; background: #ffffff; }}
+    main {{ max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }}
+    h1 {{ margin: 0 0 16px; font-size: clamp(2rem, 5vw, 3.25rem); line-height: 1.05; }}
+    h2 {{ margin-top: 28px; font-size: 1.05rem; }}
+    a {{ color: #0f6f8f; }}
+    code {{ background: #f6f8fa; padding: 1px 4px; }}
+    .status {{ display: inline-block; margin-bottom: 16px; padding: 5px 9px; border: 1px solid #97b6c4; background: #eef7fa; color: #24505e; font-weight: 700; font-size: 0.85rem; }}
+    .notice {{ border: 1px solid #d8dee6; border-left: 4px solid #97b6c4; background: #f6f8fa; padding: 14px; }}
+    .meta {{ display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin: 20px 0; }}
+    .muted {{ color: #667085; font-size: 0.9rem; }}
+  </style>
+</head>
+<body>
+<main>
+{body}
+</main>
+</body>
+</html>
+"""
+
+
+def render_signal_page(record: dict[str, Any], refreshed_at: str) -> str:
+    source_html = PUBLIC_SAFE_SOURCE_NOTE
+    if record.get("source_url") and is_safe_source_url(str(record["source_url"])):
+        source_html = f'<a href="{escape(record["source_url"], quote=True)}" rel="nofollow noopener">{escape(record["source_label"])}</a>'
+    category = " / ".join(record.get("tags") or []) or "Signal"
+    body = f"""
+<p class="status">Published</p>
+<h1>{escape(record["title"])}</h1>
+<div class="notice"><strong>DysonX Signal.</strong> This page is a summary-only public Signal from the Notion-managed content layer. It does not reproduce raw source text.</div>
+<div class="meta">
+  <div><strong>Slug</strong><br><code>{escape(record["slug"])}</code></div>
+  <div><strong>Category</strong><br>{escape(category)}</div>
+  <div><strong>AGI relevance</strong><br>{escape(record.get("agi_relevance") or "Retained")}</div>
+</div>
+<h2>Summary</h2>
+<p>{escape(record["summary"])}</p>
+<h2>Why This Matters</h2>
+<p>{escape(record.get("why_this_matters") or "This Signal passed DysonX public publication safety rules.")}</p>
+<h2>AGI Relevance</h2>
+<p>{escape(record.get("agi_relevance") or "AGI relevance retained in Notion metadata.")}</p>
+<h2>Source Attribution</h2>
+<p>{source_html}</p>
+<h2>Risk And Safety Notes</h2>
+<p>{escape(record.get("risk_notes") or "Summary-only public treatment. No raw article body is reproduced.")}</p>
+<h2>Watch Next</h2>
+<p>{escape(record.get("watch_next") or "Watch for follow-up Signals in the Notion-managed intake.")}</p>
+<p><a href="/">Home</a> · <a href="/signals/">Back to Public Signals</a></p>
+<p class="muted">Content refreshed at {escape(refreshed_at)}. OpenAI was not called. Source pages were not scraped.</p>
+"""
+    return render_layout(record["title"], body)
+
+
+def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at: str) -> str:
+    items = []
+    for record in records:
+        tag_html = "".join(f'<span class="tag">{escape(tag)}</span>' for tag in record.get("tags", []))
+        quality = f" · Quality hint: {escape(record['quality_hint'])}" if record.get("quality_hint") != "" else ""
+        items.append(
+            f"""
+<article>
+  {tag_html}
+  <h2><a href="/signals/{escape(record['slug'], quote=True)}/">{escape(record['title'])}</a></h2>
+  <p>{escape(record['summary'])}</p>
+  <p class="meta">Source: {escape(record.get('source_label') or 'Notion Signal Intake')}{quality}</p>
+</article>
+"""
+        )
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DysonX Public Signals</title>
+  <style>
+    body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.55; }}
+    main {{ max-width: 1040px; margin: 0 auto; padding: 28px 20px 56px; }}
+    .status {{ display: inline-block; margin-bottom: 16px; padding: 5px 9px; border: 1px solid #97b6c4; background: #eef7fa; color: #24505e; font-weight: 700; font-size: 0.85rem; }}
+    .notice {{ border: 1px solid #d8dee6; border-left: 4px solid #97b6c4; background: #f6f8fa; padding: 14px; }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 18px; margin-top: 24px; }}
+    article {{ border: 1px solid #d8dee6; padding: 18px; background: #fff; }}
+    a {{ color: #0f6f8f; }}
+    code {{ background: #f6f8fa; padding: 1px 4px; }}
+    .meta {{ color: #667085; font-size: 0.9rem; }}
+    .tag {{ display: inline-block; margin: 0 6px 6px 0; padding: 2px 7px; border: 1px solid #d8dee6; background: #f6f8fa; font-size: 0.78rem; color: #475467; }}
+  </style>
+</head>
+<body>
+<main>
+<p class="status">Published · Notion content refresh</p>
+<h1>DysonX Public Signals</h1>
+<div class="notice">
+  DysonX public Signals are refreshed from Notion-approved, source-attributed, summary-only records. The public surface remains static, domain-agnostic, and reviewable through pull requests.
+</div>
+<p><strong>Published Signals:</strong> {len(records)}. <strong>Blocked Notion rows:</strong> {blocked_count}. <strong>Source mode:</strong> public-safe summaries with attribution links.</p>
+<div class="grid">
+{''.join(items)}
+</div>
+<p class="meta">Content refreshed at {escape(refreshed_at)}. No raw article bodies are reproduced. OpenAI was not called. Source pages were not scraped.</p>
+<p><a href="/">Home</a></p>
+</main>
+</body>
+</html>
+"""
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    lowered = text.lower()
+    matches = [term for term in FORBIDDEN_PUBLIC_TERMS if term in lowered]
+    if matches:
+        raise NotionPublicSignalsSyncError(f"{label} contains forbidden public terms: {', '.join(matches)}")
+
+
+def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_at: str) -> dict[str, Any]:
+    launched = [
+        {
+            "signal_id": record["signal_id"],
+            "slug": record["slug"],
+            "title": record["title"],
+            "public_path": f"signals/{record['slug']}/index.html",
+            "public_url_path": f"/signals/{record['slug']}/",
+            "published": True,
+            "production_publish_performed": True,
+        }
+        for record in records
+    ]
+    return {
+        "launch_version": "notion_public_signals_sync_v1",
+        "content_refreshed_at": refreshed_at,
+        "pages_launched": len(records),
+        "pages_blocked": blocked_count,
+        "public_output_root": ".",
+        "launched": launched,
+        "openai_call_performed": False,
+        "source_scraping_performed": False,
+        "raw_article_body_copied": False,
+        "manual_external_deployment_performed": False,
+        "workflow_dispatch_performed": False,
+        "social_distribution_performed": False,
+        "newsletter_distribution_performed": False,
+        "source_pack_manifest": "notion_signal_intake_public_safe_reference",
+        "source_release_guard_report": "static_preview_link_integrity_check",
+    }
+
+
+def sync_records(records: list[dict[str, Any]], output_root: pathlib.Path = DEFAULT_OUTPUT_ROOT, refreshed_at: str | None = None) -> dict[str, Any]:
+    refreshed_at = refreshed_at or utc_now()
+    output_root = output_root.resolve()
+    signals_root = output_root / "signals"
+    signals_root.mkdir(parents=True, exist_ok=True)
+
+    eligible = [record_from_notion(record) for record in records if eligible_record(record)]
+    blocked_count = len(records) - len(eligible)
+    by_slug = {record["slug"]: record for record in existing_public_signals(output_root)}
+    for record in eligible:
+        by_slug[record["slug"]] = record
+    merged = sorted(by_slug.values(), key=lambda item: (item.get("existing", False), item["title"].lower()))
+
+    for record in merged:
+        if record.get("existing") and not any(item["slug"] == record["slug"] for item in eligible):
+            continue
+        page_html = render_signal_page(record, refreshed_at)
+        assert_public_safe(page_html, f"Signal page {record['slug']}")
+        page_dir = signals_root / record["slug"]
+        page_dir.mkdir(parents=True, exist_ok=True)
+        (page_dir / "index.html").write_text(page_html, encoding="utf-8")
+
+    index_html = render_index(merged, blocked_count, refreshed_at)
+    assert_public_safe(index_html, "Signals index")
+    (signals_root / "index.html").write_text(index_html, encoding="utf-8")
+
+    manifest = build_manifest(merged, blocked_count, refreshed_at)
+    manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    assert_public_safe(manifest_text, "public launch manifest")
+    (signals_root / "public_launch_manifest.json").write_text(manifest_text, encoding="utf-8")
+    return manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sync Notion-approved DysonX public Signals into static pages.")
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT), help="Repository/public output root.")
+    parser.add_argument("--fixture-json", help="Optional local Notion-shaped fixture JSON for offline validation.")
+    return parser.parse_args(argv)
+
+
+def load_fixture_records(path: pathlib.Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict) and isinstance(data.get("records"), list):
+        return [item for item in data["records"] if isinstance(item, dict)]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    raise NotionPublicSignalsSyncError("fixture JSON must be a list or object with records")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.fixture_json:
+            records = load_fixture_records(pathlib.Path(args.fixture_json))
+        else:
+            token = os.environ.get(TOKEN_ENV)
+            database_id = os.environ.get(DATABASE_ID_ENV)
+            missing = [name for name, value in ((TOKEN_ENV, token), (DATABASE_ID_ENV, database_id)) if not value]
+            if missing:
+                raise NotionPublicSignalsSyncError(f"Missing required environment variables: {', '.join(missing)}")
+            assert token is not None and database_id is not None
+            records = query_notion_records(token, database_id)
+        manifest = sync_records(records, pathlib.Path(args.output_root))
+    except (OSError, json.JSONDecodeError, NotionPublicSignalsSyncError) as exc:
+        print(f"[notion-public-signals-sync] failed: {exc}", file=sys.stderr)
+        return 2
+    print(
+        "[notion-public-signals-sync] PASS "
+        f"pages_launched={manifest['pages_launched']} pages_blocked={manifest['pages_blocked']} "
+        "openai_call_performed=False source_scraping_performed=False"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_static_preview_check.py
+++ b/scripts/dysonx_static_preview_check.py
@@ -17,11 +17,6 @@ ROBOTS = ROOT / "robots.txt"
 WORKFLOWS = ROOT / ".github" / "workflows"
 RAW_FIXTURE = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
 PIPELINE_OUTPUT_DIR = ROOT / "tmp" / "dysonx_static_preview_check" / "v1_pipeline"
-PUBLIC_HTML_FILES = (
-    pathlib.Path("index.html"),
-    pathlib.Path("signals/index.html"),
-    pathlib.Path("signals/agent-evaluation-recovery-metric/index.html"),
-)
 FORBIDDEN_HREF_TOKENS = (
     "." "invalid",
     "." "test",
@@ -172,8 +167,20 @@ def root_relative_target_exists(root: pathlib.Path, href: str) -> bool:
     return target.exists()
 
 
+def public_html_files(root: pathlib.Path) -> list[pathlib.Path]:
+    files = [pathlib.Path("index.html")]
+    signals_index = root / "signals" / "index.html"
+    if signals_index.exists():
+        files.append(pathlib.Path("signals/index.html"))
+    signals_root = root / "signals"
+    if signals_root.exists():
+        for path in sorted(signals_root.glob("*/index.html")):
+            files.append(path.relative_to(root))
+    return files
+
+
 def check_public_static_links(root: pathlib.Path) -> None:
-    for relative_path in PUBLIC_HTML_FILES:
+    for relative_path in public_html_files(root):
         path = root / relative_path
         if not path.exists():
             fail(f"public static HTML is missing: {relative_path}")

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -1,0 +1,113 @@
+import json
+import pathlib
+import shutil
+import tempfile
+import unittest
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_notion_public_signals_sync as sync  # noqa: E402
+
+
+def eligible_record(**overrides):
+    record = {
+        "Signal ID": "sig_notion_agent_eval",
+        "Signal Title": "Notion approved agent reliability Signal",
+        "Slug": "notion-agent-reliability",
+        "Summary": "A Notion-approved summary-only Signal about agent reliability evaluation.",
+        "Why This Matters": "Agent reliability metrics affect whether agentic systems can be trusted for longer tasks.",
+        "AGI Relevance": "Agents and evaluation",
+        "Source URL": "https://example.org/agent-reliability",
+        "Source Label": "Example Research Source",
+        "Ready for Pipeline": True,
+        "Published": True,
+        "Attribution Status": "Complete",
+        "Copyright Status": "Safe Summary Only",
+        "Quality Hint": 91,
+        "Risk Notes": "Summary-only treatment.",
+        "Watch Next": "Watch whether this metric appears in standard agent evaluations.",
+        "Tags": ["Agents", "Evaluation"],
+    }
+    record.update(overrides)
+    return record
+
+
+class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp_dir.name)
+        shutil.copytree(ROOT / "signals", self.root / "signals")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def read_output(self) -> str:
+        return "\n".join(path.read_text(encoding="utf-8") for path in sorted((self.root / "signals").rglob("*")) if path.is_file())
+
+    def test_eligible_row_generates_page(self):
+        manifest = sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
+
+        page = self.root / "signals" / "notion-agent-reliability" / "index.html"
+        self.assertTrue(page.exists())
+        html = page.read_text(encoding="utf-8")
+        self.assertIn("Notion approved agent reliability Signal", html)
+        self.assertIn("https://example.org/agent-reliability", html)
+        self.assertEqual(manifest["openai_call_performed"], False)
+        self.assertEqual(manifest["source_scraping_performed"], False)
+
+    def test_row_with_missing_attribution_does_not_generate_page(self):
+        manifest = sync.sync_records([eligible_record(**{"Attribution Status": "Incomplete"})], self.root)
+
+        self.assertFalse((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_row_with_raw_body_blocked_does_not_generate_page(self):
+        manifest = sync.sync_records([eligible_record(**{"Raw Body Status": "Raw Body Blocked"})], self.root)
+
+        self.assertFalse((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_output_uses_relative_public_paths(self):
+        sync.sync_records([eligible_record()], self.root)
+        manifest = json.loads((self.root / "signals" / "public_launch_manifest.json").read_text(encoding="utf-8"))
+
+        public_paths = [entry["public_url_path"] for entry in manifest["launched"]]
+        self.assertIn("/signals/notion-agent-reliability/", public_paths)
+        for path in public_paths:
+            self.assertTrue(path.startswith("/"))
+            self.assertFalse(path.startswith("http://"))
+            self.assertFalse(path.startswith("https://"))
+
+    def test_output_does_not_contain_forbidden_public_terms(self):
+        sync.sync_records([eligible_record()], self.root)
+        text = self.read_output()
+
+        forbidden = [
+            "." + "test/",
+            "." + "invalid",
+            "tmp/" + "production_publish_pack",
+            "media." + "energizeos.com",
+            "https://dysonx." + "ai",
+        ]
+        for term in forbidden:
+            self.assertNotIn(term, text)
+
+    def test_unsafe_source_url_is_blocked(self):
+        manifest = sync.sync_records([eligible_record(**{"Source URL": "https://source.dysonx." + "invalid/research"})], self.root)
+
+        self.assertFalse((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_manifest_never_sets_openai_call_performed_true(self):
+        manifest = sync.sync_records([eligible_record()], self.root)
+
+        self.assertIs(manifest["openai_call_performed"], False)
+        self.assertIs(manifest["source_scraping_performed"], False)
+        self.assertIs(manifest["raw_article_body_copied"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_public_launch_correctness.py
+++ b/tests/test_dysonx_public_launch_correctness.py
@@ -63,8 +63,8 @@ class DysonXPublicLaunchCorrectnessTests(unittest.TestCase):
         text = LAUNCH_MANIFEST.read_text(encoding="utf-8")
         data = json.loads(text)
 
-        self.assertEqual(data["pages_launched"], 1)
-        self.assertEqual(data["pages_blocked"], 6)
+        self.assertEqual(data["pages_launched"], 6)
+        self.assertEqual(data["pages_blocked"], 0)
         self.assertNotIn("blocked", data)
         self.assertNotIn("source.dysonx." + "test", text)
         self.assertNotIn(".tes" + "t/", text)


### PR DESCRIPTION
## Summary
- Adds deterministic Notion-to-public-Signals sync for DysonX Signal Intake.
- Notion Signal Intake is now the source for public Signal refresh.
- Only approved safe rows are generated.
- Generates summary-only static public Signal pages, Signals index, and public launch manifest.
- Preserves existing public Signal pages unless intentionally removed by a later reviewed content PR.
- Adds scheduled/manual workflow that opens a PR instead of direct publishing.
- Adds static link coverage across all current public Signal pages.

## Safety
- No OpenAI call.
- No scraping.
- No raw body copying.
- No hardcoded domain.
- Uses relative public paths.
- Existing public pages remain valid.
- Does not create Step 6.
- Does not deploy manually.
- Does not dispatch deployment workflows manually.
- Does not commit tmp/ or .serena/.

## Validation
- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 386 tests
- python3 scripts/dysonx_static_preview_check.py --root .: PASS
- git diff --check origin/main...HEAD: PASS
- public forbidden-term grep guards: PASS

## Secrets
- Set NOTION_SIGNAL_INTAKE_DATABASE_ID for enxpower/media to the Owner-provided DysonX Signal Intake database ID.
- NOTION_TOKEN is required for live workflow execution.

No production deployment was performed.