### PR TITLE
feat: add DysonX public Signals auto-merge gate

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -44,6 +44,34 @@ jobs:
           ! grep -R "\.test/" -n signals scripts tests docs
           ! grep -R "tmp/production_publish_pack" -n signals scripts tests docs
 
+      - name: Check auto-merge marker eligibility
+        id: auto_merge_marker
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          marker = Path("auto_merge_marker.txt")
+          manifest_path = Path("signals/public_launch_manifest.json")
+          required = {
+              "source_name",
+              "source_url",
+              "source_priority",
+              "attribution_status",
+              "copyright_status",
+              "quality_hint",
+              "ready_for_pipeline",
+              "published",
+          }
+          eligible = False
+          if manifest_path.exists():
+              data = json.loads(manifest_path.read_text(encoding="utf-8"))
+              launched = data.get("launched", [])
+              eligible = bool(launched) and all(isinstance(item, dict) and required <= set(item) for item in launched)
+          marker.write_text("AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1\n" if eligible else "", encoding="utf-8")
+          print(f"eligible={str(eligible).lower()}")
+          PY
+
       - name: Detect public Signals changes
         id: signals_changes
         run: |
@@ -66,6 +94,6 @@ jobs:
           git push --set-upstream origin "$BRANCH"
           gh pr create \
             --title "content: sync DysonX public Signals from Notion" \
-            --body "Automated Notion public Signals sync. Opens PR only; no auto-merge, no OpenAI call, no scraping, no raw article body copying, no hardcoded deployment domain." \
+            --body "$(printf 'Automated Notion public Signals sync. Opens PR only unless the strict DysonX public Signals auto-merge gate passes. No OpenAI call, no scraping, no raw article body copying, no hardcoded deployment domain.\n\n'; cat auto_merge_marker.txt)" \
             --base main \
             --head "$BRANCH"

--- a/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
+++ b/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
@@ -1,0 +1,124 @@
+name: DysonX Public Signals Auto-Merge V1
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  public-signals-auto-merge-v1:
+    name: Gate and auto-merge public Signals sync PRs
+    if: github.event.pull_request.title == 'content: sync DysonX public Signals from Notion' && startsWith(github.event.pull_request.head.ref, 'automation/dysonx-notion-signals-')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      AUTO_MERGE_ENABLED: ${{ vars.DYSONX_PUBLIC_SIGNALS_AUTO_MERGE }}
+
+    steps:
+      - name: Validate PR identity
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+            echo "[public-signals-auto-merge] blocked: PR must come from the same repository"
+            exit 1
+          fi
+          if [ "${{ github.event.pull_request.draft }}" = "true" ]; then
+            echo "[public-signals-auto-merge] blocked: PR is draft"
+            exit 1
+          fi
+          if [ "${{ github.event.pull_request.title }}" != "content: sync DysonX public Signals from Notion" ]; then
+            echo "[public-signals-auto-merge] skipped: title does not match public Signals sync PR"
+            exit 0
+          fi
+          case "${{ github.event.pull_request.head.ref }}" in
+            automation/dysonx-notion-signals-*) ;;
+            *)
+              echo "[public-signals-auto-merge] skipped: head branch is not an automation public Signals branch"
+              exit 0
+              ;;
+          esac
+          gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json body --jq '.body' > pr_body.txt
+          if ! grep -Fxq "AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1" pr_body.txt; then
+            echo "[public-signals-auto-merge] blocked: missing auto-merge candidate marker"
+            exit 1
+          fi
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Fetch changed files
+        run: |
+          gh pr diff "$PR_NUMBER" --repo "${{ github.repository }}" --name-only > changed_files.txt
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          files = [line.strip() for line in Path("changed_files.txt").read_text(encoding="utf-8").splitlines() if line.strip()]
+          Path("changed_files.json").write_text(json.dumps(files, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Reject files outside public Signals output
+        run: |
+          python3 - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          allowed = re.compile(r"^(signals/index\.html|signals/public_launch_manifest\.json|signals/[^/]+/index\.html)$")
+          files = json.loads(Path("changed_files.json").read_text(encoding="utf-8"))
+          bad = [path for path in files if not allowed.match(path)]
+          if bad:
+              raise SystemExit(f"changed files outside allowed signals paths: {bad}")
+          print("[public-signals-auto-merge] changed file scope PASS")
+          PY
+
+      - name: Run static link integrity check
+        run: python3 scripts/dysonx_static_preview_check.py --root .
+
+      - name: Run forbidden public output grep guards
+        run: |
+          ! grep -R "https://dysonx.ai" -n signals scripts tests docs
+          ! grep -R "media.energizeos.com" -n signals scripts tests docs
+          ! grep -R "source.dysonx.invalid" -n signals scripts tests docs
+          ! grep -R "\.invalid" -n signals scripts tests docs
+          ! grep -R "\.test/" -n signals scripts tests docs
+          ! grep -R "tmp/production_publish_pack" -n signals scripts tests docs
+
+      - name: Run strict public Signals auto-merge gate
+        run: |
+          python3 scripts/dysonx_public_signals_auto_merge_gate.py \
+            --manifest signals/public_launch_manifest.json \
+            --changed-files-json changed_files.json \
+            --min-quality 92 \
+            --required-priority Critical \
+            --require-attribution-complete \
+            --require-safe-summary-only
+
+      - name: Confirm required checks are green
+        run: |
+          gh pr checks "$PR_NUMBER" --repo "${{ github.repository }}" --required --watch
+
+      - name: Respect emergency kill switch
+        run: |
+          if [ "$AUTO_MERGE_ENABLED" != "true" ]; then
+            echo "[public-signals-auto-merge] gate passed, but DYSONX_PUBLIC_SIGNALS_AUTO_MERGE is not true; no merge performed"
+            exit 0
+          fi
+
+      - name: Squash merge public Signals sync PR
+        if: env.AUTO_MERGE_ENABLED == 'true'
+        run: gh pr merge "$PR_NUMBER" --repo "${{ github.repository }}" --squash --delete-branch

--- a/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
+++ b/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
@@ -108,9 +108,14 @@ jobs:
             --require-attribution-complete \
             --require-safe-summary-only
 
-      - name: Confirm required checks are green
+      - name: Confirm all non-excluded checks are green
         run: |
-          gh pr checks "$PR_NUMBER" --repo "${{ github.repository }}" --required --watch
+          python3 scripts/dysonx_pr_checks_gate.py \
+            --repo "${{ github.repository }}" \
+            --pr-number "$PR_NUMBER" \
+            --exclude-check-name "DysonX Public Signals Auto-Merge V1 / Gate and auto-merge public Signals sync PRs" \
+            --timeout-seconds 900 \
+            --poll-seconds 15
 
       - name: Respect emergency kill switch
         run: |

--- a/docs/DYSONX_PUBLIC_SIGNALS_AUTO_MERGE_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNALS_AUTO_MERGE_V1.md
@@ -88,6 +88,22 @@ Manifest safety flags must include:
 - `network_source_fetch_performed = false`
 - `manual_external_deployment_performed = false`
 
+## GitHub Checks Rule
+
+Auto-merge requires all relevant PR checks to be green, not only branch-protection-required checks.
+
+The checks gate waits for every non-excluded PR check to reach a terminal state. It passes only when every non-excluded conclusion is `success`, `skipped`, or `neutral`.
+
+Failures in non-required checks still block auto-merge. `failure`, `cancelled`, `timed_out`, and `action_required` all block.
+
+The auto-merge workflow excludes its own check:
+
+```text
+DysonX Public Signals Auto-Merge V1 / Gate and auto-merge public Signals sync PRs
+```
+
+This self-exclusion prevents a deadlock where the workflow waits for itself to complete before it can finish.
+
 ## Critical-Only Rule
 
 Non-Critical content must not auto-merge.

--- a/docs/DYSONX_PUBLIC_SIGNALS_AUTO_MERGE_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNALS_AUTO_MERGE_V1.md
@@ -92,9 +92,13 @@ Manifest safety flags must include:
 
 Auto-merge requires all relevant PR checks to be green, not only branch-protection-required checks.
 
-The checks gate waits for every non-excluded PR check to reach a terminal state. It passes only when every non-excluded conclusion is `success`, `skipped`, or `neutral`.
+The checks gate uses official `gh pr checks` JSON fields: `name`, `workflow`, `state`, `bucket`, and `link`.
 
-Failures in non-required checks still block auto-merge. `failure`, `cancelled`, `timed_out`, and `action_required` all block.
+The gate classifies `bucket` values first. It passes only when every non-excluded check has `bucket = pass` or `bucket = skipping`.
+
+Failures in non-required checks still block auto-merge. `bucket = fail` and `bucket = cancel` both block. `bucket = pending` waits until the check reaches a terminal bucket.
+
+If a bucket is missing, the gate falls back to `state` conservatively and fails closed for unknown states.
 
 The auto-merge workflow excludes its own check:
 

--- a/docs/DYSONX_PUBLIC_SIGNALS_AUTO_MERGE_V1.md
+++ b/docs/DYSONX_PUBLIC_SIGNALS_AUTO_MERGE_V1.md
@@ -1,0 +1,124 @@
+# DysonX Public Signals Auto-Merge V1
+
+## Purpose
+
+Public Signals Auto-Merge V1 removes the daily manual merge step only for the existing Notion public Signals content PR path.
+
+It is not a new launch step, product milestone, publishing architecture, UI redesign, deployment system, source collector, scraper, or OpenAI workflow.
+
+Allowed chain:
+
+```text
+DysonX Sources
+-> Signal Intake
+-> Public Signals Sync PR
+-> strict auto-merge gate
+-> automatic squash merge
+-> public page updates
+```
+
+## Eligible PR Scope
+
+Auto-merge may consider only PRs created by the existing public Signals sync workflow.
+
+Required PR identity:
+
+- Title exactly equals `content: sync DysonX public Signals from Notion`.
+- Head branch starts with `automation/dysonx-notion-signals-`.
+- PR is not draft.
+- PR is from the same repository, not a fork.
+- PR body contains `AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1`.
+
+Allowed changed files:
+
+- `signals/index.html`
+- `signals/public_launch_manifest.json`
+- `signals/<slug>/index.html`
+
+Any file outside `signals/` blocks auto-merge.
+
+## Emergency Kill Switch
+
+Repository variable:
+
+```text
+DYSONX_PUBLIC_SIGNALS_AUTO_MERGE
+```
+
+Auto-merge runs only when:
+
+```text
+DYSONX_PUBLIC_SIGNALS_AUTO_MERGE=true
+```
+
+If the variable is missing or any value other than `true`, the gate may run and report, but no merge is performed.
+
+Emergency disable method:
+
+```text
+DYSONX_PUBLIC_SIGNALS_AUTO_MERGE=false
+```
+
+## Strict Gate Rules
+
+Every changed public Signal page must have a matching manifest entry and pass:
+
+- `quality_hint >= 92`
+- `source_priority = Critical`
+- `attribution_status = Complete`
+- `copyright_status = Safe Summary Only`
+- `ready_for_pipeline = true`
+- `published = true`
+- source URL is absolute `http` or `https`
+- summary-only public page
+- no raw article body markers
+- no source-page body copied
+- no forbidden deployment host
+- no fake test or invalid source domain
+- no internal temporary artifact path
+- no `script` tags
+- no `iframe` tags
+- no inline event handlers
+- no external JavaScript
+- no unknown generated file path
+
+Manifest safety flags must include:
+
+- `openai_call_performed = false`
+- `network_source_fetch_performed = false`
+- `manual_external_deployment_performed = false`
+
+## Critical-Only Rule
+
+Non-Critical content must not auto-merge.
+
+High and Medium priority Signals may still be generated into a PR, but they require human review and manual merge.
+
+## Manifest Requirements
+
+Public sync manifests must include these fields per launched Signal so the gate can decide without reading Notion:
+
+- `source_name`
+- `source_url`
+- `source_priority`
+- `attribution_status`
+- `copyright_status`
+- `quality_hint`
+- `ready_for_pipeline`
+- `published`
+
+## Public Safety Rules
+
+The auto-merge gate does not call OpenAI, fetch sources, scrape source pages, copy raw article bodies, dispatch workflows, or manually deploy.
+
+Public links remain domain-agnostic. Generated public links should use relative public paths by default. Source attribution links may be absolute `http` or `https` URLs.
+
+## Monitoring
+
+Monitor the workflow:
+
+```text
+DysonX Public Signals Auto-Merge V1
+```
+
+Blocked runs should be treated as normal safety behavior. The fix should be made in Notion source/intake data or in the public sync generator, then allowed to create a new public Signals sync PR.

--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -199,6 +199,18 @@ def source_label(record: dict[str, Any]) -> str:
     return normalize_text(field(record, "Source Label", "Source", "source_label")) or "Source"
 
 
+def source_priority(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Source Priority", "Priority", "source_priority"))
+
+
+def attribution_status(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Attribution Status", "attribution_status"))
+
+
+def copyright_status(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "Copyright Status", "copyright_status"))
+
+
 def tags(record: dict[str, Any]) -> list[str]:
     value = field(record, "Tags", "Tag", "Categories", "Category")
     return [normalize_text(item) for item in as_list(value) if normalize_text(item)]
@@ -224,9 +236,9 @@ def eligibility_blockers(record: dict[str, Any]) -> list[str]:
         blockers.append("ready_for_pipeline_not_checked")
     if field(record, "Published", "published") is not True:
         blockers.append("published_not_checked")
-    if normalize_text(field(record, "Attribution Status", "attribution_status")) != "Complete":
+    if attribution_status(record) != "Complete":
         blockers.append("attribution_not_complete")
-    if normalize_text(field(record, "Copyright Status", "copyright_status")) != "Safe Summary Only":
+    if copyright_status(record) != "Safe Summary Only":
         blockers.append("copyright_not_safe_summary_only")
     if quality_hint(record) < 80:
         blockers.append("quality_hint_below_80")
@@ -293,6 +305,12 @@ def existing_public_signals(output_root: pathlib.Path) -> list[dict[str, Any]]:
                 "title": title,
                 "summary": parser.summary or "Existing public Signal summary retained.",
                 "source_label": "existing public Signal",
+                "source_url": "",
+                "source_priority": "",
+                "attribution_status": "",
+                "copyright_status": "",
+                "ready_for_pipeline": True,
+                "published": True,
                 "agi_relevance": "Retained",
                 "quality_hint": "",
                 "tags": [],
@@ -313,6 +331,11 @@ def record_from_notion(record: dict[str, Any]) -> dict[str, Any]:
         "agi_relevance": text_field(record, "AGI Relevance", "agi_relevance", default="AGI relevance retained in Notion metadata."),
         "source_label": source_label(record),
         "source_url": source_url(record),
+        "source_priority": source_priority(record),
+        "attribution_status": attribution_status(record),
+        "copyright_status": copyright_status(record),
+        "ready_for_pipeline": field(record, "Ready for Pipeline", "ready_for_pipeline") is True,
+        "published": field(record, "Published", "published") is True,
         "quality_hint": int(quality_hint(record)),
         "risk_notes": text_field(record, "Risk Notes", "Safety Notes", "risk_notes", default="Summary-only public treatment. No raw article body is reproduced."),
         "watch_next": text_field(record, "Watch Next", "watch_next", default="Watch for follow-up Signals in the Notion-managed intake."),
@@ -451,6 +474,13 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
             "public_path": f"signals/{record['slug']}/index.html",
             "public_url_path": f"/signals/{record['slug']}/",
             "published": True,
+            "source_name": record.get("source_label", ""),
+            "source_url": record.get("source_url", ""),
+            "source_priority": record.get("source_priority", ""),
+            "attribution_status": record.get("attribution_status", ""),
+            "copyright_status": record.get("copyright_status", ""),
+            "quality_hint": record.get("quality_hint", ""),
+            "ready_for_pipeline": bool(record.get("ready_for_pipeline")),
             "production_publish_performed": True,
         }
         for record in records
@@ -464,6 +494,7 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
         "launched": launched,
         "openai_call_performed": False,
         "source_scraping_performed": False,
+        "network_source_fetch_performed": False,
         "raw_article_body_copied": False,
         "manual_external_deployment_performed": False,
         "workflow_dispatch_performed": False,

--- a/scripts/dysonx_pr_checks_gate.py
+++ b/scripts/dysonx_pr_checks_gate.py
@@ -11,9 +11,12 @@ import time
 from typing import Any, Callable
 
 
-PASSING_CONCLUSIONS = {"success", "skipped", "neutral"}
-FAILING_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required"}
-WAITING_STATES = {"queued", "in_progress", "pending", "expected"}
+PASSING_BUCKETS = {"pass", "skipping"}
+FAILING_BUCKETS = {"fail", "cancel"}
+WAITING_BUCKETS = {"pending"}
+PASSING_STATE_TOKENS = ("success", "pass", "skipped", "neutral")
+FAILING_STATE_TOKENS = ("fail", "error", "cancel", "timed_out", "action_required")
+WAITING_STATE_TOKENS = ("pending", "queued", "in_progress", "expected")
 
 
 class PRChecksGateError(RuntimeError):
@@ -34,17 +37,17 @@ def normalize(value: Any) -> str:
 
 
 def check_name(check: dict[str, Any]) -> str:
-    workflow = normalize(check.get("workflowName") or check.get("workflow"))
-    name = normalize(check.get("name") or check.get("context"))
+    workflow = normalize(check.get("workflow"))
+    name = normalize(check.get("name"))
     return f"{workflow} / {name}" if workflow and name else name or workflow or "<unnamed check>"
 
 
+def check_bucket(check: dict[str, Any]) -> str:
+    return normalize(check.get("bucket")).lower()
+
+
 def check_state(check: dict[str, Any]) -> str:
-    return normalize(check.get("state") or check.get("status")).lower()
-
-
-def check_conclusion(check: dict[str, Any]) -> str:
-    return normalize(check.get("conclusion") or check.get("state") or check.get("status")).lower()
+    return normalize(check.get("state")).lower()
 
 
 def load_checks(repo: str, pr_number: str, runner: Runner = run_gh) -> list[dict[str, Any]]:
@@ -57,7 +60,7 @@ def load_checks(repo: str, pr_number: str, runner: Runner = run_gh) -> list[dict
             "--repo",
             repo,
             "--json",
-            "name,workflowName,state,conclusion,status",
+            "name,workflow,state,bucket,link",
         ]
     )
     data = json.loads(output)
@@ -75,17 +78,28 @@ def classify_checks(checks: list[dict[str, Any]], exclude_check_name: str) -> tu
         if name == exclude_check_name:
             continue
         checked += 1
-        conclusion = check_conclusion(check)
+        bucket = check_bucket(check)
         state = check_state(check)
-        if conclusion in PASSING_CONCLUSIONS:
+        if bucket in PASSING_BUCKETS:
             continue
-        if conclusion in FAILING_CONCLUSIONS:
-            failing.append(f"{name}: {conclusion}")
+        if bucket in FAILING_BUCKETS:
+            failing.append(f"{name}: {bucket}")
             continue
-        if state in WAITING_STATES or conclusion in WAITING_STATES or not conclusion:
-            waiting.append(f"{name}: {state or conclusion or 'pending'}")
+        if bucket in WAITING_BUCKETS:
+            waiting.append(f"{name}: {bucket}")
             continue
-        failing.append(f"{name}: unexpected conclusion {conclusion}")
+        if bucket:
+            failing.append(f"{name}: unknown bucket {bucket}")
+            continue
+        if any(token in state for token in PASSING_STATE_TOKENS):
+            continue
+        if any(token in state for token in FAILING_STATE_TOKENS):
+            failing.append(f"{name}: {state}")
+            continue
+        if any(token in state for token in WAITING_STATE_TOKENS) or not state:
+            waiting.append(f"{name}: {state or 'pending'}")
+            continue
+        failing.append(f"{name}: unknown state {state}")
     return failing, waiting, checked
 
 

--- a/scripts/dysonx_pr_checks_gate.py
+++ b/scripts/dysonx_pr_checks_gate.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Wait for all relevant GitHub PR checks to pass."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from typing import Any, Callable
+
+
+PASSING_CONCLUSIONS = {"success", "skipped", "neutral"}
+FAILING_CONCLUSIONS = {"failure", "cancelled", "timed_out", "action_required"}
+WAITING_STATES = {"queued", "in_progress", "pending", "expected"}
+
+
+class PRChecksGateError(RuntimeError):
+    """Raised when PR checks are not safe for auto-merge."""
+
+
+Runner = Callable[[list[str]], str]
+Sleeper = Callable[[float], None]
+Clock = Callable[[], float]
+
+
+def run_gh(args: list[str]) -> str:
+    return subprocess.check_output(args, text=True)
+
+
+def normalize(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def check_name(check: dict[str, Any]) -> str:
+    workflow = normalize(check.get("workflowName") or check.get("workflow"))
+    name = normalize(check.get("name") or check.get("context"))
+    return f"{workflow} / {name}" if workflow and name else name or workflow or "<unnamed check>"
+
+
+def check_state(check: dict[str, Any]) -> str:
+    return normalize(check.get("state") or check.get("status")).lower()
+
+
+def check_conclusion(check: dict[str, Any]) -> str:
+    return normalize(check.get("conclusion") or check.get("state") or check.get("status")).lower()
+
+
+def load_checks(repo: str, pr_number: str, runner: Runner = run_gh) -> list[dict[str, Any]]:
+    output = runner(
+        [
+            "gh",
+            "pr",
+            "checks",
+            pr_number,
+            "--repo",
+            repo,
+            "--json",
+            "name,workflowName,state,conclusion,status",
+        ]
+    )
+    data = json.loads(output)
+    if not isinstance(data, list):
+        raise PRChecksGateError("gh pr checks did not return a JSON list")
+    return [item for item in data if isinstance(item, dict)]
+
+
+def classify_checks(checks: list[dict[str, Any]], exclude_check_name: str) -> tuple[list[str], list[str], int]:
+    failing: list[str] = []
+    waiting: list[str] = []
+    checked = 0
+    for check in checks:
+        name = check_name(check)
+        if name == exclude_check_name:
+            continue
+        checked += 1
+        conclusion = check_conclusion(check)
+        state = check_state(check)
+        if conclusion in PASSING_CONCLUSIONS:
+            continue
+        if conclusion in FAILING_CONCLUSIONS:
+            failing.append(f"{name}: {conclusion}")
+            continue
+        if state in WAITING_STATES or conclusion in WAITING_STATES or not conclusion:
+            waiting.append(f"{name}: {state or conclusion or 'pending'}")
+            continue
+        failing.append(f"{name}: unexpected conclusion {conclusion}")
+    return failing, waiting, checked
+
+
+def wait_for_checks(
+    repo: str,
+    pr_number: str,
+    exclude_check_name: str,
+    timeout_seconds: int,
+    poll_seconds: int,
+    runner: Runner = run_gh,
+    sleeper: Sleeper = time.sleep,
+    clock: Clock = time.monotonic,
+) -> None:
+    deadline = clock() + timeout_seconds
+    last_waiting: list[str] = []
+    while True:
+        checks = load_checks(repo, pr_number, runner=runner)
+        failing, waiting, checked = classify_checks(checks, exclude_check_name)
+        if failing:
+            raise PRChecksGateError("failing checks: " + "; ".join(failing))
+        if checked == 0:
+            raise PRChecksGateError("no non-excluded PR checks found")
+        if not waiting:
+            print(f"[dysonx-pr-checks-gate] PASS checks={checked}")
+            return
+        last_waiting = waiting
+        if clock() >= deadline:
+            raise PRChecksGateError("timed out waiting for checks: " + "; ".join(last_waiting))
+        print("[dysonx-pr-checks-gate] waiting: " + "; ".join(waiting))
+        sleeper(poll_seconds)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Wait for all non-excluded GitHub PR checks to pass.")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr-number", required=True)
+    parser.add_argument("--exclude-check-name", required=True)
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    parser.add_argument("--poll-seconds", type=int, default=15)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        wait_for_checks(
+            repo=args.repo,
+            pr_number=args.pr_number,
+            exclude_check_name=args.exclude_check_name,
+            timeout_seconds=args.timeout_seconds,
+            poll_seconds=args.poll_seconds,
+        )
+    except (PRChecksGateError, json.JSONDecodeError, subprocess.CalledProcessError) as exc:
+        print(f"[dysonx-pr-checks-gate] FAIL: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dysonx_public_signals_auto_merge_gate.py
+++ b/scripts/dysonx_public_signals_auto_merge_gate.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Strict auto-merge gate for DysonX public Signals sync PRs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+from html.parser import HTMLParser
+from typing import Any
+from urllib.parse import urlsplit
+
+
+GATE_VERSION = "dysonx_public_signals_auto_merge_gate_v1"
+ALLOWED_STATIC_FILES = {"signals/index.html", "signals/public_launch_manifest.json"}
+FORBIDDEN_TERMS = (
+    "https://dysonx." "ai",
+    "media." "energizeos.com",
+    "source.dysonx." "invalid",
+    "." "invalid",
+    "." "test/",
+    "tmp/" "production_publish_pack",
+)
+RAW_BODY_MARKERS = (
+    "raw article body",
+    "source-page body copied",
+    "full article text",
+    "verbatim article body",
+)
+INLINE_EVENT_PATTERN = re.compile(r"\son[a-z]+\s*=", re.IGNORECASE)
+
+
+class AutoMergeGateError(RuntimeError):
+    """Raised when the public Signals auto-merge gate must block."""
+
+
+class HrefParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: list[str] = []
+        self.ids: set[str] = set()
+        self.script_tags = 0
+        self.iframe_tags = 0
+        self.inline_event_handlers: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {key.lower(): value or "" for key, value in attrs}
+        if tag == "script":
+            self.script_tags += 1
+        if tag == "iframe":
+            self.iframe_tags += 1
+        if "id" in attr_map and attr_map["id"]:
+            self.ids.add(attr_map["id"])
+        if "href" in attr_map:
+            self.hrefs.append(attr_map["href"])
+        self.inline_event_handlers.extend(key for key in attr_map if key.startswith("on"))
+
+
+def normalize_path(value: str) -> str:
+    return value.strip().lstrip("./")
+
+
+def signal_slug_from_path(path: str) -> str | None:
+    parts = pathlib.PurePosixPath(normalize_path(path)).parts
+    if len(parts) == 3 and parts[0] == "signals" and parts[2] == "index.html":
+        return parts[1]
+    return None
+
+
+def is_allowed_changed_file(path: str) -> bool:
+    normalized = normalize_path(path)
+    if normalized in ALLOWED_STATIC_FILES:
+        return True
+    return signal_slug_from_path(normalized) is not None
+
+
+def load_changed_files(path: str | None) -> list[str]:
+    if not path:
+        return []
+    data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, list) or not all(isinstance(item, str) for item in data):
+        raise AutoMergeGateError("changed files JSON must be a list of strings")
+    return [normalize_path(item) for item in data]
+
+
+def fail_if_forbidden_text(text: str, label: str) -> None:
+    lowered = text.lower()
+    for term in FORBIDDEN_TERMS:
+        if term in lowered:
+            raise AutoMergeGateError(f"{label} contains forbidden term: {term}")
+    for marker in RAW_BODY_MARKERS:
+        if marker in lowered:
+            raise AutoMergeGateError(f"{label} contains raw/source body marker: {marker}")
+
+
+def public_path_exists(root: pathlib.Path, href: str) -> bool:
+    path = urlsplit(href).path
+    if path == "/":
+        return (root / "index.html").exists()
+    relative = path.lstrip("/")
+    if path.endswith("/"):
+        return (root / relative / "index.html").exists()
+    return (root / relative).exists()
+
+
+def check_html_file(path: pathlib.Path, root: pathlib.Path) -> None:
+    if not path.exists():
+        raise AutoMergeGateError(f"changed public HTML file is missing: {path}")
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    fail_if_forbidden_text(text, str(path))
+    if INLINE_EVENT_PATTERN.search(text):
+        raise AutoMergeGateError(f"{path} contains inline event handler")
+    parser = HrefParser()
+    parser.feed(text)
+    if parser.script_tags:
+        raise AutoMergeGateError(f"{path} contains script tag")
+    if parser.iframe_tags:
+        raise AutoMergeGateError(f"{path} contains iframe tag")
+    if parser.inline_event_handlers:
+        raise AutoMergeGateError(f"{path} contains inline event handler attribute")
+    for href in parser.hrefs:
+        lowered = href.lower()
+        if not href or href == "#":
+            raise AutoMergeGateError(f"{path} contains empty or bare href")
+        if any(term in lowered for term in FORBIDDEN_TERMS):
+            raise AutoMergeGateError(f"{path} contains forbidden href: {href}")
+        if href.startswith("#"):
+            if href[1:] not in parser.ids:
+                raise AutoMergeGateError(f"{path} links to missing same-page anchor: {href}")
+            continue
+        if href.startswith("/"):
+            if not public_path_exists(root, href):
+                raise AutoMergeGateError(f"{path} links to missing public path: {href}")
+            continue
+        if href.startswith(("http://", "https://")):
+            parsed = urlsplit(href)
+            if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+                raise AutoMergeGateError(f"{path} contains invalid external source link: {href}")
+            continue
+        raise AutoMergeGateError(f"{path} contains non-relative unsupported href: {href}")
+
+
+def launched_by_slug(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    launched = manifest.get("launched")
+    if not isinstance(launched, list):
+        raise AutoMergeGateError("manifest launched must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for entry in launched:
+        if not isinstance(entry, dict):
+            raise AutoMergeGateError("manifest launched entries must be objects")
+        slug = str(entry.get("slug") or "")
+        if not slug:
+            raise AutoMergeGateError("manifest launched entry is missing slug")
+        result[slug] = entry
+    return result
+
+
+def changed_signal_slugs(changed_files: list[str], manifest: dict[str, Any]) -> set[str]:
+    slugs = {slug for path in changed_files if (slug := signal_slug_from_path(path))}
+    if not changed_files or not slugs:
+        slugs = set(launched_by_slug(manifest))
+    return slugs
+
+
+def check_manifest_flags(manifest: dict[str, Any]) -> None:
+    expected_false = {
+        "openai_call_performed": False,
+        "network_source_fetch_performed": False,
+        "manual_external_deployment_performed": False,
+    }
+    for key, expected in expected_false.items():
+        if manifest.get(key) is not expected:
+            raise AutoMergeGateError(f"manifest {key} must be {expected}")
+
+
+def check_entry(entry: dict[str, Any], *, min_quality: float, required_priority: str, require_attribution_complete: bool, require_safe_summary_only: bool) -> None:
+    slug = str(entry.get("slug") or "<missing-slug>")
+    try:
+        quality = float(entry.get("quality_hint"))
+    except (TypeError, ValueError):
+        raise AutoMergeGateError(f"{slug} quality_hint is missing or non-numeric") from None
+    if quality < min_quality:
+        raise AutoMergeGateError(f"{slug} quality_hint {quality:g} is below {min_quality:g}")
+    if str(entry.get("source_priority") or "") != required_priority:
+        raise AutoMergeGateError(f"{slug} source_priority must be {required_priority}")
+    if require_attribution_complete and str(entry.get("attribution_status") or "") != "Complete":
+        raise AutoMergeGateError(f"{slug} attribution_status must be Complete")
+    if require_safe_summary_only and str(entry.get("copyright_status") or "") != "Safe Summary Only":
+        raise AutoMergeGateError(f"{slug} copyright_status must be Safe Summary Only")
+    source_url = str(entry.get("source_url") or "")
+    parsed = urlsplit(source_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise AutoMergeGateError(f"{slug} source_url must be absolute http/https")
+    if entry.get("ready_for_pipeline") is not True:
+        raise AutoMergeGateError(f"{slug} ready_for_pipeline must be true")
+    if entry.get("published") is not True:
+        raise AutoMergeGateError(f"{slug} published must be true")
+
+
+def run_gate(args: argparse.Namespace) -> None:
+    manifest_path = pathlib.Path(args.manifest)
+    root = manifest_path.parent.parent
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    fail_if_forbidden_text(manifest_text, str(manifest_path))
+    manifest = json.loads(manifest_text)
+    if not isinstance(manifest, dict):
+        raise AutoMergeGateError("manifest must be a JSON object")
+    check_manifest_flags(manifest)
+
+    changed_files = load_changed_files(args.changed_files_json)
+    for changed_file in changed_files:
+        if not is_allowed_changed_file(changed_file):
+            raise AutoMergeGateError(f"changed file is outside allowed public Signals paths: {changed_file}")
+
+    entries = launched_by_slug(manifest)
+    slugs_to_check = changed_signal_slugs(changed_files, manifest)
+    if not slugs_to_check:
+        raise AutoMergeGateError("no changed or launched Signal pages found")
+
+    for slug in slugs_to_check:
+        entry = entries.get(slug)
+        if not entry:
+            raise AutoMergeGateError(f"changed Signal page has no manifest entry: {slug}")
+        check_entry(
+            entry,
+            min_quality=args.min_quality,
+            required_priority=args.required_priority,
+            require_attribution_complete=args.require_attribution_complete,
+            require_safe_summary_only=args.require_safe_summary_only,
+        )
+
+    paths_to_check = {path for path in changed_files if path.endswith(".html")}
+    if not changed_files:
+        paths_to_check = {"signals/index.html", *[f"signals/{slug}/index.html" for slug in slugs_to_check]}
+    for relative_path in sorted(paths_to_check):
+        check_html_file(root / relative_path, root)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Gate DysonX public Signals auto-merge candidates.")
+    parser.add_argument("--manifest", required=True, help="Path to signals/public_launch_manifest.json.")
+    parser.add_argument("--changed-files-json", help="Optional JSON list of changed files.")
+    parser.add_argument("--min-quality", type=float, default=92)
+    parser.add_argument("--required-priority", default="Critical")
+    parser.add_argument("--require-attribution-complete", action="store_true")
+    parser.add_argument("--require-safe-summary-only", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        run_gate(args)
+    except (AutoMergeGateError, OSError, json.JSONDecodeError) as exc:
+        print(f"[{GATE_VERSION}] FAIL: {exc}", file=sys.stderr)
+        return 2
+    print(f"[{GATE_VERSION}] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -22,6 +22,7 @@ def eligible_record(**overrides):
         "AGI Relevance": "Agents and evaluation",
         "Source URL": "https://example.org/agent-reliability",
         "Source Label": "Example Research Source",
+        "Source Priority": "Critical",
         "Ready for Pipeline": True,
         "Published": True,
         "Attribution Status": "Complete",
@@ -106,7 +107,21 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
 
         self.assertIs(manifest["openai_call_performed"], False)
         self.assertIs(manifest["source_scraping_performed"], False)
+        self.assertIs(manifest["network_source_fetch_performed"], False)
         self.assertIs(manifest["raw_article_body_copied"], False)
+
+    def test_manifest_includes_auto_merge_gate_fields(self):
+        manifest = sync.sync_records([eligible_record(**{"Quality Hint": 94})], self.root)
+        entry = next(item for item in manifest["launched"] if item["slug"] == "notion-agent-reliability")
+
+        self.assertEqual(entry["source_name"], "Example Research Source")
+        self.assertEqual(entry["source_url"], "https://example.org/agent-reliability")
+        self.assertEqual(entry["source_priority"], "Critical")
+        self.assertEqual(entry["attribution_status"], "Complete")
+        self.assertEqual(entry["copyright_status"], "Safe Summary Only")
+        self.assertEqual(entry["quality_hint"], 94)
+        self.assertIs(entry["ready_for_pipeline"], True)
+        self.assertIs(entry["published"], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_dysonx_pr_checks_gate.py
+++ b/tests/test_dysonx_pr_checks_gate.py
@@ -13,13 +13,13 @@ import dysonx_pr_checks_gate as gate  # noqa: E402
 EXCLUDED = "DysonX Public Signals Auto-Merge V1 / Gate and auto-merge public Signals sync PRs"
 
 
-def check(name, conclusion=None, state="COMPLETED", workflow="CI"):
+def check(name, bucket="pass", state="", workflow="CI"):
     return {
         "name": name,
-        "workflowName": workflow,
+        "workflow": workflow,
         "state": state,
-        "status": state,
-        "conclusion": conclusion,
+        "bucket": bucket,
+        "link": "https://example.org/check",
     }
 
 
@@ -61,42 +61,42 @@ class DysonXPRChecksGateTests(unittest.TestCase):
         )
         return runner.calls
 
-    def test_passes_when_all_checks_success_skipped_or_neutral(self):
-        calls = self.wait([[check("unit", "success"), check("docs", "skipped"), check("lint", "neutral")]])
+    def test_passes_when_bucket_is_pass(self):
+        calls = self.wait([[check("unit", "pass")]])
         self.assertEqual(calls, 1)
 
-    def test_fails_when_any_check_is_failure(self):
-        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: failure"):
-            self.wait([[check("unit", "failure")]])
+    def test_passes_when_bucket_is_skipping(self):
+        calls = self.wait([[check("docs", "skipping")]])
+        self.assertEqual(calls, 1)
 
-    def test_fails_when_any_check_is_cancelled(self):
-        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: cancelled"):
-            self.wait([[check("unit", "cancelled")]])
+    def test_waits_when_bucket_pending_then_passes(self):
+        calls = self.wait([[check("unit", "pending")], [check("unit", "pass")]])
+        self.assertEqual(calls, 2)
 
-    def test_fails_when_any_check_is_timed_out(self):
-        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: timed_out"):
-            self.wait([[check("unit", "timed_out")]])
+    def test_fails_when_bucket_is_fail(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: fail"):
+            self.wait([[check("unit", "fail")]])
 
-    def test_fails_when_any_check_is_action_required(self):
-        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: action_required"):
-            self.wait([[check("unit", "action_required")]])
+    def test_fails_when_bucket_is_cancel(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: cancel"):
+            self.wait([[check("unit", "cancel")]])
 
-    def test_pending_in_progress_and_queued_wait_until_terminal(self):
-        calls = self.wait(
-            [
-                [check("unit", None, state="QUEUED")],
-                [check("unit", None, state="IN_PROGRESS")],
-                [check("unit", "success", state="COMPLETED")],
-            ]
-        )
-        self.assertEqual(calls, 3)
+    def test_falls_back_to_state_when_bucket_missing(self):
+        calls = self.wait([[check("unit", bucket="", state="SUCCESS")]])
+        self.assertEqual(calls, 1)
+
+    def test_fail_closed_on_unknown_bucket_or_state(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unknown bucket mystery"):
+            self.wait([[check("unit", "mystery")]])
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unknown state weird"):
+            self.wait([[check("unit", bucket="", state="WEIRD")]])
 
     def test_excluded_auto_merge_check_does_not_block(self):
         calls = self.wait(
             [
                 [
                     check("Gate and auto-merge public Signals sync PRs", None, state="IN_PROGRESS", workflow="DysonX Public Signals Auto-Merge V1"),
-                    check("unit", "success"),
+                    check("unit", "pass"),
                 ]
             ]
         )
@@ -104,7 +104,7 @@ class DysonXPRChecksGateTests(unittest.TestCase):
 
     def test_timeout_fails_with_clear_message(self):
         with self.assertRaisesRegex(gate.PRChecksGateError, "timed out waiting for checks"):
-            self.wait([[check("unit", None, state="IN_PROGRESS")]], timeout=10, poll=5)
+            self.wait([[check("unit", "pending")]], timeout=10, poll=5)
 
 
 if __name__ == "__main__":

--- a/tests/test_dysonx_pr_checks_gate.py
+++ b/tests/test_dysonx_pr_checks_gate.py
@@ -1,0 +1,111 @@
+import json
+import unittest
+import sys
+import pathlib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_pr_checks_gate as gate  # noqa: E402
+
+
+EXCLUDED = "DysonX Public Signals Auto-Merge V1 / Gate and auto-merge public Signals sync PRs"
+
+
+def check(name, conclusion=None, state="COMPLETED", workflow="CI"):
+    return {
+        "name": name,
+        "workflowName": workflow,
+        "state": state,
+        "status": state,
+        "conclusion": conclusion,
+    }
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+class Runner:
+    def __init__(self, snapshots):
+        self.snapshots = list(snapshots)
+        self.calls = 0
+
+    def __call__(self, args):
+        self.calls += 1
+        index = min(self.calls - 1, len(self.snapshots) - 1)
+        return json.dumps(self.snapshots[index])
+
+
+class DysonXPRChecksGateTests(unittest.TestCase):
+    def wait(self, snapshots, timeout=60, poll=5):
+        clock = FakeClock()
+        runner = Runner(snapshots)
+        gate.wait_for_checks(
+            repo="owner/repo",
+            pr_number="12",
+            exclude_check_name=EXCLUDED,
+            timeout_seconds=timeout,
+            poll_seconds=poll,
+            runner=runner,
+            sleeper=clock.sleep,
+            clock=clock,
+        )
+        return runner.calls
+
+    def test_passes_when_all_checks_success_skipped_or_neutral(self):
+        calls = self.wait([[check("unit", "success"), check("docs", "skipped"), check("lint", "neutral")]])
+        self.assertEqual(calls, 1)
+
+    def test_fails_when_any_check_is_failure(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: failure"):
+            self.wait([[check("unit", "failure")]])
+
+    def test_fails_when_any_check_is_cancelled(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: cancelled"):
+            self.wait([[check("unit", "cancelled")]])
+
+    def test_fails_when_any_check_is_timed_out(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: timed_out"):
+            self.wait([[check("unit", "timed_out")]])
+
+    def test_fails_when_any_check_is_action_required(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "unit: action_required"):
+            self.wait([[check("unit", "action_required")]])
+
+    def test_pending_in_progress_and_queued_wait_until_terminal(self):
+        calls = self.wait(
+            [
+                [check("unit", None, state="QUEUED")],
+                [check("unit", None, state="IN_PROGRESS")],
+                [check("unit", "success", state="COMPLETED")],
+            ]
+        )
+        self.assertEqual(calls, 3)
+
+    def test_excluded_auto_merge_check_does_not_block(self):
+        calls = self.wait(
+            [
+                [
+                    check("Gate and auto-merge public Signals sync PRs", None, state="IN_PROGRESS", workflow="DysonX Public Signals Auto-Merge V1"),
+                    check("unit", "success"),
+                ]
+            ]
+        )
+        self.assertEqual(calls, 1)
+
+    def test_timeout_fails_with_clear_message(self):
+        with self.assertRaisesRegex(gate.PRChecksGateError, "timed out waiting for checks"):
+            self.wait([[check("unit", None, state="IN_PROGRESS")]], timeout=10, poll=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -1,0 +1,170 @@
+import json
+import pathlib
+import tempfile
+import unittest
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import dysonx_public_signals_auto_merge_gate as gate  # noqa: E402
+
+
+def forbidden_domain() -> str:
+    return "https://dysonx." + "ai"
+
+
+class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temp_dir.name)
+        self.signals = self.root / "signals"
+        self.slug = "critical-agent-signal"
+        (self.signals / self.slug).mkdir(parents=True)
+        (self.root / "index.html").write_text('<a href="/signals/">Signals</a>', encoding="utf-8")
+        (self.signals / "index.html").write_text(
+            f'<h1>Signals</h1><a href="/signals/{self.slug}/">Signal</a>',
+            encoding="utf-8",
+        )
+        (self.signals / self.slug / "index.html").write_text(
+            '<h1>Critical Agent Signal</h1><p>Summary-only public Signal.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a>',
+            encoding="utf-8",
+        )
+        self.manifest_path = self.signals / "public_launch_manifest.json"
+        self.changed_files_path = self.root / "changed_files.json"
+        self.write_manifest()
+        self.write_changed_files([f"signals/{self.slug}/index.html", "signals/index.html", "signals/public_launch_manifest.json"])
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def manifest(self, **entry_overrides):
+        entry = {
+            "signal_id": "sig_critical_agent",
+            "slug": self.slug,
+            "title": "Critical Agent Signal",
+            "public_path": f"signals/{self.slug}/index.html",
+            "public_url_path": f"/signals/{self.slug}/",
+            "source_name": "Example Source",
+            "source_url": "https://example.org/source",
+            "source_priority": "Critical",
+            "attribution_status": "Complete",
+            "copyright_status": "Safe Summary Only",
+            "quality_hint": 94,
+            "ready_for_pipeline": True,
+            "published": True,
+            "production_publish_performed": True,
+        }
+        entry.update(entry_overrides)
+        return {
+            "launch_version": "notion_public_signals_sync_v1",
+            "pages_launched": 1,
+            "pages_blocked": 0,
+            "launched": [entry],
+            "openai_call_performed": False,
+            "network_source_fetch_performed": False,
+            "manual_external_deployment_performed": False,
+        }
+
+    def write_manifest(self, **entry_overrides):
+        self.manifest_path.write_text(json.dumps(self.manifest(**entry_overrides), indent=2), encoding="utf-8")
+
+    def write_changed_files(self, files):
+        self.changed_files_path.write_text(json.dumps(files), encoding="utf-8")
+
+    def run_gate(self):
+        return gate.main(
+            [
+                "--manifest",
+                str(self.manifest_path),
+                "--changed-files-json",
+                str(self.changed_files_path),
+                "--min-quality",
+                "92",
+                "--required-priority",
+                "Critical",
+                "--require-attribution-complete",
+                "--require-safe-summary-only",
+            ]
+        )
+
+    def test_passes_for_critical_high_quality_complete_safe_summary_signal(self):
+        self.assertEqual(self.run_gate(), 0)
+
+    def test_fails_when_quality_below_threshold(self):
+        self.write_manifest(quality_hint=91)
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_source_priority_is_high_instead_of_critical(self):
+        self.write_manifest(source_priority="High")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_attribution_is_partial_or_missing(self):
+        for status in ("Partial", "Missing"):
+            with self.subTest(status=status):
+                self.write_manifest(attribution_status=status)
+                self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_copyright_status_is_not_safe_summary_only(self):
+        self.write_manifest(copyright_status="Unsafe")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_unknown_changed_file_path_exists(self):
+        self.write_changed_files([f"signals/{self.slug}/index.html", "index.html"])
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_raw_body_marker_appears(self):
+        (self.signals / self.slug / "index.html").write_text("full article text", encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_script_tag_appears(self):
+        (self.signals / self.slug / "index.html").write_text("<script>alert(1)</script>", encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_forbidden_terms_appear(self):
+        forbidden = [
+            "." + "invalid",
+            "." + "test/",
+            "media." + "energizeos.com",
+            forbidden_domain(),
+            "tmp/" + "production_publish_pack",
+        ]
+        for term in forbidden:
+            with self.subTest(term=term):
+                self.write_manifest(title=term)
+                self.assertNotEqual(self.run_gate(), 0)
+                self.write_manifest()
+
+    def test_fails_when_manifest_says_openai_call_performed_true(self):
+        data = self.manifest()
+        data["openai_call_performed"] = True
+        self.manifest_path.write_text(json.dumps(data), encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_manifest_says_network_source_fetch_performed_true(self):
+        data = self.manifest()
+        data["network_source_fetch_performed"] = True
+        self.manifest_path.write_text(json.dumps(data), encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_manifest_says_manual_external_deployment_performed_true(self):
+        data = self.manifest()
+        data["manual_external_deployment_performed"] = True
+        self.manifest_path.write_text(json.dumps(data), encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_passes_only_for_allowed_signals_paths(self):
+        allowed = [
+            "signals/index.html",
+            "signals/public_launch_manifest.json",
+            f"signals/{self.slug}/index.html",
+        ]
+        for path in allowed:
+            with self.subTest(path=path):
+                self.write_changed_files([path])
+                self.assertEqual(self.run_gate(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds DysonX Public Signals Auto-Merge V1 workflow.
- Adds strict deterministic auto-merge gate for Notion public Signals sync PRs.
- Updates public Signals sync manifests with gate metadata.
- Adds auto-merge candidate marker only after public sync validation passes.
- Documents emergency kill switch and gate rules.

## Auto-merge scope
- Auto-merge applies only to public Signals sync PRs.
- PR title must be exactly: content: sync DysonX public Signals from Notion.
- PR head branch must start with automation/dysonx-notion-signals-.
- PR body must contain AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1.
- PR must be same-repo, non-draft, and limited to signals/ public output paths.

## Safety gates
- Auto-merge is disabled unless DYSONX_PUBLIC_SIGNALS_AUTO_MERGE=true.
- Auto-merge requires Quality Hint >= 92.
- Auto-merge requires Critical source only.
- Auto-merge requires Attribution Status = Complete.
- Auto-merge requires Copyright Status = Safe Summary Only.
- Auto-merge requires GitHub checks green.
- Auto-merge rejects any file outside signals/.
- Auto-merge rejects hardcoded domains and unsafe markup.

## Safety confirmations
- No OpenAI call.
- No scraping.
- No raw body copying.
- No manual deployment.
- No Step 6.
- No tmp/ or .serena/ committed.

## Validation
- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 420 tests
- python3 scripts/dysonx_static_preview_check.py --root .: PASS
- git diff --check origin/main...HEAD: PASS
- Forbidden grep checks: PASS