### PR TITLE
fix: unblock DysonX public Signals sync visibility

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -3,6 +3,9 @@ name: DysonX Notion Public Signals Sync
 on:
   schedule:
     - cron: "0 */6 * * *"
+  workflow_run:
+    workflows: ["DysonX Source Collector V1"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -14,6 +17,7 @@ jobs:
     name: Sync public Signals from Notion
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
 
     env:
       NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
@@ -30,9 +34,9 @@ jobs:
           python-version: "3.11"
 
       - name: Sync Notion public Signals
-        run: python3 scripts/dysonx_notion_public_signals_sync.py --output-root .
+        run: python3 scripts/dysonx_notion_public_signals_sync.py --output-root . --output-report tmp/dysonx_public_signals_sync_report.json
 
-      - name: Print public Signals manifest diagnostics
+      - name: Print public Signals sync diagnostics
         if: always()
         run: |
           if [ -f signals/public_launch_manifest.json ]; then
@@ -47,17 +51,24 @@ jobs:
           else
             echo "[notion-public-signals-sync] public launch manifest was not created"
           fi
+          if [ -f tmp/dysonx_public_signals_sync_report.json ]; then
+            python3 -m json.tool tmp/dysonx_public_signals_sync_report.json
+          else
+            echo "[notion-public-signals-sync] sync report was not created"
+          fi
 
       - name: Print public Signals diff stat
         if: always()
         run: git diff --stat -- signals
 
-      - name: Upload public Signals manifest
+      - name: Upload public Signals diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: dysonx-public-signals-manifest
-          path: signals/public_launch_manifest.json
+          name: dysonx-public-signals-diagnostics
+          path: |
+            signals/public_launch_manifest.json
+            tmp/dysonx_public_signals_sync_report.json
           if-no-files-found: warn
 
       - name: Run static link integrity check
@@ -77,25 +88,20 @@ jobs:
         run: |
           python3 - <<'PY'
           import json
+          import subprocess
           from pathlib import Path
+          import sys
+
+          sys.path.insert(0, "scripts")
+          import dysonx_notion_public_signals_sync as sync
 
           marker = Path("auto_merge_marker.txt")
           manifest_path = Path("signals/public_launch_manifest.json")
-          required = {
-              "source_name",
-              "source_url",
-              "source_priority",
-              "attribution_status",
-              "copyright_status",
-              "quality_hint",
-              "ready_for_pipeline",
-              "published",
-          }
           eligible = False
           if manifest_path.exists():
               data = json.loads(manifest_path.read_text(encoding="utf-8"))
-              launched = data.get("launched", [])
-              eligible = bool(launched) and all(isinstance(item, dict) and required <= set(item) for item in launched)
+              changed_files = subprocess.check_output(["git", "diff", "--name-only", "--", "signals"], text=True).splitlines()
+              eligible = sync.auto_merge_marker_eligible(data, changed_files)
           marker.write_text("AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1\n" if eligible else "", encoding="utf-8")
           print(f"eligible={str(eligible).lower()}")
           PY

--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -258,6 +258,68 @@ def eligible_record(record: dict[str, Any]) -> bool:
     return not eligibility_blockers(record)
 
 
+def build_sync_report(records: list[dict[str, Any]], existing_slugs: list[str], eligible: list[dict[str, Any]]) -> dict[str, Any]:
+    blocked: list[dict[str, Any]] = []
+    for record in records:
+        reasons = eligibility_blockers(record)
+        if reasons:
+            blocked.append(
+                {
+                    "title": signal_title(record) or "(untitled)",
+                    "slug": signal_slug(record),
+                    "reasons": reasons,
+                    "source_priority": source_priority(record),
+                    "quality_hint": int(quality_hint(record)),
+                    "ready_for_pipeline": field(record, "Ready for Pipeline", "ready_for_pipeline") is True,
+                    "published": field(record, "Published", "published") is True,
+                }
+            )
+    eligible_slugs = sorted({record["slug"] for record in eligible})
+    existing_slug_set = set(existing_slugs)
+    return {
+        "sync_version": SYNC_VERSION,
+        "total_notion_rows": len(records),
+        "eligible_public_rows": len(eligible),
+        "blocked_rows": len(blocked),
+        "blocked_reasons_by_title": {item["title"]: item["reasons"] for item in blocked},
+        "blocked": blocked,
+        "new_slugs": [slug for slug in eligible_slugs if slug not in existing_slug_set],
+        "existing_slugs": sorted(existing_slug_set),
+    }
+
+
+def auto_merge_entry_eligible(entry: dict[str, Any]) -> bool:
+    try:
+        quality = float(entry.get("quality_hint"))
+    except (TypeError, ValueError):
+        quality = 0.0
+    return (
+        entry.get("source_priority") == "Critical"
+        and quality >= 92
+        and entry.get("attribution_status") == "Complete"
+        and entry.get("copyright_status") == "Safe Summary Only"
+        and entry.get("ready_for_pipeline") is True
+        and entry.get("published") is True
+    )
+
+
+def changed_signal_slugs(changed_files: list[str]) -> set[str]:
+    slugs: set[str] = set()
+    for path in changed_files:
+        match = re.fullmatch(r"signals/([^/]+)/index\.html", path)
+        if match and match.group(1) != "index":
+            slugs.add(match.group(1))
+    return slugs
+
+
+def auto_merge_marker_eligible(manifest: dict[str, Any], changed_files: list[str]) -> bool:
+    slugs = changed_signal_slugs(changed_files)
+    if not slugs:
+        return False
+    entries = {entry.get("slug"): entry for entry in manifest.get("launched", []) if isinstance(entry, dict)}
+    return all(slug in entries and auto_merge_entry_eligible(entries[slug]) for slug in slugs)
+
+
 class ExistingSignalParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
@@ -505,15 +567,23 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
     }
 
 
-def sync_records(records: list[dict[str, Any]], output_root: pathlib.Path = DEFAULT_OUTPUT_ROOT, refreshed_at: str | None = None) -> dict[str, Any]:
+def sync_records(
+    records: list[dict[str, Any]],
+    output_root: pathlib.Path = DEFAULT_OUTPUT_ROOT,
+    refreshed_at: str | None = None,
+    output_report: pathlib.Path | None = None,
+) -> dict[str, Any]:
     refreshed_at = refreshed_at or utc_now()
     output_root = output_root.resolve()
     signals_root = output_root / "signals"
     signals_root.mkdir(parents=True, exist_ok=True)
 
+    existing = existing_public_signals(output_root)
+    existing_slugs = [record["slug"] for record in existing]
     eligible = [record_from_notion(record) for record in records if eligible_record(record)]
     blocked_count = len(records) - len(eligible)
-    by_slug = {record["slug"]: record for record in existing_public_signals(output_root)}
+    report = build_sync_report(records, existing_slugs, eligible)
+    by_slug = {record["slug"]: record for record in existing}
     for record in eligible:
         by_slug[record["slug"]] = record
     merged = sorted(by_slug.values(), key=lambda item: (item.get("existing", False), item["title"].lower()))
@@ -535,6 +605,11 @@ def sync_records(records: list[dict[str, Any]], output_root: pathlib.Path = DEFA
     manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
     assert_public_safe(manifest_text, "public launch manifest")
     (signals_root / "public_launch_manifest.json").write_text(manifest_text, encoding="utf-8")
+    if output_report:
+        output_report.parent.mkdir(parents=True, exist_ok=True)
+        report_text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+        assert_public_safe(report_text, "public Signals sync report")
+        output_report.write_text(report_text, encoding="utf-8")
     return manifest
 
 
@@ -542,6 +617,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Sync Notion-approved DysonX public Signals into static pages.")
     parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT), help="Repository/public output root.")
     parser.add_argument("--fixture-json", help="Optional local Notion-shaped fixture JSON for offline validation.")
+    parser.add_argument("--output-report", help="Optional JSON diagnostics report path.")
     return parser.parse_args(argv)
 
 
@@ -567,7 +643,11 @@ def main(argv: list[str] | None = None) -> int:
                 raise NotionPublicSignalsSyncError(f"Missing required environment variables: {', '.join(missing)}")
             assert token is not None and database_id is not None
             records = query_notion_records(token, database_id)
-        manifest = sync_records(records, pathlib.Path(args.output_root))
+        manifest = sync_records(
+            records,
+            pathlib.Path(args.output_root),
+            output_report=pathlib.Path(args.output_report) if args.output_report else None,
+        )
     except (OSError, json.JSONDecodeError, NotionPublicSignalsSyncError) as exc:
         print(f"[notion-public-signals-sync] failed: {exc}", file=sys.stderr)
         return 2

--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -196,7 +196,7 @@ def source_url(record: dict[str, Any]) -> str:
 
 
 def source_label(record: dict[str, Any]) -> str:
-    return normalize_text(field(record, "Source Label", "Source", "source_label")) or "Source"
+    return normalize_text(field(record, "Source Label", "Source Name", "Source", "source_label", "source_name")) or "Source"
 
 
 def source_priority(record: dict[str, Any]) -> str:

--- a/scripts/dysonx_source_collector_v1.py
+++ b/scripts/dysonx_source_collector_v1.py
@@ -32,7 +32,6 @@ SIGNAL_INTAKE_DATABASE_ENV = "NOTION_SIGNAL_INTAKE_DATABASE_ID"
 NOTION_VERSION = "2022-06-28"
 SUPPORTED_SOURCE_TYPES = {"rss", "atom", "feed", "arxiv", "official website", "website", "government", "policy", "manual"}
 ALLOWED_PRIORITIES = {"Critical", "High", "Medium"}
-AUTO_PUBLISH_PRIORITIES = {"Critical", "High"}
 COPYRIGHT_STATUS = "Safe Summary Only"
 ATTRIBUTION_STATUS = "Complete"
 OPENAI_CALL_PERFORMED = False
@@ -439,14 +438,14 @@ def safe_summary_only(item: SourceItem) -> str:
 
 def can_auto_publish(item: SourceItem, candidate: dict[str, Any]) -> bool:
     return (
-        item.priority in AUTO_PUBLISH_PRIORITIES
+        item.priority == "Critical"
         and item.authority_score >= 85
         and item.attribution_complete
         and bool(absolute_http_url(item.link))
         and len(candidate["Summary"]) <= 260
         and candidate["Copyright Status"] == COPYRIGHT_STATUS
         and candidate["AGI Relevance"] != "Low"
-        and candidate["Quality Hint"] >= 85
+        and candidate["Quality Hint"] >= 92
         and "raw" not in json.dumps(candidate).lower()
     )
 

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -131,6 +131,16 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
 
         self.assertEqual(entry["source_priority"], "Critical")
 
+    def test_source_name_is_used_when_source_label_is_missing(self):
+        record = eligible_record(**{"Source Name": "arXiv cs.CV RSS", "Quality Hint": 94})
+        del record["Source Label"]
+        manifest = sync.sync_records([record], self.root)
+        entry = next(item for item in manifest["launched"] if item["slug"] == "notion-agent-reliability")
+        page = (self.root / "signals" / "notion-agent-reliability" / "index.html").read_text(encoding="utf-8")
+
+        self.assertEqual(entry["source_name"], "arXiv cs.CV RSS")
+        self.assertIn(">arXiv cs.CV RSS</a>", page)
+
     def test_sync_report_includes_blocked_reasons(self):
         report_path = self.root / "tmp" / "dysonx_public_signals_sync_report.json"
         sync.sync_records(

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -131,6 +131,85 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
 
         self.assertEqual(entry["source_priority"], "Critical")
 
+    def test_sync_report_includes_blocked_reasons(self):
+        report_path = self.root / "tmp" / "dysonx_public_signals_sync_report.json"
+        sync.sync_records(
+            [
+                eligible_record(),
+                eligible_record(
+                    **{
+                        "Signal Title": "Blocked missing attribution Signal",
+                        "Slug": "blocked-missing-attribution",
+                        "Attribution Status": "Missing",
+                    }
+                ),
+            ],
+            self.root,
+            output_report=report_path,
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(report["total_notion_rows"], 2)
+        self.assertEqual(report["eligible_public_rows"], 1)
+        self.assertEqual(report["blocked_rows"], 1)
+        self.assertIn("Blocked missing attribution Signal", report["blocked_reasons_by_title"])
+        self.assertIn("attribution_not_complete", report["blocked_reasons_by_title"]["Blocked missing attribution Signal"])
+        self.assertIn("notion-agent-reliability", report["new_slugs"])
+
+    def test_auto_merge_marker_absent_for_changed_non_critical_or_quality_below_92(self):
+        manifest = sync.sync_records(
+            [
+                eligible_record(**{"Source Priority": "High", "Quality Hint": 94}),
+                eligible_record(
+                    **{
+                        "Signal ID": "sig_low_quality",
+                        "Signal Title": "Critical but low quality Signal",
+                        "Slug": "critical-low-quality",
+                        "Quality Hint": 88,
+                    }
+                ),
+            ],
+            self.root,
+        )
+
+        self.assertFalse(sync.auto_merge_marker_eligible(manifest, ["signals/notion-agent-reliability/index.html"]))
+        self.assertFalse(sync.auto_merge_marker_eligible(manifest, ["signals/critical-low-quality/index.html"]))
+
+    def test_auto_merge_marker_present_only_when_all_changed_signals_are_critical_quality_92(self):
+        manifest = sync.sync_records(
+            [
+                eligible_record(**{"Quality Hint": 92}),
+                eligible_record(
+                    **{
+                        "Signal ID": "sig_second_critical",
+                        "Signal Title": "Second Critical Signal",
+                        "Slug": "second-critical-signal",
+                        "Quality Hint": 94,
+                    }
+                ),
+            ],
+            self.root,
+        )
+
+        self.assertTrue(
+            sync.auto_merge_marker_eligible(
+                manifest,
+                [
+                    "signals/notion-agent-reliability/index.html",
+                    "signals/second-critical-signal/index.html",
+                    "signals/index.html",
+                    "signals/public_launch_manifest.json",
+                ],
+            )
+        )
+
+    def test_public_manifest_still_carries_source_priority(self):
+        sync.sync_records([eligible_record(**{"Quality Hint": 94})], self.root)
+        manifest = json.loads((self.root / "signals" / "public_launch_manifest.json").read_text(encoding="utf-8"))
+        entry = next(item for item in manifest["launched"] if item["slug"] == "notion-agent-reliability")
+
+        self.assertEqual(entry["source_priority"], "Critical")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dysonx_source_collector_v1.py
+++ b/tests/test_dysonx_source_collector_v1.py
@@ -189,7 +189,27 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         self.assertNotIn("Agent evaluation benchmark improves reliability scoring", titles)
         self.assertGreaterEqual(result["duplicates_skipped"], 1)
 
-    def test_high_authority_ai_relevant_source_can_auto_publish(self):
+    def test_high_priority_quality_88_is_created_but_not_published(self):
+        item = collector.SourceItem(
+            title="AI driving scenario complexity detection via joint embedding predictive architecture",
+            link="https://example.org/zero-label-driving-scenario-complexity",
+            published_date="2026-06-30",
+            summary="A research paper metadata summary about AI driving scenario complexity detection.",
+            source_name="arXiv cs.CV RSS",
+            source_url="https://export.arxiv.org/rss/cs.CV",
+            source_type="arXiv",
+            priority="High",
+            authority_score=88,
+            attribution_complete=True,
+        )
+        candidate = collector.candidate_from_item(item)
+
+        self.assertEqual(candidate["Source Priority"], "High")
+        self.assertEqual(candidate["Quality Hint"], 88)
+        self.assertFalse(candidate["Ready for Pipeline"])
+        self.assertFalse(candidate["Published"])
+
+    def test_critical_quality_at_least_92_is_published_and_ready(self):
         sources = [load_records("source_registry_sample.json")[1]]
         result = collector.build_candidates(sources, [], fetch=self.fixture_fetch)
         candidate = result["candidates"][0]
@@ -197,7 +217,8 @@ class DysonXSourceCollectorV1Tests(unittest.TestCase):
         self.assertTrue(candidate["Ready for Pipeline"])
         self.assertTrue(candidate["Published"])
         self.assertEqual(candidate["Status"], "Ready for Quality Audit")
-        self.assertGreaterEqual(candidate["Quality Hint"], 85)
+        self.assertEqual(candidate["Source Priority"], "Critical")
+        self.assertGreaterEqual(candidate["Quality Hint"], 92)
 
     def test_generated_candidate_has_safe_summary_only_copyright_status(self):
         sources = [load_records("source_registry_sample.json")[0]]


### PR DESCRIPTION
Purpose: Fix the Notion-to-public Signals sync visibility path without relaxing DysonX safety gates.

Scope:
- Align Source Collector auto-publish with the strict Auto-Merge Gate: Critical only, Quality Hint >= 92, attribution Complete, copyright Safe Summary Only.
- Keep High / Medium rows eligible for Signal Intake creation but not automatic Published marking.
- Add deterministic public sync diagnostics and report output at tmp/dysonx_public_signals_sync_report.json.
- Split manual public sync eligibility from auto-merge marker eligibility by evaluating only changed Signal slugs against Critical + Quality Hint >= 92 and required safety fields.
- Trigger public sync after successful DysonX Source Collector V1 workflow completion while keeping the existing schedule.

Required confirmations:
- Source Collector auto-publish is now aligned with Auto-Merge Gate.
- High / Quality 88 rows are no longer auto-Published.
- Public sync now emits diagnostics/report artifacts.
- Auto-merge marker only appears for Critical + Quality >= 92 changed Signals.
- Auto-merge gate was not relaxed.
- No OpenAI call.
- No scraping.
- No raw body copying.
- No deployment.
- No workflow dispatch.

Constitution compliance:
- Preserves Signal-first design.
- Preserves English-default / Chinese-switchable architecture.
- Keeps Notion as the managed source of truth.
- Strengthens publishing quality gates and auditability.
- Does not create generic news/blog/RSS behavior or thin SEO content.

Tests run:
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check

Architecture impact: Improves observability and makes automation gating stricter and more deterministic. No production data, deployment, secrets, or schema changes.

Rollback notes: Revert this PR to restore prior collector auto-publish and public sync workflow behavior.

Known limitations: Existing polluted Notion rows remain in Notion for manual review/cleanup; this PR prevents new High/88 auto-published pollution and reports blocked sync reasons.

No merge or production deployment was performed.