### PR TITLE
fix: repair DysonX public Signals sync workflow diagnostics

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -40,14 +40,7 @@ jobs:
         if: always()
         run: |
           if [ -f signals/public_launch_manifest.json ]; then
-            python3 - <<'PY'
-            import json
-            from pathlib import Path
-
-            data = json.loads(Path("signals/public_launch_manifest.json").read_text(encoding="utf-8"))
-            print("pages_launched:", data.get("pages_launched"))
-            print("pages_blocked:", data.get("pages_blocked"))
-            PY
+            python3 -c 'import json; from pathlib import Path; data = json.loads(Path("signals/public_launch_manifest.json").read_text(encoding="utf-8")); print("pages_launched:", data.get("pages_launched")); print("pages_blocked:", data.get("pages_blocked"))'
           else
             echo "[notion-public-signals-sync] public launch manifest was not created"
           fi
@@ -86,25 +79,7 @@ jobs:
       - name: Check auto-merge marker eligibility
         id: auto_merge_marker
         run: |
-          python3 - <<'PY'
-          import json
-          import subprocess
-          from pathlib import Path
-          import sys
-
-          sys.path.insert(0, "scripts")
-          import dysonx_notion_public_signals_sync as sync
-
-          marker = Path("auto_merge_marker.txt")
-          manifest_path = Path("signals/public_launch_manifest.json")
-          eligible = False
-          if manifest_path.exists():
-              data = json.loads(manifest_path.read_text(encoding="utf-8"))
-              changed_files = subprocess.check_output(["git", "diff", "--name-only", "--", "signals"], text=True).splitlines()
-              eligible = sync.auto_merge_marker_eligible(data, changed_files)
-          marker.write_text("AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1\n" if eligible else "", encoding="utf-8")
-          print(f"eligible={str(eligible).lower()}")
-          PY
+          python3 -c 'import json, subprocess, sys; from pathlib import Path; sys.path.insert(0, "scripts"); import dysonx_notion_public_signals_sync as sync; marker = Path("auto_merge_marker.txt"); manifest_path = Path("signals/public_launch_manifest.json"); eligible = False; data = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else None; changed_files = subprocess.check_output(["git", "diff", "--name-only", "--", "signals"], text=True).splitlines() if data is not None else []; eligible = sync.auto_merge_marker_eligible(data, changed_files) if data is not None else False; marker.write_text("AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1\n" if eligible else "", encoding="utf-8"); print(f"eligible={str(eligible).lower()}")'
 
       - name: Detect public Signals changes
         id: signals_changes


### PR DESCRIPTION
Purpose: Fix the DysonX Notion Public Signals Sync workflow failure caused by indented bash heredoc delimiters in YAML run blocks.

Scope:
- Only .github/workflows/dysonx-notion-public-signals-sync.yml changed.
- Replaced heredoc Python snippets with indentation-safe python3 -c commands.
- Kept diagnostics output for pages_launched, pages_blocked, and pretty-printed tmp/dysonx_public_signals_sync_report.json.
- Preserved auto-merge marker behavior: read signals/public_launch_manifest.json, compute git diff changed Signal files, import scripts/dysonx_notion_public_signals_sync.py, and write AUTO_MERGE_CANDIDATE only when sync.auto_merge_marker_eligible(...) returns true.

Required confirmations:
- Fixes heredoc indentation failure.
- Only workflow file changed.
- Public sync logic unchanged.
- Auto-merge gate unchanged.
- No workflow dispatch.
- No deployment.
- No OpenAI call.
- No scraping.
- No raw body copying.

Constitution compliance:
- Preserves Signal-first design.
- Preserves Notion-managed source workflow.
- Does not change content, source lists, quality gates, or publishing criteria.
- Does not create generic news/blog/RSS behavior.

Validation:
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check
- YAML syntax validated locally with python3 yaml.safe_load

Architecture impact: Workflow execution robustness only. Public sync logic and auto-merge policy are unchanged.

Rollback notes: Revert this PR to restore the prior heredoc-based workflow snippets.

Known limitations: This PR does not dispatch the workflow or modify generated signals content.

No merge or production deployment was performed.