### PR TITLE
feat: add DysonX Source Collector V1

### DIFF
--- a/.github/workflows/dysonx-source-collector-v1.yml
+++ b/.github/workflows/dysonx-source-collector-v1.yml
@@ -1,0 +1,41 @@
+name: DysonX Source Collector V1
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  source-collector-v1:
+    name: Collect source metadata into Signal Intake
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+      DYSONX_NOTION_SOURCES_DATABASE_ID: ${{ secrets.DYSONX_NOTION_SOURCES_DATABASE_ID }}
+      NOTION_SIGNAL_INTAKE_DATABASE_ID: ${{ secrets.NOTION_SIGNAL_INTAKE_DATABASE_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run Source Collector V1
+        run: python3 scripts/dysonx_source_collector_v1.py
+
+      - name: Confirm no public static files changed
+        run: |
+          if ! git diff --quiet -- signals index.html; then
+            echo "[source-collector-v1] FAIL: collector must not modify public static files"
+            git diff -- signals index.html
+            exit 1
+          fi
+          echo "[source-collector-v1] PASS: no public static files changed"

--- a/.github/workflows/dysonx-source-collector-v1.yml
+++ b/.github/workflows/dysonx-source-collector-v1.yml
@@ -2,7 +2,7 @@ name: DysonX Source Collector V1
 
 on:
   schedule:
-    - cron: "17 */6 * * *"
+    - cron: "50 23,5,11,17 * * *"
   workflow_dispatch:
 
 permissions:

--- a/docs/DYSONX_SOURCE_COLLECTOR_V1.md
+++ b/docs/DYSONX_SOURCE_COLLECTOR_V1.md
@@ -1,0 +1,137 @@
+# DysonX Source Collector V1
+
+DysonX Source Collector V1 connects the Notion-managed `DysonX Sources` database to the Notion `DysonX Signal Intake` database.
+
+It is not a launch step and does not create Step 6. It does not write public pages. Public page generation remains owned by the Notion public Signals sync workflow introduced after PR #82.
+
+## Purpose
+
+The collector reads enabled sources, collects recent public metadata/items, converts them into safe candidate Signals, and writes those candidates into Signal Intake.
+
+It supports:
+
+- RSS and Atom feeds.
+- arXiv RSS-style metadata feeds.
+- Official website pages with title, canonical URL, and meta description extraction.
+- Government and policy pages with metadata extraction.
+- Manual source URLs.
+
+## Required Secrets
+
+The workflow requires:
+
+- `NOTION_TOKEN`
+- `DYSONX_NOTION_SOURCES_DATABASE_ID`
+- `NOTION_SIGNAL_INTAKE_DATABASE_ID`
+
+## Source Eligibility
+
+A source can be collected only when:
+
+- `Enabled` is checked.
+- `Priority` is `Critical`, `High`, or `Medium`.
+- `URL` exists.
+- `Source Type` or `Platform` is supported.
+- `Fetch Frequency` allows a new run when `Last Fetched At` exists.
+
+The live collector may update `Last Fetched At`, `Last Success At`, and `Last Error` when source-page status tracking is available in Notion.
+
+## Metadata Collection Rules
+
+For RSS and Atom feeds, V1 extracts:
+
+- title
+- link
+- published date when available
+- summary or description when available
+
+For non-feed pages, V1 extracts only:
+
+- page title
+- canonical URL
+- meta description
+
+The collector does not scrape article bodies and does not copy full page text.
+
+For arXiv sources, V1 prefers RSS/Atom metadata and may use abstract summary metadata available in the feed. It does not copy full paper text.
+
+## Candidate Signal Fields
+
+Each candidate includes:
+
+- Signal Title
+- Slug
+- Source Name
+- Source URL
+- Published Date when available
+- Category
+- AGI Relevance
+- Summary
+- Why It Matters
+- Evidence
+- Risk / Safety Notes
+- Attribution Status
+- Copyright Status
+- Quality Hint
+- Status
+- Ready for Pipeline
+- Published
+
+## Auto-Publish Eligibility
+
+The collector may mark a candidate `Ready for Pipeline` and `Published` only when all conditions are true:
+
+- Source priority is `Critical` or `High`.
+- Source authority score is at least `85`.
+- Attribution is complete.
+- Source URL is present.
+- Summary is short and summary-only.
+- No raw article body is included.
+- The item is clearly AI, AGI, agent, model, evaluation, compute, safety, or policy relevant.
+- Quality Hint is at least `85`.
+- Copyright Status is `Safe Summary Only`.
+
+Otherwise, the candidate remains not ready and not published, with status such as `Needs Owner Review` or `Needs More Sources`.
+
+## Deduplication
+
+Before creating a Signal Intake row, V1 checks existing Signal Intake records by:
+
+- Source URL
+- normalized Signal title
+
+Duplicates are skipped. V1 does not create duplicate public Signals.
+
+## Safety Rules
+
+Source Collector V1 must not:
+
+- Call OpenAI.
+- Use LLM-generated claims.
+- Copy raw article bodies.
+- Scrape full source-page bodies.
+- Publish unknown-source content.
+- Publish missing-attribution content.
+- Publish low-relevance content directly.
+- Write public static pages.
+- Hardcode a deployment domain.
+- Deploy.
+- Auto-merge.
+
+V1 uses deterministic rule-based scoring only.
+
+## Workflow
+
+`.github/workflows/dysonx-source-collector-v1.yml` runs every six hours, offset from the public Signals sync workflow, and supports manual `workflow_dispatch`.
+
+The workflow does only:
+
+`DysonX Sources -> DysonX Signal Intake`
+
+It does not modify `signals/`, does not commit public files, and does not open public content PRs.
+
+The existing Notion public Signals sync workflow remains responsible for:
+
+`DysonX Signal Intake -> Public Signals static pages -> content PR`
+
+No production deployment is performed by Source Collector V1.

--- a/scripts/dysonx_source_collector_v1.py
+++ b/scripts/dysonx_source_collector_v1.py
@@ -406,10 +406,10 @@ def category_for(item: SourceItem) -> str:
     if "arxiv" in item.source_type.lower() or "research" in text or "paper" in text:
         return "Research"
     if "agent" in text:
-        return "Agents"
+        return "Research"
     if "compute" in text or "inference" in text:
-        return "Infrastructure"
-    return "AI / AGI"
+        return "Compute"
+    return "Market Signal"
 
 
 def quality_hint(item: SourceItem) -> int:
@@ -457,7 +457,7 @@ def candidate_from_item(item: SourceItem) -> dict[str, Any]:
         "Why It Matters": f"This source is a monitored DysonX {item.priority.lower()}-priority signal for {category_for(item).lower()} tracking.",
         "Evidence": f"Metadata collected from {item.source_name}; no source-page body was copied.",
         "Risk / Safety Notes": "Rule-based V1 candidate. Requires Owner review unless all auto-publish gates pass.",
-        "Attribution Status": ATTRIBUTION_STATUS if item.attribution_complete and item.link else "Incomplete",
+        "Attribution Status": ATTRIBUTION_STATUS if item.attribution_complete and item.link else "Missing",
         "Copyright Status": COPYRIGHT_STATUS,
         "Quality Hint": quality_hint(item),
         "Status": "Needs Owner Review",
@@ -468,7 +468,7 @@ def candidate_from_item(item: SourceItem) -> dict[str, Any]:
     if can_auto_publish(item, candidate):
         candidate["Ready for Pipeline"] = True
         candidate["Published"] = True
-        candidate["Status"] = "Auto-Ready"
+        candidate["Status"] = "Ready for Quality Audit"
     elif candidate["AGI Relevance"] == "Low":
         candidate["Status"] = "Needs More Sources"
     return candidate
@@ -574,9 +574,9 @@ def notion_candidate_properties(candidate: dict[str, Any]) -> dict[str, Any]:
     def rich(value: Any) -> dict[str, Any]:
         return {"rich_text": [{"text": {"content": normalize_text(value)[:1900]}}]}
 
+    notes = normalize_text(candidate.get("Notes")) or f"Collector Version: {normalize_text(candidate.get('Collector Version') or 'source_collector_v1')}"
     return {
         "Signal Title": {"title": [{"text": {"content": normalize_text(candidate["Signal Title"])[:1900]}}]},
-        "Slug": rich(candidate["Slug"]),
         "Source Name": rich(candidate["Source Name"]),
         "Source URL": {"url": normalize_text(candidate["Source URL"])},
         "Published Date": {"date": {"start": candidate["Published Date"]}} if candidate.get("Published Date") else {"date": None},
@@ -592,7 +592,7 @@ def notion_candidate_properties(candidate: dict[str, Any]) -> dict[str, Any]:
         "Status": {"select": {"name": normalize_text(candidate["Status"])}},
         "Ready for Pipeline": {"checkbox": bool(candidate["Ready for Pipeline"])},
         "Published": {"checkbox": bool(candidate["Published"])},
-        "Collector Version": rich(candidate["Collector Version"]),
+        "Notes": rich(notes),
     }
 
 

--- a/scripts/dysonx_source_collector_v1.py
+++ b/scripts/dysonx_source_collector_v1.py
@@ -147,6 +147,14 @@ def parse_date(value: str) -> str:
         return value
 
 
+def absolute_http_url(value: str, base_url: str = "") -> str:
+    url = urllib.parse.urljoin(normalize_text(base_url), normalize_text(value))
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    return url
+
+
 def notion_plain_text(items: list[dict[str, Any]] | None) -> str:
     if not items:
         return ""
@@ -336,7 +344,7 @@ def parse_feed_items(xml_text_value: str, source: SourceRecord) -> list[SourceIt
     items: list[SourceItem] = []
     for entry in entries[:20]:
         title = xml_text(entry, ("title",))
-        link = xml_link(entry)
+        link = absolute_http_url(xml_link(entry), source.url)
         summary = xml_text(entry, ("description", "summary", "subtitle", "content"))
         published = xml_text(entry, ("pubdate", "published", "updated", "date"))
         if title and link:
@@ -361,7 +369,7 @@ def parse_page_metadata(page_html: str, source: SourceRecord) -> list[SourceItem
     parser = MetadataHTMLParser()
     parser.feed(page_html)
     title = normalize_text(parser.title) or source.name
-    link = normalize_text(parser.canonical) or source.url
+    link = absolute_http_url(parser.canonical or source.url, source.url)
     summary = short_summary(parser.description or title)
     return [
         SourceItem(
@@ -434,7 +442,7 @@ def can_auto_publish(item: SourceItem, candidate: dict[str, Any]) -> bool:
         item.priority in AUTO_PUBLISH_PRIORITIES
         and item.authority_score >= 85
         and item.attribution_complete
-        and bool(item.link)
+        and bool(absolute_http_url(item.link))
         and len(candidate["Summary"]) <= 260
         and candidate["Copyright Status"] == COPYRIGHT_STATUS
         and candidate["AGI Relevance"] != "Low"
@@ -445,11 +453,13 @@ def can_auto_publish(item: SourceItem, candidate: dict[str, Any]) -> bool:
 
 def candidate_from_item(item: SourceItem) -> dict[str, Any]:
     summary = safe_summary_only(item)
+    source_url = absolute_http_url(item.link)
+    attribution_complete = item.attribution_complete and bool(source_url)
     candidate = {
         "Signal Title": item.title,
         "Slug": slugify(item.title),
         "Source Name": item.source_name,
-        "Source URL": item.link,
+        "Source URL": source_url,
         "Published Date": item.published_date,
         "Category": category_for(item),
         "AGI Relevance": ai_relevance_text(item),
@@ -457,7 +467,7 @@ def candidate_from_item(item: SourceItem) -> dict[str, Any]:
         "Why It Matters": f"This source is a monitored DysonX {item.priority.lower()}-priority signal for {category_for(item).lower()} tracking.",
         "Evidence": f"Metadata collected from {item.source_name}; no source-page body was copied.",
         "Risk / Safety Notes": "Rule-based V1 candidate. Requires Owner review unless all auto-publish gates pass.",
-        "Attribution Status": ATTRIBUTION_STATUS if item.attribution_complete and item.link else "Missing",
+        "Attribution Status": ATTRIBUTION_STATUS if attribution_complete else "Missing",
         "Copyright Status": COPYRIGHT_STATUS,
         "Quality Hint": quality_hint(item),
         "Status": "Needs Owner Review",

--- a/scripts/dysonx_source_collector_v1.py
+++ b/scripts/dysonx_source_collector_v1.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""DysonX Source Collector V1.
+
+Reads enabled Notion-managed DysonX Sources, collects recent public metadata,
+and writes safe candidate Signals into DysonX Signal Intake.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import email.utils
+import hashlib
+import html
+import json
+import os
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, asdict
+from html.parser import HTMLParser
+from typing import Any, Callable
+
+
+NOTION_TOKEN_ENV = "NOTION_TOKEN"
+SOURCES_DATABASE_ENV = "DYSONX_NOTION_SOURCES_DATABASE_ID"
+SIGNAL_INTAKE_DATABASE_ENV = "NOTION_SIGNAL_INTAKE_DATABASE_ID"
+NOTION_VERSION = "2022-06-28"
+SUPPORTED_SOURCE_TYPES = {"rss", "atom", "feed", "arxiv", "official website", "website", "government", "policy", "manual"}
+ALLOWED_PRIORITIES = {"Critical", "High", "Medium"}
+AUTO_PUBLISH_PRIORITIES = {"Critical", "High"}
+COPYRIGHT_STATUS = "Safe Summary Only"
+ATTRIBUTION_STATUS = "Complete"
+OPENAI_CALL_PERFORMED = False
+SOURCE_PAGE_BODY_SCRAPING_PERFORMED = False
+PUBLIC_STATIC_FILES_WRITTEN = False
+
+AI_RELEVANCE_KEYWORDS = (
+    "ai",
+    "agi",
+    "agent",
+    "agents",
+    "agentic",
+    "model",
+    "models",
+    "evaluation",
+    "eval",
+    "compute",
+    "safety",
+    "policy",
+    "alignment",
+    "robotics",
+    "multimodal",
+    "inference",
+    "benchmark",
+    "foundation model",
+)
+
+
+class SourceCollectorError(RuntimeError):
+    """Raised when collector input or Notion IO fails."""
+
+
+NotionTransport = Callable[[str, dict[str, str], dict[str, Any] | None, str], dict[str, Any]]
+FetchTransport = Callable[[str], str]
+
+
+@dataclass(frozen=True)
+class SourceRecord:
+    notion_page_id: str
+    name: str
+    url: str
+    source_type: str
+    platform: str
+    priority: str
+    authority_score: int
+    enabled: bool
+    fetch_frequency: str = ""
+    last_fetched_at: str = ""
+
+
+@dataclass(frozen=True)
+class SourceItem:
+    title: str
+    link: str
+    published_date: str
+    summary: str
+    source_name: str
+    source_url: str
+    source_type: str
+    priority: str
+    authority_score: int
+    attribution_complete: bool
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "untitled-signal"
+
+
+def normalized_title(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", value.lower()).strip()
+
+
+def strip_markup(value: str) -> str:
+    text = re.sub(r"<[^>]+>", " ", value)
+    return normalize_text(html.unescape(text))
+
+
+def short_summary(value: str, limit: int = 260) -> str:
+    text = strip_markup(value)
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def parse_date(value: str) -> str:
+    value = normalize_text(value)
+    if not value:
+        return ""
+    try:
+        parsed = email.utils.parsedate_to_datetime(value)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+        return parsed.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except (TypeError, ValueError):
+        return value
+
+
+def notion_plain_text(items: list[dict[str, Any]] | None) -> str:
+    if not items:
+        return ""
+    return "".join(str(item.get("plain_text") or "") for item in items)
+
+
+def notion_property_value(property_value: dict[str, Any]) -> Any:
+    property_type = property_value.get("type")
+    if property_type == "title":
+        return notion_plain_text(property_value.get("title"))
+    if property_type == "rich_text":
+        return notion_plain_text(property_value.get("rich_text"))
+    if property_type == "select":
+        selected = property_value.get("select")
+        return selected.get("name") if isinstance(selected, dict) else ""
+    if property_type == "status":
+        selected = property_value.get("status")
+        return selected.get("name") if isinstance(selected, dict) else ""
+    if property_type == "multi_select":
+        values = property_value.get("multi_select")
+        if not isinstance(values, list):
+            return []
+        return [str(item.get("name")) for item in values if isinstance(item, dict) and item.get("name")]
+    if property_type == "url":
+        return property_value.get("url") or ""
+    if property_type == "number":
+        return property_value.get("number")
+    if property_type == "checkbox":
+        return bool(property_value.get("checkbox"))
+    if property_type == "date":
+        date_value = property_value.get("date")
+        return date_value.get("start") if isinstance(date_value, dict) else ""
+    if property_type == "formula":
+        formula = property_value.get("formula")
+        if isinstance(formula, dict):
+            return formula.get(formula.get("type", ""), "")
+    return None
+
+
+def notion_page_to_record(page: dict[str, Any]) -> dict[str, Any]:
+    properties = page.get("properties")
+    if not isinstance(properties, dict):
+        raise SourceCollectorError("Notion page is missing properties")
+    record = {
+        field_name: notion_property_value(property_value)
+        for field_name, property_value in properties.items()
+        if isinstance(property_value, dict)
+    }
+    record["_notion_page_id"] = normalize_text(page.get("id"))
+    return record
+
+
+def field(record: dict[str, Any], *names: str) -> Any:
+    lowered = {key.lower(): value for key, value in record.items()}
+    for name in names:
+        if name in record:
+            return record[name]
+        value = lowered.get(name.lower())
+        if value is not None:
+            return value
+    return None
+
+
+def source_from_record(record: dict[str, Any]) -> SourceRecord:
+    source_type = normalize_text(field(record, "Source Type", "source_type", "Type"))
+    platform = normalize_text(field(record, "Platform", "platform"))
+    authority = field(record, "Authority Score", "authority_score", "Authority")
+    try:
+        authority_score = int(authority)
+    except (TypeError, ValueError):
+        authority_score = 0
+    return SourceRecord(
+        notion_page_id=normalize_text(field(record, "_notion_page_id", "id")),
+        name=normalize_text(field(record, "Name", "Source Name", "name")) or "Untitled Source",
+        url=normalize_text(field(record, "URL", "Feed URL", "Source URL", "url")),
+        source_type=source_type,
+        platform=platform,
+        priority=normalize_text(field(record, "Priority", "priority")),
+        authority_score=authority_score,
+        enabled=field(record, "Enabled", "enabled") is True,
+        fetch_frequency=normalize_text(field(record, "Fetch Frequency", "fetch_frequency")),
+        last_fetched_at=normalize_text(field(record, "Last Fetched At", "last_fetched_at")),
+    )
+
+
+def supported_source(source: SourceRecord) -> bool:
+    source_type = (source.source_type or source.platform).lower()
+    platform = source.platform.lower()
+    joined = f"{source_type} {platform}"
+    return any(kind in joined for kind in SUPPORTED_SOURCE_TYPES)
+
+
+def frequency_due(source: SourceRecord, now: dt.datetime | None = None) -> bool:
+    if not source.last_fetched_at:
+        return True
+    frequency = source.fetch_frequency.lower()
+    hours = 24
+    if "hour" in frequency:
+        match = re.search(r"(\d+)", frequency)
+        hours = int(match.group(1)) if match else 1
+    elif "daily" in frequency:
+        hours = 24
+    elif "weekly" in frequency:
+        hours = 24 * 7
+    try:
+        last = dt.datetime.fromisoformat(source.last_fetched_at.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    now = now or dt.datetime.now(dt.timezone.utc)
+    return now - last >= dt.timedelta(hours=hours)
+
+
+def eligible_source(source: SourceRecord) -> bool:
+    return (
+        source.enabled
+        and source.priority in ALLOWED_PRIORITIES
+        and bool(source.url)
+        and supported_source(source)
+        and frequency_due(source)
+    )
+
+
+class MetadataHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.title = ""
+        self.description = ""
+        self.canonical = ""
+        self._in_title = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {key.lower(): value or "" for key, value in attrs}
+        if tag == "title":
+            self._in_title = True
+        elif tag == "meta":
+            name = attr_map.get("name", "").lower()
+            prop = attr_map.get("property", "").lower()
+            if name == "description" or prop == "og:description":
+                self.description = self.description or attr_map.get("content", "")
+        elif tag == "link" and attr_map.get("rel", "").lower() == "canonical":
+            self.canonical = attr_map.get("href", "")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self.title += data
+
+
+def fetch_url(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "DysonXSourceCollectorV1/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.read(2_000_000).decode("utf-8", errors="ignore")
+    except urllib.error.URLError as exc:
+        raise SourceCollectorError(f"source fetch failed: {exc}") from exc
+
+
+def xml_text(element: ET.Element, names: tuple[str, ...]) -> str:
+    for child in list(element):
+        local = child.tag.rsplit("}", 1)[-1].lower()
+        if local in names and child.text:
+            return normalize_text(child.text)
+    return ""
+
+
+def xml_link(element: ET.Element) -> str:
+    for child in list(element):
+        local = child.tag.rsplit("}", 1)[-1].lower()
+        if local == "link":
+            href = child.attrib.get("href")
+            if href:
+                return normalize_text(href)
+            if child.text:
+                return normalize_text(child.text)
+    return ""
+
+
+def parse_feed_items(xml_text_value: str, source: SourceRecord) -> list[SourceItem]:
+    try:
+        root = ET.fromstring(xml_text_value)
+    except ET.ParseError as exc:
+        raise SourceCollectorError(f"feed parse failed: {exc}") from exc
+    entries = [item for item in root.iter() if item.tag.rsplit("}", 1)[-1].lower() in {"item", "entry"}]
+    items: list[SourceItem] = []
+    for entry in entries[:20]:
+        title = xml_text(entry, ("title",))
+        link = xml_link(entry)
+        summary = xml_text(entry, ("description", "summary", "subtitle", "content"))
+        published = xml_text(entry, ("pubdate", "published", "updated", "date"))
+        if title and link:
+            items.append(
+                SourceItem(
+                    title=title,
+                    link=link,
+                    published_date=parse_date(published),
+                    summary=short_summary(summary or title),
+                    source_name=source.name,
+                    source_url=source.url,
+                    source_type=source.source_type or source.platform,
+                    priority=source.priority,
+                    authority_score=source.authority_score,
+                    attribution_complete=True,
+                )
+            )
+    return items
+
+
+def parse_page_metadata(page_html: str, source: SourceRecord) -> list[SourceItem]:
+    parser = MetadataHTMLParser()
+    parser.feed(page_html)
+    title = normalize_text(parser.title) or source.name
+    link = normalize_text(parser.canonical) or source.url
+    summary = short_summary(parser.description or title)
+    return [
+        SourceItem(
+            title=title,
+            link=link,
+            published_date="",
+            summary=summary,
+            source_name=source.name,
+            source_url=source.url,
+            source_type=source.source_type or source.platform,
+            priority=source.priority,
+            authority_score=source.authority_score,
+            attribution_complete=bool(link),
+        )
+    ]
+
+
+def collect_source_items(source: SourceRecord, fetch: FetchTransport = fetch_url) -> list[SourceItem]:
+    content = fetch(source.url)
+    source_kind = f"{source.source_type} {source.platform}".lower()
+    if "<rss" in content[:500].lower() or "<feed" in content[:500].lower() or any(token in source_kind for token in ("rss", "atom", "feed", "arxiv")):
+        return parse_feed_items(content, source)
+    return parse_page_metadata(content, source)
+
+
+def ai_relevance_text(item: SourceItem) -> str:
+    text = f"{item.title} {item.summary} {item.source_type}".lower()
+    matches = [keyword for keyword in AI_RELEVANCE_KEYWORDS if keyword in text]
+    if not matches:
+        return "Low"
+    if any(keyword in matches for keyword in ("agi", "agent", "agents", "agentic", "evaluation", "compute", "safety", "policy")):
+        return "High"
+    return "Medium"
+
+
+def category_for(item: SourceItem) -> str:
+    text = f"{item.title} {item.summary}".lower()
+    if "policy" in text or "government" in item.source_type.lower():
+        return "Policy"
+    if "safety" in text or "alignment" in text:
+        return "Safety"
+    if "arxiv" in item.source_type.lower() or "research" in text or "paper" in text:
+        return "Research"
+    if "agent" in text:
+        return "Agents"
+    if "compute" in text or "inference" in text:
+        return "Infrastructure"
+    return "AI / AGI"
+
+
+def quality_hint(item: SourceItem) -> int:
+    score = min(95, max(45, item.authority_score))
+    if ai_relevance_text(item) == "Low":
+        score -= 20
+    if not item.attribution_complete or not item.link:
+        score -= 25
+    if len(item.summary) > 280:
+        score -= 10
+    if item.priority == "Critical":
+        score += 3
+    return max(0, min(100, score))
+
+
+def safe_summary_only(item: SourceItem) -> str:
+    return short_summary(item.summary or item.title, 240)
+
+
+def can_auto_publish(item: SourceItem, candidate: dict[str, Any]) -> bool:
+    return (
+        item.priority in AUTO_PUBLISH_PRIORITIES
+        and item.authority_score >= 85
+        and item.attribution_complete
+        and bool(item.link)
+        and len(candidate["Summary"]) <= 260
+        and candidate["Copyright Status"] == COPYRIGHT_STATUS
+        and candidate["AGI Relevance"] != "Low"
+        and candidate["Quality Hint"] >= 85
+        and "raw" not in json.dumps(candidate).lower()
+    )
+
+
+def candidate_from_item(item: SourceItem) -> dict[str, Any]:
+    summary = safe_summary_only(item)
+    candidate = {
+        "Signal Title": item.title,
+        "Slug": slugify(item.title),
+        "Source Name": item.source_name,
+        "Source URL": item.link,
+        "Published Date": item.published_date,
+        "Category": category_for(item),
+        "AGI Relevance": ai_relevance_text(item),
+        "Summary": summary,
+        "Why It Matters": f"This source is a monitored DysonX {item.priority.lower()}-priority signal for {category_for(item).lower()} tracking.",
+        "Evidence": f"Metadata collected from {item.source_name}; no source-page body was copied.",
+        "Risk / Safety Notes": "Rule-based V1 candidate. Requires Owner review unless all auto-publish gates pass.",
+        "Attribution Status": ATTRIBUTION_STATUS if item.attribution_complete and item.link else "Incomplete",
+        "Copyright Status": COPYRIGHT_STATUS,
+        "Quality Hint": quality_hint(item),
+        "Status": "Needs Owner Review",
+        "Ready for Pipeline": False,
+        "Published": False,
+        "Collector Version": "source_collector_v1",
+    }
+    if can_auto_publish(item, candidate):
+        candidate["Ready for Pipeline"] = True
+        candidate["Published"] = True
+        candidate["Status"] = "Auto-Ready"
+    elif candidate["AGI Relevance"] == "Low":
+        candidate["Status"] = "Needs More Sources"
+    return candidate
+
+
+def existing_keys(records: list[dict[str, Any]]) -> set[str]:
+    keys: set[str] = set()
+    for record in records:
+        url = normalize_text(field(record, "Source URL", "source_url"))
+        title = normalize_text(field(record, "Signal Title", "Title", "Name"))
+        if url:
+            keys.add(f"url:{url.lower()}")
+        if title:
+            keys.add(f"title:{normalized_title(title)}")
+    return keys
+
+
+def dedupe_candidates(candidates: list[dict[str, Any]], existing_records: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], int]:
+    keys = existing_keys(existing_records)
+    emitted: list[dict[str, Any]] = []
+    skipped = 0
+    for candidate in candidates:
+        url_key = f"url:{normalize_text(candidate.get('Source URL')).lower()}"
+        title_key = f"title:{normalized_title(normalize_text(candidate.get('Signal Title')))}"
+        if url_key in keys or title_key in keys:
+            skipped += 1
+            continue
+        keys.add(url_key)
+        keys.add(title_key)
+        emitted.append(candidate)
+    return emitted, skipped
+
+
+def urllib_notion_transport(url: str, headers: dict[str, str], payload: dict[str, Any] | None, method: str) -> dict[str, Any]:
+    data = json.dumps(payload or {}).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        raise SourceCollectorError(f"Notion request failed: {exc}") from exc
+    return json.loads(body) if body else {}
+
+
+class NotionClient:
+    def __init__(self, token: str, sources_database_id: str, signal_intake_database_id: str, transport: NotionTransport = urllib_notion_transport):
+        self.token = token
+        self.sources_database_id = sources_database_id
+        self.signal_intake_database_id = signal_intake_database_id
+        self.transport = transport
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+            "Notion-Version": NOTION_VERSION,
+        }
+
+    def query_database(self, database_id: str) -> list[dict[str, Any]]:
+        url = f"https://api.notion.com/v1/databases/{database_id}/query"
+        payload: dict[str, Any] = {"page_size": 100}
+        records: list[dict[str, Any]] = []
+        while True:
+            response = self.transport(url, self.headers, payload, "POST")
+            results = response.get("results")
+            if not isinstance(results, list):
+                raise SourceCollectorError("Notion query response is missing results")
+            records.extend(notion_page_to_record(page) for page in results if isinstance(page, dict))
+            if response.get("has_more") is not True:
+                return records
+            cursor = response.get("next_cursor")
+            if not cursor:
+                raise SourceCollectorError("Notion query response is missing next_cursor")
+            payload = {"page_size": 100, "start_cursor": cursor}
+
+    def list_sources(self) -> list[dict[str, Any]]:
+        return self.query_database(self.sources_database_id)
+
+    def list_signal_intake(self) -> list[dict[str, Any]]:
+        return self.query_database(self.signal_intake_database_id)
+
+    def create_signal_intake_row(self, candidate: dict[str, Any]) -> None:
+        payload = {
+            "parent": {"database_id": self.signal_intake_database_id},
+            "properties": notion_candidate_properties(candidate),
+        }
+        self.transport("https://api.notion.com/v1/pages", self.headers, payload, "POST")
+
+    def update_source_fetch_status(self, source: SourceRecord, fetched_at: str, success: bool, error: str = "") -> None:
+        if not source.notion_page_id:
+            return
+        properties: dict[str, Any] = {
+            "Last Fetched At": {"date": {"start": fetched_at}},
+            "Last Error": {"rich_text": [{"text": {"content": error[:1800]}}]},
+        }
+        if success:
+            properties["Last Success At"] = {"date": {"start": fetched_at}}
+        self.transport(f"https://api.notion.com/v1/pages/{source.notion_page_id}", self.headers, {"properties": properties}, "PATCH")
+
+
+def notion_candidate_properties(candidate: dict[str, Any]) -> dict[str, Any]:
+    def rich(value: Any) -> dict[str, Any]:
+        return {"rich_text": [{"text": {"content": normalize_text(value)[:1900]}}]}
+
+    return {
+        "Signal Title": {"title": [{"text": {"content": normalize_text(candidate["Signal Title"])[:1900]}}]},
+        "Slug": rich(candidate["Slug"]),
+        "Source Name": rich(candidate["Source Name"]),
+        "Source URL": {"url": normalize_text(candidate["Source URL"])},
+        "Published Date": {"date": {"start": candidate["Published Date"]}} if candidate.get("Published Date") else {"date": None},
+        "Category": {"select": {"name": normalize_text(candidate["Category"])}},
+        "AGI Relevance": {"select": {"name": normalize_text(candidate["AGI Relevance"])}},
+        "Summary": rich(candidate["Summary"]),
+        "Why It Matters": rich(candidate["Why It Matters"]),
+        "Evidence": rich(candidate["Evidence"]),
+        "Risk / Safety Notes": rich(candidate["Risk / Safety Notes"]),
+        "Attribution Status": {"select": {"name": normalize_text(candidate["Attribution Status"])}},
+        "Copyright Status": {"select": {"name": normalize_text(candidate["Copyright Status"])}},
+        "Quality Hint": {"number": candidate["Quality Hint"]},
+        "Status": {"select": {"name": normalize_text(candidate["Status"])}},
+        "Ready for Pipeline": {"checkbox": bool(candidate["Ready for Pipeline"])},
+        "Published": {"checkbox": bool(candidate["Published"])},
+        "Collector Version": rich(candidate["Collector Version"]),
+    }
+
+
+def build_candidates(
+    source_records: list[dict[str, Any]],
+    existing_signal_intake: list[dict[str, Any]],
+    fetch: FetchTransport = fetch_url,
+) -> dict[str, Any]:
+    sources = [source_from_record(record) for record in source_records]
+    collected_candidates: list[dict[str, Any]] = []
+    source_results: list[dict[str, Any]] = []
+    for source in sources:
+        if not eligible_source(source):
+            source_results.append({"source": source.name, "status": "skipped"})
+            continue
+        try:
+            items = collect_source_items(source, fetch=fetch)
+            candidates = [candidate_from_item(item) for item in items]
+            collected_candidates.extend(candidates)
+            source_results.append({"source": source.name, "status": "collected", "items": len(items)})
+        except SourceCollectorError as exc:
+            source_results.append({"source": source.name, "status": "error", "error": str(exc)})
+    deduped, duplicates_skipped = dedupe_candidates(collected_candidates, existing_signal_intake)
+    return {
+        "collector_version": "source_collector_v1",
+        "candidates": deduped,
+        "candidate_count": len(deduped),
+        "duplicates_skipped": duplicates_skipped,
+        "sources_seen": len(source_records),
+        "source_results": source_results,
+        "openai_call_performed": OPENAI_CALL_PERFORMED,
+        "source_page_body_scraping_performed": SOURCE_PAGE_BODY_SCRAPING_PERFORMED,
+        "public_static_files_written": PUBLIC_STATIC_FILES_WRITTEN,
+    }
+
+
+def load_json_records(path: pathlib.Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(data, dict) and isinstance(data.get("records"), list):
+        return [item for item in data["records"] if isinstance(item, dict)]
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    raise SourceCollectorError(f"{path} must contain a list or records array")
+
+
+def fixture_fetcher(mapping: dict[str, pathlib.Path]) -> FetchTransport:
+    def fetch(url: str) -> str:
+        path = mapping.get(url)
+        if not path:
+            raise SourceCollectorError(f"missing fixture for URL: {url}")
+        return path.read_text(encoding="utf-8")
+
+    return fetch
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Collect DysonX source metadata into Signal Intake candidates.")
+    parser.add_argument("--sources-fixture", help="Offline source registry fixture JSON.")
+    parser.add_argument("--existing-signal-intake-fixture", help="Offline existing Signal Intake fixture JSON.")
+    parser.add_argument("--fetch-fixture-map", help="JSON object mapping source URL to local fixture path.")
+    parser.add_argument("--output-candidates", help="Optional offline candidate report path.")
+    parser.add_argument("--dry-run", action="store_true", help="Do not write Notion rows.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        if args.sources_fixture:
+            sources = load_json_records(pathlib.Path(args.sources_fixture))
+            existing = load_json_records(pathlib.Path(args.existing_signal_intake_fixture)) if args.existing_signal_intake_fixture else []
+            fetch_map = {}
+            if args.fetch_fixture_map:
+                raw_map = json.loads(pathlib.Path(args.fetch_fixture_map).read_text(encoding="utf-8"))
+                fetch_map = {url: pathlib.Path(path) for url, path in raw_map.items()}
+            result = build_candidates(sources, existing, fetch=fixture_fetcher(fetch_map) if fetch_map else fetch_url)
+        else:
+            missing = [
+                name
+                for name in (NOTION_TOKEN_ENV, SOURCES_DATABASE_ENV, SIGNAL_INTAKE_DATABASE_ENV)
+                if not os.environ.get(name)
+            ]
+            if missing:
+                raise SourceCollectorError(f"Missing required environment variables: {', '.join(missing)}")
+            client = NotionClient(
+                token=os.environ[NOTION_TOKEN_ENV],
+                sources_database_id=os.environ[SOURCES_DATABASE_ENV],
+                signal_intake_database_id=os.environ[SIGNAL_INTAKE_DATABASE_ENV],
+            )
+            sources = client.list_sources()
+            existing = client.list_signal_intake()
+            result = build_candidates(sources, existing)
+            if not args.dry_run:
+                for candidate in result["candidates"]:
+                    client.create_signal_intake_row(candidate)
+
+        if args.output_candidates:
+            output_path = pathlib.Path(args.output_candidates)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(
+            "[source-collector-v1] PASS "
+            f"candidates={result['candidate_count']} duplicates_skipped={result['duplicates_skipped']} "
+            "openai_call_performed=False public_static_files_written=False"
+        )
+        return 0
+    except (OSError, json.JSONDecodeError, SourceCollectorError) as exc:
+        print(f"[source-collector-v1] failed: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/source_collector_v1/arxiv_feed_sample.xml
+++ b/tests/fixtures/source_collector_v1/arxiv_feed_sample.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>arXiv AI Agents</title>
+  <entry>
+    <title>Compute-aware evaluation for autonomous AI agents</title>
+    <link href="https://arxiv.org/abs/2606.12345" />
+    <published>2026-06-27T10:00:00Z</published>
+    <summary>Abstract metadata summary describing compute-aware benchmarks for autonomous AI agent evaluation.</summary>
+  </entry>
+</feed>

--- a/tests/fixtures/source_collector_v1/existing_signal_intake_sample.json
+++ b/tests/fixtures/source_collector_v1/existing_signal_intake_sample.json
@@ -1,0 +1,8 @@
+{
+  "records": [
+    {
+      "Signal Title": "Existing duplicate agent evaluation benchmark",
+      "Source URL": "https://example.org/research/agent-evaluation-benchmark"
+    }
+  ]
+}

--- a/tests/fixtures/source_collector_v1/expected_signal_candidates.json
+++ b/tests/fixtures/source_collector_v1/expected_signal_candidates.json
@@ -1,0 +1,10 @@
+{
+  "candidate_titles": [
+    "Compute-aware evaluation for autonomous AI agents",
+    "Agent evaluation benchmark improves reliability scoring"
+  ],
+  "auto_ready_title": "Compute-aware evaluation for autonomous AI agents",
+  "copyright_status": "Safe Summary Only",
+  "openai_call_performed": false,
+  "public_static_files_written": false
+}

--- a/tests/fixtures/source_collector_v1/rss_feed_sample.xml
+++ b/tests/fixtures/source_collector_v1/rss_feed_sample.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Official AI Lab RSS</title>
+    <item>
+      <title>Agent evaluation benchmark improves reliability scoring</title>
+      <link>https://example.org/research/agent-evaluation-benchmark</link>
+      <pubDate>Sat, 27 Jun 2026 08:00:00 GMT</pubDate>
+      <description>Official metadata summary: a new agent evaluation benchmark tracks recovery, reliability, and task completion behavior.</description>
+    </item>
+    <item>
+      <title>General company operations update</title>
+      <link>https://example.org/company/operations-update</link>
+      <pubDate>Sat, 27 Jun 2026 09:00:00 GMT</pubDate>
+      <description>Metadata summary about office operations without direct AI relevance.</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/source_collector_v1/source_registry_sample.json
+++ b/tests/fixtures/source_collector_v1/source_registry_sample.json
@@ -1,0 +1,62 @@
+{
+  "records": [
+    {
+      "_notion_page_id": "src_high_rss",
+      "Name": "Official AI Lab RSS",
+      "URL": "https://example.org/rss.xml",
+      "Source Type": "RSS",
+      "Platform": "RSS",
+      "Priority": "High",
+      "Authority Score": 92,
+      "Enabled": true,
+      "Fetch Frequency": "6 hours"
+    },
+    {
+      "_notion_page_id": "src_arxiv",
+      "Name": "arXiv AI Agents",
+      "URL": "https://export.arxiv.org/rss/cs.AI",
+      "Source Type": "arXiv",
+      "Platform": "RSS",
+      "Priority": "Critical",
+      "Authority Score": 90,
+      "Enabled": true
+    },
+    {
+      "_notion_page_id": "src_low_authority",
+      "Name": "Medium Authority AI Blog",
+      "URL": "https://example.org/medium-rss.xml",
+      "Source Type": "RSS",
+      "Platform": "RSS",
+      "Priority": "Medium",
+      "Authority Score": 70,
+      "Enabled": true
+    },
+    {
+      "_notion_page_id": "src_disabled",
+      "Name": "Disabled Source",
+      "URL": "https://example.org/disabled.xml",
+      "Source Type": "RSS",
+      "Priority": "High",
+      "Authority Score": 90,
+      "Enabled": false
+    },
+    {
+      "_notion_page_id": "src_missing_url",
+      "Name": "Missing URL Source",
+      "URL": "",
+      "Source Type": "RSS",
+      "Priority": "High",
+      "Authority Score": 90,
+      "Enabled": true
+    },
+    {
+      "_notion_page_id": "src_unsupported",
+      "Name": "Unsupported Source",
+      "URL": "https://example.org/video",
+      "Source Type": "Video",
+      "Priority": "High",
+      "Authority Score": 90,
+      "Enabled": true
+    }
+  ]
+}

--- a/tests/test_dysonx_source_collector_v1.py
+++ b/tests/test_dysonx_source_collector_v1.py
@@ -91,7 +91,7 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
 
         self.assertFalse(candidate["Ready for Pipeline"])
         self.assertFalse(candidate["Published"])
-        self.assertEqual(candidate["Attribution Status"], "Incomplete")
+        self.assertEqual(candidate["Attribution Status"], "Missing")
 
     def test_raw_body_is_never_included(self):
         sources = [load_records("source_registry_sample.json")[0]]
@@ -119,7 +119,7 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
 
         self.assertTrue(candidate["Ready for Pipeline"])
         self.assertTrue(candidate["Published"])
-        self.assertEqual(candidate["Status"], "Auto-Ready")
+        self.assertEqual(candidate["Status"], "Ready for Quality Audit")
         self.assertGreaterEqual(candidate["Quality Hint"], 85)
 
     def test_generated_candidate_has_safe_summary_only_copyright_status(self):
@@ -180,6 +180,66 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         self.assertEqual(auto["Copyright Status"], expected["copyright_status"])
         self.assertEqual(result["openai_call_performed"], expected["openai_call_performed"])
         self.assertEqual(result["public_static_files_written"], expected["public_static_files_written"])
+
+    def test_notion_writeback_properties_match_signal_intake_schema(self):
+        sources = [load_records("source_registry_sample.json")[1]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+        candidate = result["candidates"][0]
+        properties = collector.notion_candidate_properties(candidate)
+        allowed = {
+            "Signal Title",
+            "Source Name",
+            "Source URL",
+            "Published Date",
+            "Category",
+            "AGI Relevance",
+            "Status",
+            "Attribution Status",
+            "Copyright Status",
+            "Quality Hint",
+            "Summary",
+            "Why It Matters",
+            "Evidence",
+            "Risk / Safety Notes",
+            "Ready for Pipeline",
+            "Published",
+            "Notes",
+        }
+
+        self.assertEqual(set(properties), allowed)
+        self.assertNotIn("Slug", properties)
+        self.assertNotIn("Collector Version", properties)
+        self.assertEqual(properties["Notes"]["rich_text"][0]["text"]["content"], "Collector Version: source_collector_v1")
+
+    def test_notion_select_values_match_signal_intake_schema(self):
+        sources = load_records("source_registry_sample.json")[:3]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+        allowed_categories = {
+            "Frontier Lab",
+            "Research",
+            "Compute",
+            "Open Source",
+            "Policy",
+            "Safety",
+            "Enterprise AI",
+            "Market Signal",
+            "Other",
+        }
+        allowed_statuses = {
+            "New",
+            "Ready for Quality Audit",
+            "Needs More Sources",
+            "Needs Owner Review",
+            "Blocked",
+            "Archived",
+        }
+        allowed_attribution = {"Complete", "Partial", "Missing"}
+
+        for candidate in result["candidates"]:
+            properties = collector.notion_candidate_properties(candidate)
+            self.assertIn(properties["Category"]["select"]["name"], allowed_categories)
+            self.assertIn(properties["Status"]["select"]["name"], allowed_statuses)
+            self.assertIn(properties["Attribution Status"]["select"]["name"], allowed_attribution)
 
 
 if __name__ == "__main__":

--- a/tests/test_dysonx_source_collector_v1.py
+++ b/tests/test_dysonx_source_collector_v1.py
@@ -44,6 +44,62 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         self.assertEqual(candidate["Signal Title"], "Compute-aware evaluation for autonomous AI agents")
         self.assertEqual(candidate["Category"], "Research")
 
+    def test_relative_canonical_path_becomes_absolute_url(self):
+        source = collector.SourceRecord(
+            notion_page_id="source-page",
+            name="Official Lab",
+            url="https://example.org/research/index.html",
+            source_type="Official Website",
+            platform="Website",
+            priority="High",
+            authority_score=95,
+            enabled=True,
+        )
+        html = """
+        <html>
+          <head>
+            <title>Agent safety evaluation update</title>
+            <link rel="canonical" href="/research/agent-safety-update" />
+            <meta name="description" content="Agent safety evaluation metadata summary." />
+          </head>
+        </html>
+        """
+
+        item = collector.parse_page_metadata(html, source)[0]
+        candidate = collector.candidate_from_item(item)
+
+        self.assertEqual(item.link, "https://example.org/research/agent-safety-update")
+        self.assertEqual(candidate["Source URL"], "https://example.org/research/agent-safety-update")
+        self.assertEqual(candidate["Attribution Status"], "Complete")
+
+    def test_relative_rss_item_link_becomes_absolute_url(self):
+        source = collector.SourceRecord(
+            notion_page_id="source-feed",
+            name="Official Lab RSS",
+            url="https://example.org/rss.xml",
+            source_type="RSS",
+            platform="RSS",
+            priority="High",
+            authority_score=95,
+            enabled=True,
+        )
+        feed = """
+        <rss><channel>
+          <item>
+            <title>Agent benchmark update</title>
+            <link>/research/agent-benchmark</link>
+            <description>Agent benchmark metadata summary.</description>
+          </item>
+        </channel></rss>
+        """
+
+        item = collector.parse_feed_items(feed, source)[0]
+        candidate = collector.candidate_from_item(item)
+
+        self.assertEqual(item.link, "https://example.org/research/agent-benchmark")
+        self.assertEqual(candidate["Source URL"], "https://example.org/research/agent-benchmark")
+        self.assertEqual(candidate["Attribution Status"], "Complete")
+
     def test_unsupported_source_is_skipped(self):
         sources = [load_records("source_registry_sample.json")[5]]
         result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
@@ -92,6 +148,26 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         self.assertFalse(candidate["Ready for Pipeline"])
         self.assertFalse(candidate["Published"])
         self.assertEqual(candidate["Attribution Status"], "Missing")
+
+    def test_non_http_source_url_cannot_auto_publish(self):
+        item = collector.SourceItem(
+            title="Agent safety evaluation update",
+            link="mailto:research@example.org",
+            published_date="",
+            summary="Agent safety evaluation metadata summary.",
+            source_name="Official Lab",
+            source_url="mailto:research@example.org",
+            source_type="RSS",
+            priority="High",
+            authority_score=95,
+            attribution_complete=True,
+        )
+        candidate = collector.candidate_from_item(item)
+
+        self.assertEqual(candidate["Source URL"], "")
+        self.assertEqual(candidate["Attribution Status"], "Missing")
+        self.assertFalse(candidate["Ready for Pipeline"])
+        self.assertFalse(candidate["Published"])
 
     def test_raw_body_is_never_included(self):
         sources = [load_records("source_registry_sample.json")[0]]
@@ -240,6 +316,14 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
             self.assertIn(properties["Category"]["select"]["name"], allowed_categories)
             self.assertIn(properties["Status"]["select"]["name"], allowed_statuses)
             self.assertIn(properties["Attribution Status"]["select"]["name"], allowed_attribution)
+
+    def test_source_collector_workflow_cron_is_offset_from_public_sync(self):
+        collector_workflow = (ROOT / ".github" / "workflows" / "dysonx-source-collector-v1.yml").read_text(encoding="utf-8")
+        public_sync_workflow = (ROOT / ".github" / "workflows" / "dysonx-notion-public-signals-sync.yml").read_text(encoding="utf-8")
+
+        self.assertIn('cron: "50 23,5,11,17 * * *"', collector_workflow)
+        self.assertNotIn('cron: "17 */6 * * *"', collector_workflow)
+        self.assertIn('cron: "0 */6 * * *"', public_sync_workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_dysonx_source_collector_v1.py
+++ b/tests/test_dysonx_source_collector_v1.py
@@ -1,0 +1,186 @@
+import json
+import pathlib
+import tempfile
+import unittest
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "tests" / "fixtures" / "source_collector_v1"
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_source_collector_v1 as collector  # noqa: E402
+
+
+def load_records(name: str):
+    data = json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+    return data["records"]
+
+
+class DysonXSourceCollectorV1Tests(unittest.TestCase):
+    def fixture_fetch(self, url: str) -> str:
+        mapping = {
+            "https://example.org/rss.xml": FIXTURES / "rss_feed_sample.xml",
+            "https://export.arxiv.org/rss/cs.AI": FIXTURES / "arxiv_feed_sample.xml",
+            "https://example.org/medium-rss.xml": FIXTURES / "rss_feed_sample.xml",
+        }
+        path = mapping.get(url)
+        if not path:
+            raise collector.SourceCollectorError(f"missing fixture: {url}")
+        return path.read_text(encoding="utf-8")
+
+    def test_rss_item_becomes_signal_candidate(self):
+        sources = [load_records("source_registry_sample.json")[0]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        titles = [item["Signal Title"] for item in result["candidates"]]
+        self.assertIn("Agent evaluation benchmark improves reliability scoring", titles)
+
+    def test_arxiv_feed_item_becomes_signal_candidate(self):
+        sources = [load_records("source_registry_sample.json")[1]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        candidate = result["candidates"][0]
+        self.assertEqual(candidate["Signal Title"], "Compute-aware evaluation for autonomous AI agents")
+        self.assertEqual(candidate["Category"], "Research")
+
+    def test_unsupported_source_is_skipped(self):
+        sources = [load_records("source_registry_sample.json")[5]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        self.assertEqual(result["candidate_count"], 0)
+        self.assertEqual(result["source_results"][0]["status"], "skipped")
+
+    def test_disabled_source_is_skipped(self):
+        sources = [load_records("source_registry_sample.json")[3]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        self.assertEqual(result["candidate_count"], 0)
+        self.assertEqual(result["source_results"][0]["status"], "skipped")
+
+    def test_missing_url_is_skipped(self):
+        sources = [load_records("source_registry_sample.json")[4]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        self.assertEqual(result["candidate_count"], 0)
+        self.assertEqual(result["source_results"][0]["status"], "skipped")
+
+    def test_low_authority_source_does_not_auto_publish(self):
+        sources = [load_records("source_registry_sample.json")[2]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        candidate = next(item for item in result["candidates"] if "Agent evaluation" in item["Signal Title"])
+        self.assertFalse(candidate["Ready for Pipeline"])
+        self.assertFalse(candidate["Published"])
+        self.assertEqual(candidate["Status"], "Needs Owner Review")
+
+    def test_missing_attribution_does_not_auto_publish(self):
+        item = collector.SourceItem(
+            title="Agent safety evaluation update",
+            link="",
+            published_date="",
+            summary="Agent safety evaluation metadata summary.",
+            source_name="Official Lab",
+            source_url="https://example.org/lab",
+            source_type="RSS",
+            priority="High",
+            authority_score=95,
+            attribution_complete=False,
+        )
+        candidate = collector.candidate_from_item(item)
+
+        self.assertFalse(candidate["Ready for Pipeline"])
+        self.assertFalse(candidate["Published"])
+        self.assertEqual(candidate["Attribution Status"], "Incomplete")
+
+    def test_raw_body_is_never_included(self):
+        sources = [load_records("source_registry_sample.json")[0]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+        text = json.dumps(result)
+
+        self.assertNotIn("<article", text)
+        self.assertNotIn("raw article body", text.lower())
+        for candidate in result["candidates"]:
+            self.assertLessEqual(len(candidate["Summary"]), 260)
+
+    def test_duplicate_source_url_is_skipped(self):
+        sources = [load_records("source_registry_sample.json")[0]]
+        existing = load_records("existing_signal_intake_sample.json")
+        result = collector.build_candidates(sources, existing, fetch=self.fixture_fetch)
+
+        titles = [item["Signal Title"] for item in result["candidates"]]
+        self.assertNotIn("Agent evaluation benchmark improves reliability scoring", titles)
+        self.assertGreaterEqual(result["duplicates_skipped"], 1)
+
+    def test_high_authority_ai_relevant_source_can_auto_publish(self):
+        sources = [load_records("source_registry_sample.json")[1]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+        candidate = result["candidates"][0]
+
+        self.assertTrue(candidate["Ready for Pipeline"])
+        self.assertTrue(candidate["Published"])
+        self.assertEqual(candidate["Status"], "Auto-Ready")
+        self.assertGreaterEqual(candidate["Quality Hint"], 85)
+
+    def test_generated_candidate_has_safe_summary_only_copyright_status(self):
+        sources = [load_records("source_registry_sample.json")[0]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        for candidate in result["candidates"]:
+            self.assertEqual(candidate["Copyright Status"], "Safe Summary Only")
+
+    def test_collector_does_not_write_public_static_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fetch_map = pathlib.Path(tmpdir) / "fetch_map.json"
+            fetch_map.write_text(
+                json.dumps(
+                    {
+                        "https://example.org/rss.xml": str(FIXTURES / "rss_feed_sample.xml"),
+                        "https://export.arxiv.org/rss/cs.AI": str(FIXTURES / "arxiv_feed_sample.xml"),
+                        "https://example.org/medium-rss.xml": str(FIXTURES / "rss_feed_sample.xml"),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output = pathlib.Path(tmpdir) / "candidates.json"
+            rc = collector.main(
+                [
+                    "--sources-fixture",
+                    str(FIXTURES / "source_registry_sample.json"),
+                    "--existing-signal-intake-fixture",
+                    str(FIXTURES / "existing_signal_intake_sample.json"),
+                    "--fetch-fixture-map",
+                    str(fetch_map),
+                    "--output-candidates",
+                    str(output),
+                ]
+            )
+            self.assertEqual(rc, 0)
+            self.assertTrue(output.exists())
+            self.assertFalse((pathlib.Path(tmpdir) / "signals").exists())
+
+    def test_collector_does_not_call_openai(self):
+        sources = [load_records("source_registry_sample.json")[1]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+
+        self.assertFalse(result["openai_call_performed"])
+        self.assertFalse(result["source_page_body_scraping_performed"])
+        self.assertFalse(result["public_static_files_written"])
+
+    def test_expected_fixture_shape_matches_candidates(self):
+        sources = load_records("source_registry_sample.json")[:2]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+        expected = json.loads((FIXTURES / "expected_signal_candidates.json").read_text(encoding="utf-8"))
+        titles = [item["Signal Title"] for item in result["candidates"]]
+
+        for title in expected["candidate_titles"]:
+            self.assertIn(title, titles)
+        auto = next(item for item in result["candidates"] if item["Signal Title"] == expected["auto_ready_title"])
+        self.assertTrue(auto["Ready for Pipeline"])
+        self.assertEqual(auto["Copyright Status"], expected["copyright_status"])
+        self.assertEqual(result["openai_call_performed"], expected["openai_call_performed"])
+        self.assertEqual(result["public_static_files_written"], expected["public_static_files_written"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds DysonX Source Collector V1.
- Reads enabled DysonX Sources from Notion.
- Collects source metadata/items from RSS, Atom/arXiv-style feeds, official pages, government/policy pages, and manual URLs.
- Writes safe Signal candidates into DysonX Signal Intake.
- Can auto-mark only high-authority, safe, attributed Signals as Ready for Pipeline + Published.
- Adds scheduled/manual collector workflow: DysonX Sources -> Signal Intake only.
- Adds offline fixtures and tests.

## Safety
- Does not directly write public pages.
- Existing PR #82 workflow remains responsible for Signal Intake -> public page generation.
- No OpenAI call.
- No raw body copying.
- No source-page body scraping.
- No hardcoded domain.
- No manual deployment.
- No auto-merge.
- No Step 6.
- Does not commit tmp/ or .serena/.

## Validation
- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 400 tests
- python3 scripts/dysonx_static_preview_check.py --root .: PASS
- git diff --check origin/main...HEAD: PASS
- forbidden grep checks: PASS

No production deployment was performed.