### PR TITLE
fix: tighten DysonX public Signals eligibility

### DIFF
--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -24,6 +24,26 @@ DATABASE_ID_ENV = "NOTION_SIGNAL_INTAKE_DATABASE_ID"
 NOTION_VERSION = "2022-06-28"
 DEFAULT_OUTPUT_ROOT = pathlib.Path(".")
 PUBLIC_SAFE_SOURCE_NOTE = "Source attribution retained in Notion launch metadata; external source URL omitted for this V1 public sample."
+PUBLIC_OUTPUT_MIN_QUALITY = 92
+PUBLIC_OUTPUT_REQUIRED_PRIORITY = "Critical"
+PUBLIC_OUTPUT_ALLOWED_AGI_RELEVANCE = {"High", "Critical"}
+OFF_TOPIC_PUBLIC_TERMS = (
+    "biology",
+    "biomedical",
+    "cattle",
+    "dairy",
+    "eclipse",
+    "eclipses",
+    "general news",
+    "general science",
+    "methane",
+    "medicine",
+    "oceanography",
+    "poetry",
+    "politics",
+    "robot vacuum",
+    "vacuum cleaner",
+)
 FORBIDDEN_PUBLIC_TERMS = (
     "." "invalid",
     "." "test/",
@@ -211,6 +231,10 @@ def copyright_status(record: dict[str, Any]) -> str:
     return normalize_text(field(record, "Copyright Status", "copyright_status"))
 
 
+def agi_relevance(record: dict[str, Any]) -> str:
+    return normalize_text(field(record, "AGI Relevance", "agi_relevance"))
+
+
 def tags(record: dict[str, Any]) -> list[str]:
     value = field(record, "Tags", "Tag", "Categories", "Category")
     return [normalize_text(item) for item in as_list(value) if normalize_text(item)]
@@ -230,18 +254,35 @@ def is_safe_source_url(url: str) -> bool:
     return not any(term in lowered for term in FORBIDDEN_PUBLIC_TERMS)
 
 
+def off_topic_public_signal(record: dict[str, Any]) -> bool:
+    haystack = " ".join(
+        [
+            signal_title(record),
+            normalize_text(field(record, "Category", "Categories", "Tag", "Tags")),
+            source_label(record),
+        ]
+    ).lower()
+    return any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS)
+
+
 def eligibility_blockers(record: dict[str, Any]) -> list[str]:
     blockers: list[str] = []
     if field(record, "Ready for Pipeline", "ready_for_pipeline") is not True:
-        blockers.append("ready_for_pipeline_not_checked")
+        blockers.append("not_ready_for_pipeline")
     if field(record, "Published", "published") is not True:
-        blockers.append("published_not_checked")
+        blockers.append("not_published")
+    if source_priority(record) != PUBLIC_OUTPUT_REQUIRED_PRIORITY:
+        blockers.append("source_priority_not_critical")
     if attribution_status(record) != "Complete":
-        blockers.append("attribution_not_complete")
+        blockers.append("attribution_incomplete")
     if copyright_status(record) != "Safe Summary Only":
         blockers.append("copyright_not_safe_summary_only")
-    if quality_hint(record) < 80:
-        blockers.append("quality_hint_below_80")
+    if quality_hint(record) < PUBLIC_OUTPUT_MIN_QUALITY:
+        blockers.append("quality_hint_below_92")
+    if agi_relevance(record) not in PUBLIC_OUTPUT_ALLOWED_AGI_RELEVANCE:
+        blockers.append("agi_relevance_not_high_or_critical")
+    if off_topic_public_signal(record):
+        blockers.append("off_topic_public_signal")
     if not signal_title(record):
         blockers.append("missing_signal_title")
     if not signal_summary(record):
@@ -583,7 +624,8 @@ def sync_records(
     eligible = [record_from_notion(record) for record in records if eligible_record(record)]
     blocked_count = len(records) - len(eligible)
     report = build_sync_report(records, existing_slugs, eligible)
-    by_slug = {record["slug"]: record for record in existing}
+    eligible_slugs = {record["slug"] for record in eligible}
+    by_slug = {record["slug"]: record for record in existing if record["slug"] in eligible_slugs}
     for record in eligible:
         by_slug[record["slug"]] = record
     merged = sorted(by_slug.values(), key=lambda item: (item.get("existing", False), item["title"].lower()))

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -19,7 +19,7 @@ def eligible_record(**overrides):
         "Slug": "notion-agent-reliability",
         "Summary": "A Notion-approved summary-only Signal about agent reliability evaluation.",
         "Why This Matters": "Agent reliability metrics affect whether agentic systems can be trusted for longer tasks.",
-        "AGI Relevance": "Agents and evaluation",
+        "AGI Relevance": "High",
         "Source URL": "https://example.org/agent-reliability",
         "Source Label": "Example Research Source",
         "Source Priority": "Critical",
@@ -27,7 +27,7 @@ def eligible_record(**overrides):
         "Published": True,
         "Attribution Status": "Complete",
         "Copyright Status": "Safe Summary Only",
-        "Quality Hint": 91,
+        "Quality Hint": 92,
         "Risk Notes": "Summary-only treatment.",
         "Watch Next": "Watch whether this metric appears in standard agent evaluations.",
         "Tags": ["Agents", "Evaluation"],
@@ -131,6 +131,81 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
 
         self.assertEqual(entry["source_priority"], "Critical")
 
+    def test_critical_quality_92_agi_high_safe_fields_is_eligible(self):
+        manifest = sync.sync_records([eligible_record(**{"Quality Hint": 92, "AGI Relevance": "High"})], self.root)
+
+        self.assertTrue((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 0)
+        entry = next(item for item in manifest["launched"] if item["slug"] == "notion-agent-reliability")
+        self.assertEqual(entry["source_priority"], "Critical")
+        self.assertEqual(entry["quality_hint"], 92)
+
+    def test_high_priority_quality_95_is_blocked_from_public_output(self):
+        manifest = sync.sync_records([eligible_record(**{"Source Priority": "High", "Quality Hint": 95})], self.root)
+
+        self.assertFalse((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_critical_quality_88_is_blocked_from_public_output(self):
+        manifest = sync.sync_records([eligible_record(**{"Quality Hint": 88})], self.root)
+
+        self.assertFalse((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_critical_quality_95_agi_medium_is_blocked_from_public_output(self):
+        manifest = sync.sync_records([eligible_record(**{"Quality Hint": 95, "AGI Relevance": "Medium"})], self.root)
+
+        self.assertFalse((self.root / "signals" / "notion-agent-reliability" / "index.html").exists())
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_published_polluted_rows_are_blocked_unless_all_strict_public_rules_pass(self):
+        records = [
+            eligible_record(
+                **{
+                    "Signal ID": "sig_general_science",
+                    "Signal Title": "General science RSS page about oceanography and eclipses",
+                    "Slug": "general-science-oceanography-eclipses",
+                    "Source Priority": "Critical",
+                    "Quality Hint": 95,
+                    "AGI Relevance": "High",
+                    "Category": "General Science",
+                }
+            ),
+            eligible_record(
+                **{
+                    "Signal ID": "sig_robot_vacuum",
+                    "Signal Title": "Robot vacuum product roundup",
+                    "Slug": "robot-vacuum-product-roundup",
+                    "Source Priority": "Critical",
+                    "Quality Hint": 95,
+                    "AGI Relevance": "High",
+                }
+            ),
+            eligible_record(
+                **{
+                    "Signal ID": "sig_valid",
+                    "Signal Title": "Critical AGI agent reliability Signal",
+                    "Slug": "critical-agi-agent-reliability",
+                    "Source Priority": "Critical",
+                    "Quality Hint": 95,
+                    "AGI Relevance": "Critical",
+                }
+            ),
+        ]
+        manifest = sync.sync_records(records, self.root)
+
+        launched_slugs = {item["slug"] for item in manifest["launched"]}
+        self.assertNotIn("general-science-oceanography-eclipses", launched_slugs)
+        self.assertNotIn("robot-vacuum-product-roundup", launched_slugs)
+        self.assertIn("critical-agi-agent-reliability", launched_slugs)
+        self.assertEqual(manifest["pages_blocked"], 2)
+
+    def test_existing_public_signals_are_not_preserved_without_current_strict_eligible_row(self):
+        manifest = sync.sync_records([], self.root)
+
+        self.assertEqual(manifest["pages_launched"], 0)
+        self.assertEqual(manifest["launched"], [])
+
     def test_source_name_is_used_when_source_label_is_missing(self):
         record = eligible_record(**{"Source Name": "arXiv cs.CV RSS", "Quality Hint": 94})
         del record["Source Label"]
@@ -163,8 +238,36 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertEqual(report["eligible_public_rows"], 1)
         self.assertEqual(report["blocked_rows"], 1)
         self.assertIn("Blocked missing attribution Signal", report["blocked_reasons_by_title"])
-        self.assertIn("attribution_not_complete", report["blocked_reasons_by_title"]["Blocked missing attribution Signal"])
+        self.assertIn("attribution_incomplete", report["blocked_reasons_by_title"]["Blocked missing attribution Signal"])
         self.assertIn("notion-agent-reliability", report["new_slugs"])
+
+    def test_sync_report_includes_strict_public_blocked_reasons(self):
+        report_path = self.root / "tmp" / "dysonx_public_signals_sync_report.json"
+        sync.sync_records(
+            [
+                eligible_record(
+                    **{
+                        "Signal Title": "Blocked loose public Signal",
+                        "Slug": "blocked-loose-public-signal",
+                        "Source Priority": "High",
+                        "Quality Hint": 88,
+                        "AGI Relevance": "Medium",
+                        "Ready for Pipeline": False,
+                        "Published": False,
+                    }
+                )
+            ],
+            self.root,
+            output_report=report_path,
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+        reasons = report["blocked_reasons_by_title"]["Blocked loose public Signal"]
+
+        self.assertIn("source_priority_not_critical", reasons)
+        self.assertIn("quality_hint_below_92", reasons)
+        self.assertIn("agi_relevance_not_high_or_critical", reasons)
+        self.assertIn("not_ready_for_pipeline", reasons)
+        self.assertIn("not_published", reasons)
 
     def test_auto_merge_marker_absent_for_changed_non_critical_or_quality_below_92(self):
         manifest = sync.sync_records(


### PR DESCRIPTION
Purpose: Tighten DysonX Notion public Signals output eligibility so polluted historical Published rows do not enter the public static output.

Scope:
- Modified scripts/dysonx_notion_public_signals_sync.py.
- Modified tests/test_dysonx_notion_public_signals_sync.py.
- No generated signals content changed.
- No workflows changed.
- PR #89 branch was not touched.

Behavior changes:
- Public output now requires Source Priority = Critical.
- Public output now requires Quality Hint >= 92.
- Public output now requires AGI Relevance = High or Critical.
- Public output still requires Attribution Status = Complete, Copyright Status = Safe Summary Only, Ready for Pipeline = true, and Published = true.
- High priority rows no longer enter public output even if Published.
- Medium AGI relevance rows no longer enter public output.
- Published polluted rows such as general science/news, medicine/biology, robot vacuum, dairy methane, poetry/eclipses, politics/oceanography are blocked by strict public eligibility.
- Existing public static pages are not carried into the public manifest/index unless a current Notion row for that slug passes strict eligibility.
- Blocked diagnostics now include strict reasons such as source_priority_not_critical, quality_hint_below_92, agi_relevance_not_high_or_critical, not_published, not_ready_for_pipeline, attribution_incomplete, and copyright_not_safe_summary_only.

Required confirmations:
- Public output now requires Critical + Quality >= 92 + AGI High/Critical.
- High priority rows no longer enter public output even if Published.
- Medium AGI relevance rows no longer enter public output.
- Auto-merge gate unchanged.
- No workflow dispatch.
- No deployment.
- No OpenAI call.
- No scraping.
- No raw body copying.

Validation:
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check

Architecture impact: Strengthens public publishing quality gates and keeps the public surface aligned with DysonX Signal-first intelligence positioning. No production data, deployment, secrets, workflows, or generated public content were modified.

Rollback notes: Revert this PR to restore the previous looser public sync eligibility behavior.

Known limitations: The off-topic filter is deterministic and intentionally conservative for the polluted categories observed in PR #89; deeper semantic cleanup remains a future LLM/quality-review concern.

No merge or production deployment was performed.