### PR TITLE
fix: propagate DysonX source priority into public Signals pipeline

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -32,6 +32,34 @@ jobs:
       - name: Sync Notion public Signals
         run: python3 scripts/dysonx_notion_public_signals_sync.py --output-root .
 
+      - name: Print public Signals manifest diagnostics
+        if: always()
+        run: |
+          if [ -f signals/public_launch_manifest.json ]; then
+            python3 - <<'PY'
+            import json
+            from pathlib import Path
+
+            data = json.loads(Path("signals/public_launch_manifest.json").read_text(encoding="utf-8"))
+            print("pages_launched:", data.get("pages_launched"))
+            print("pages_blocked:", data.get("pages_blocked"))
+            PY
+          else
+            echo "[notion-public-signals-sync] public launch manifest was not created"
+          fi
+
+      - name: Print public Signals diff stat
+        if: always()
+        run: git diff --stat -- signals
+
+      - name: Upload public Signals manifest
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dysonx-public-signals-manifest
+          path: signals/public_launch_manifest.json
+          if-no-files-found: warn
+
       - name: Run static link integrity check
         run: python3 scripts/dysonx_static_preview_check.py --root .
 

--- a/.github/workflows/dysonx-source-collector-v1.yml
+++ b/.github/workflows/dysonx-source-collector-v1.yml
@@ -29,7 +29,34 @@ jobs:
           python-version: "3.11"
 
       - name: Run Source Collector V1
-        run: python3 scripts/dysonx_source_collector_v1.py
+        run: python3 scripts/dysonx_source_collector_v1.py --output-candidates tmp/dysonx_source_collector_v1_candidates.json
+
+      - name: Print Source Collector diagnostics
+        if: always()
+        run: |
+          if [ -f tmp/dysonx_source_collector_v1_candidates.json ]; then
+            python3 - <<'PY'
+            import json
+            from pathlib import Path
+
+            data = json.loads(Path("tmp/dysonx_source_collector_v1_candidates.json").read_text(encoding="utf-8"))
+            print("candidate_count:", data.get("candidate_count"))
+            print("duplicates_skipped:", data.get("duplicates_skipped"))
+            print("source_results:")
+            for item in data.get("source_results", []):
+                print(" -", item)
+            PY
+          else
+            echo "[source-collector-v1] candidate artifact was not created"
+          fi
+
+      - name: Upload Source Collector diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dysonx-source-collector-v1-candidates
+          path: tmp/dysonx_source_collector_v1_candidates.json
+          if-no-files-found: warn
 
       - name: Confirm no public static files changed
         run: |

--- a/docs/DYSONX_SIGNAL_INTAKE_SCHEMA_FIX_V1.md
+++ b/docs/DYSONX_SIGNAL_INTAKE_SCHEMA_FIX_V1.md
@@ -1,0 +1,47 @@
+# DysonX Signal Intake Schema Fix V1
+
+## Purpose
+
+DysonX public Signals automation now carries source priority from DysonX Sources into Signal Intake and then into the public launch manifest.
+
+This lets the Public Signals Auto-Merge Gate make deterministic decisions without reading Notion during merge.
+
+## Required Signal Intake Property
+
+Add this property to the DysonX Signal Intake database:
+
+```text
+Source Priority
+```
+
+Type:
+
+```text
+Select
+```
+
+Allowed options:
+
+- `Critical`
+- `High`
+- `Medium`
+- `Low`
+
+## Why This Is Required
+
+The auto-merge gate intentionally remains strict:
+
+- `Quality Hint >= 92`
+- `source_priority = Critical`
+- `Attribution Status = Complete`
+- `Copyright Status = Safe Summary Only`
+- `Ready for Pipeline = true`
+- `Published = true`
+
+Source Collector V1 reads source priority from DysonX Sources and includes it in generated Signal candidates. If Signal Intake supports `Source Priority`, the collector writes that select value. Public Signals Sync then copies the value into `signals/public_launch_manifest.json` as `source_priority`.
+
+Without this property, source-collected Signals may still appear in Signal Intake, but the public auto-merge gate cannot prove they are Critical-source Signals and will block automatic merge.
+
+## Safety Boundary
+
+This schema fix does not relax the auto-merge gate, lower quality thresholds, permit non-Critical auto-merge, call OpenAI, scrape source-page bodies, copy raw article bodies, dispatch workflows, or deploy.

--- a/scripts/dysonx_source_collector_v1.py
+++ b/scripts/dysonx_source_collector_v1.py
@@ -460,6 +460,7 @@ def candidate_from_item(item: SourceItem) -> dict[str, Any]:
         "Slug": slugify(item.title),
         "Source Name": item.source_name,
         "Source URL": source_url,
+        "Source Priority": item.priority,
         "Published Date": item.published_date,
         "Category": category_for(item),
         "AGI Relevance": ai_relevance_text(item),
@@ -564,9 +565,16 @@ class NotionClient:
     def create_signal_intake_row(self, candidate: dict[str, Any]) -> None:
         payload = {
             "parent": {"database_id": self.signal_intake_database_id},
-            "properties": notion_candidate_properties(candidate),
+            "properties": notion_candidate_properties(candidate, supported_properties=self.signal_intake_property_names()),
         }
         self.transport("https://api.notion.com/v1/pages", self.headers, payload, "POST")
+
+    def signal_intake_property_names(self) -> set[str]:
+        response = self.transport(f"https://api.notion.com/v1/databases/{self.signal_intake_database_id}", self.headers, None, "GET")
+        properties = response.get("properties")
+        if not isinstance(properties, dict):
+            return set()
+        return {str(name) for name in properties}
 
     def update_source_fetch_status(self, source: SourceRecord, fetched_at: str, success: bool, error: str = "") -> None:
         if not source.notion_page_id:
@@ -580,12 +588,12 @@ class NotionClient:
         self.transport(f"https://api.notion.com/v1/pages/{source.notion_page_id}", self.headers, {"properties": properties}, "PATCH")
 
 
-def notion_candidate_properties(candidate: dict[str, Any]) -> dict[str, Any]:
+def notion_candidate_properties(candidate: dict[str, Any], supported_properties: set[str] | None = None) -> dict[str, Any]:
     def rich(value: Any) -> dict[str, Any]:
         return {"rich_text": [{"text": {"content": normalize_text(value)[:1900]}}]}
 
     notes = normalize_text(candidate.get("Notes")) or f"Collector Version: {normalize_text(candidate.get('Collector Version') or 'source_collector_v1')}"
-    return {
+    properties = {
         "Signal Title": {"title": [{"text": {"content": normalize_text(candidate["Signal Title"])[:1900]}}]},
         "Source Name": rich(candidate["Source Name"]),
         "Source URL": {"url": normalize_text(candidate["Source URL"])},
@@ -604,6 +612,9 @@ def notion_candidate_properties(candidate: dict[str, Any]) -> dict[str, Any]:
         "Published": {"checkbox": bool(candidate["Published"])},
         "Notes": rich(notes),
     }
+    if supported_properties and "Source Priority" in supported_properties and normalize_text(candidate.get("Source Priority")):
+        properties["Source Priority"] = {"select": {"name": normalize_text(candidate["Source Priority"])}}
+    return properties
 
 
 def build_candidates(

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -123,6 +123,14 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertIs(entry["ready_for_pipeline"], True)
         self.assertIs(entry["published"], True)
 
+    def test_manifest_carries_source_priority_from_priority_fallback(self):
+        record = eligible_record(**{"Quality Hint": 94, "Priority": "Critical"})
+        del record["Source Priority"]
+        manifest = sync.sync_records([record], self.root)
+        entry = next(item for item in manifest["launched"] if item["slug"] == "notion-agent-reliability")
+
+        self.assertEqual(entry["source_priority"], "Critical")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -92,6 +92,10 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
     def test_passes_for_critical_high_quality_complete_safe_summary_signal(self):
         self.assertEqual(self.run_gate(), 0)
 
+    def test_critical_quality_at_least_92_complete_safe_summary_can_pass_gate(self):
+        self.write_manifest(source_priority="Critical", quality_hint=92, attribution_status="Complete", copyright_status="Safe Summary Only")
+        self.assertEqual(self.run_gate(), 0)
+
     def test_fails_when_quality_below_threshold(self):
         self.write_manifest(quality_hint=91)
         self.assertNotEqual(self.run_gate(), 0)

--- a/tests/test_dysonx_source_collector_v1.py
+++ b/tests/test_dysonx_source_collector_v1.py
@@ -43,6 +43,7 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         candidate = result["candidates"][0]
         self.assertEqual(candidate["Signal Title"], "Compute-aware evaluation for autonomous AI agents")
         self.assertEqual(candidate["Category"], "Research")
+        self.assertEqual(candidate["Source Priority"], "Critical")
 
     def test_relative_canonical_path_becomes_absolute_url(self):
         source = collector.SourceRecord(
@@ -286,6 +287,14 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         self.assertNotIn("Slug", properties)
         self.assertNotIn("Collector Version", properties)
         self.assertEqual(properties["Notes"]["rich_text"][0]["text"]["content"], "Collector Version: source_collector_v1")
+
+    def test_notion_writeback_includes_source_priority_when_schema_supports_it(self):
+        sources = [load_records("source_registry_sample.json")[1]]
+        result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
+        candidate = result["candidates"][0]
+        properties = collector.notion_candidate_properties(candidate, supported_properties={"Source Priority"})
+
+        self.assertEqual(properties["Source Priority"]["select"]["name"], "Critical")
 
     def test_notion_select_values_match_signal_intake_schema(self):
         sources = load_records("source_registry_sample.json")[:3]


### PR DESCRIPTION
## Summary
- Propagates Source Priority from Source Collector candidates into Signal Intake writeback when the Signal Intake schema supports the property.
- Keeps public Signals manifest source_priority populated from Source Priority / Priority.
- Adds scheduled workflow diagnostics and artifacts for Source Collector and Public Signals Sync visibility.
- Documents the Signal Intake Source Priority schema fix.

## Safety
- Auto-merge gate was not relaxed.
- Quality Hint threshold was not lowered.
- Non-Critical auto-merge remains blocked.
- No OpenAI call.
- No scraping.
- No raw body copying.
- No deployment.
- No workflow dispatch.

## Validation
- python3 scripts/constitution_guard.py: PASS
- python3 scripts/architecture_guard.py: PASS
- python3 scripts/release_guard.py: PASS
- python3 -m py_compile scripts/*.py: PASS
- python3 -m unittest discover -s tests: PASS, 432 tests
- python3 scripts/dysonx_static_preview_check.py --root .: PASS
- git diff --check: PASS