### PR TITLE
fix: strengthen DysonX public Signals topic filter

### DIFF
--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -31,21 +31,105 @@ PUBLIC_OUTPUT_ALLOWED_AGI_RELEVANCE = {"Medium", "High", "Critical"}
 SOURCE_PRIORITY_RANK = {"Critical": 0, "High": 1}
 AGI_RELEVANCE_RANK = {"Critical": 0, "High": 1, "Medium": 2}
 OFF_TOPIC_PUBLIC_TERMS = (
+    "agriculture",
     "biology",
     "biomedical",
     "cattle",
+    "cancer",
+    "child online safety",
+    "clinical",
     "dairy",
+    "drug drug interaction",
+    "drug-drug interaction",
     "eclipse",
     "eclipses",
+    "electoral politics",
     "general news",
     "general science",
+    "generic policy news",
+    "healthcare diagnosis",
+    "indoor robotics",
+    "lab agent",
+    "lab agents",
+    "laboratory agent",
+    "laboratory agents",
+    "law",
+    "legal deliberation",
+    "legal domain",
+    "legal-domain",
+    "medical",
+    "medical imaging",
     "methane",
     "medicine",
     "oceanography",
+    "online safety",
     "poetry",
     "politics",
+    "prostate",
     "robot vacuum",
+    "social media ban",
+    "social media bans",
+    "ultrasound",
     "vacuum cleaner",
+)
+OFF_TOPIC_PUBLIC_OVERRIDE_TERMS = (
+    "agi governance",
+    "agi safety",
+    "ai act",
+    "ai governance",
+    "ai regulation",
+    "ai safety",
+    "ai safety evaluation",
+    "frontier ai safety",
+    "frontier model evaluation",
+    "frontier model governance",
+    "frontier model safety",
+    "model evaluation",
+)
+CORE_PUBLIC_TOPIC_TERMS = (
+    "agentic workflow",
+    "agentic workflows",
+    "agi governance",
+    "agi safety",
+    "ai agent",
+    "ai agents",
+    "ai governance",
+    "ai infrastructure",
+    "ai regulation",
+    "ai safety",
+    "autonomous ai agent",
+    "autonomous ai agents",
+    "benchmark",
+    "benchmarks",
+    "code agent",
+    "code agents",
+    "coding agent",
+    "coding agents",
+    "developer tool",
+    "developer tools",
+    "frontier model",
+    "frontier models",
+    "frontier model operations",
+    "llm agent",
+    "llm agents",
+    "llm judge",
+    "llm judges",
+    "model evaluation",
+    "model evaluations",
+)
+MULTI_AGENT_TERMS = ("multi-agent", "multi agent")
+MULTI_AGENT_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "governance", "coordination")
+AGENT_CONTEXT_TERMS = ("capability", "control", "evaluation", "governance", "reliability", "safety", "workflow")
+AUTONOMY_TERMS = ("autonomy", "autonomous systems")
+AUTONOMY_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "control")
+VLA_TERMS = ("vla", "vision-language-action", "vision language action")
+VLA_CONTEXT_TERMS = (
+    "agent capability",
+    "embodied agent",
+    "embodied ai",
+    "foundation model",
+    "robotics agent",
+    "robotics foundation model",
 )
 FORBIDDEN_PUBLIC_TERMS = (
     "." "invalid",
@@ -277,11 +361,37 @@ def off_topic_public_signal(record: dict[str, Any]) -> bool:
     haystack = " ".join(
         [
             signal_title(record),
+            signal_summary(record),
             normalize_text(field(record, "Category", "Categories", "Tag", "Tags")),
             source_label(record),
         ]
     ).lower()
-    return any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS)
+    if not any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS):
+        return False
+    return not any(term in haystack for term in OFF_TOPIC_PUBLIC_OVERRIDE_TERMS)
+
+
+def has_core_public_topic(record: dict[str, Any]) -> bool:
+    haystack = " ".join(
+        [
+            signal_title(record),
+            signal_summary(record),
+            normalize_text(field(record, "Category", "Categories", "Tag", "Tags")),
+            source_label(record),
+            agi_relevance(record),
+        ]
+    ).lower()
+    if any(term in haystack for term in CORE_PUBLIC_TOPIC_TERMS):
+        return True
+    if "agent" in haystack and any(term in haystack for term in AGENT_CONTEXT_TERMS):
+        return True
+    if any(term in haystack for term in MULTI_AGENT_TERMS) and any(term in haystack for term in MULTI_AGENT_CONTEXT_TERMS):
+        return True
+    if any(term in haystack for term in AUTONOMY_TERMS) and any(term in haystack for term in AUTONOMY_CONTEXT_TERMS):
+        return True
+    if any(term in haystack for term in VLA_TERMS) and any(term in haystack for term in VLA_CONTEXT_TERMS):
+        return True
+    return False
 
 
 def eligibility_blockers(record: dict[str, Any]) -> list[str]:
@@ -298,6 +408,8 @@ def eligibility_blockers(record: dict[str, Any]) -> list[str]:
         blockers.append("agi_relevance_below_medium")
     if off_topic_public_signal(record):
         blockers.append("off_topic_public_signal")
+    if not has_core_public_topic(record):
+        blockers.append("missing_core_public_topic")
     if not signal_title(record):
         blockers.append("missing_signal_title")
     if not signal_summary(record):
@@ -360,6 +472,7 @@ def auto_merge_entry_eligible(entry: dict[str, Any]) -> bool:
         and bool(entry.get("summary"))
         and is_safe_source_url(str(entry.get("source_url") or ""))
         and not off_topic_public_signal(entry)
+        and has_core_public_topic(entry)
     )
 
 

--- a/scripts/dysonx_public_signals_auto_merge_gate.py
+++ b/scripts/dysonx_public_signals_auto_merge_gate.py
@@ -19,21 +19,105 @@ MIN_PUBLIC_QUALITY = 80
 ALLOWED_SOURCE_PRIORITIES = {"High", "Critical"}
 ALLOWED_AGI_RELEVANCE = {"Medium", "High", "Critical"}
 OFF_TOPIC_PUBLIC_TERMS = (
+    "agriculture",
     "biology",
     "biomedical",
     "cattle",
+    "cancer",
+    "child online safety",
+    "clinical",
     "dairy",
+    "drug drug interaction",
+    "drug-drug interaction",
     "eclipse",
     "eclipses",
+    "electoral politics",
     "general news",
     "general science",
+    "generic policy news",
+    "healthcare diagnosis",
+    "indoor robotics",
+    "lab agent",
+    "lab agents",
+    "laboratory agent",
+    "laboratory agents",
+    "law",
+    "legal deliberation",
+    "legal domain",
+    "legal-domain",
+    "medical",
+    "medical imaging",
     "methane",
     "medicine",
     "oceanography",
+    "online safety",
     "poetry",
     "politics",
+    "prostate",
     "robot vacuum",
+    "social media ban",
+    "social media bans",
+    "ultrasound",
     "vacuum cleaner",
+)
+OFF_TOPIC_PUBLIC_OVERRIDE_TERMS = (
+    "agi governance",
+    "agi safety",
+    "ai act",
+    "ai governance",
+    "ai regulation",
+    "ai safety",
+    "ai safety evaluation",
+    "frontier ai safety",
+    "frontier model evaluation",
+    "frontier model governance",
+    "frontier model safety",
+    "model evaluation",
+)
+CORE_PUBLIC_TOPIC_TERMS = (
+    "agentic workflow",
+    "agentic workflows",
+    "agi governance",
+    "agi safety",
+    "ai agent",
+    "ai agents",
+    "ai governance",
+    "ai infrastructure",
+    "ai regulation",
+    "ai safety",
+    "autonomous ai agent",
+    "autonomous ai agents",
+    "benchmark",
+    "benchmarks",
+    "code agent",
+    "code agents",
+    "coding agent",
+    "coding agents",
+    "developer tool",
+    "developer tools",
+    "frontier model",
+    "frontier models",
+    "frontier model operations",
+    "llm agent",
+    "llm agents",
+    "llm judge",
+    "llm judges",
+    "model evaluation",
+    "model evaluations",
+)
+MULTI_AGENT_TERMS = ("multi-agent", "multi agent")
+MULTI_AGENT_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "governance", "coordination")
+AGENT_CONTEXT_TERMS = ("capability", "control", "evaluation", "governance", "reliability", "safety", "workflow")
+AUTONOMY_TERMS = ("autonomy", "autonomous systems")
+AUTONOMY_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "control")
+VLA_TERMS = ("vla", "vision-language-action", "vision language action")
+VLA_CONTEXT_TERMS = (
+    "agent capability",
+    "embodied agent",
+    "embodied ai",
+    "foundation model",
+    "robotics agent",
+    "robotics foundation model",
 )
 FORBIDDEN_TERMS = (
     "https://dysonx." "ai",
@@ -200,7 +284,27 @@ def off_topic_public_signal(entry: dict[str, Any]) -> bool:
         str(entry.get(key) or "")
         for key in ("title", "summary", "source_name", "source_priority", "agi_relevance")
     ).lower()
-    return any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS)
+    if not any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS):
+        return False
+    return not any(term in haystack for term in OFF_TOPIC_PUBLIC_OVERRIDE_TERMS)
+
+
+def has_core_public_topic(entry: dict[str, Any]) -> bool:
+    haystack = " ".join(
+        str(entry.get(key) or "")
+        for key in ("title", "summary", "source_name", "source_priority", "agi_relevance")
+    ).lower()
+    if any(term in haystack for term in CORE_PUBLIC_TOPIC_TERMS):
+        return True
+    if "agent" in haystack and any(term in haystack for term in AGENT_CONTEXT_TERMS):
+        return True
+    if any(term in haystack for term in MULTI_AGENT_TERMS) and any(term in haystack for term in MULTI_AGENT_CONTEXT_TERMS):
+        return True
+    if any(term in haystack for term in AUTONOMY_TERMS) and any(term in haystack for term in AUTONOMY_CONTEXT_TERMS):
+        return True
+    if any(term in haystack for term in VLA_TERMS) and any(term in haystack for term in VLA_CONTEXT_TERMS):
+        return True
+    return False
 
 
 def check_entry(entry: dict[str, Any], *, min_quality: float, allowed_priorities: set[str], allowed_agi_relevance: set[str], require_attribution_complete: bool, require_safe_summary_only: bool) -> None:
@@ -229,6 +333,8 @@ def check_entry(entry: dict[str, Any], *, min_quality: float, allowed_priorities
         raise AutoMergeGateError(f"{slug} source_url must be absolute http/https")
     if off_topic_public_signal(entry):
         raise AutoMergeGateError(f"{slug} is off-topic for public Signals")
+    if not has_core_public_topic(entry):
+        raise AutoMergeGateError(f"{slug} is missing a core DysonX public topic")
 
 
 def run_gate(args: argparse.Namespace) -> None:

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -267,6 +267,114 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
             self.assertNotIn(slug, launched_slugs)
         self.assertEqual(manifest["pages_blocked"], len(polluted))
 
+    def test_new_public_topic_blockers_reject_polluted_rows(self):
+        polluted = [
+            ("child-online-safety", "Child online safety policy update", "Policy"),
+            ("medical-object-segmentation", "Medical object segmentation benchmark", "Medical Imaging"),
+            ("drug-drug-interaction", "Drug-drug interaction prediction model", "Biomedical"),
+            ("prostate-cancer-ultrasound", "Prostate cancer ultrasound detection model", "Clinical"),
+            ("legal-deliberation", "Generic law deliberation with multi-agent debate", "Law"),
+        ]
+        records = [
+            eligible_record(
+                **{
+                    "Signal ID": f"sig_{slug}",
+                    "Signal Title": title,
+                    "Slug": slug,
+                    "Summary": "A summary-only Signal with enough model language but outside DysonX public scope.",
+                    "Category": category,
+                    "Source Priority": "High",
+                    "AGI Relevance": "Medium",
+                    "Quality Hint": 90,
+                }
+            )
+            for slug, title, category in polluted
+        ]
+        manifest = sync.sync_records(records, self.root)
+
+        launched_slugs = {item["slug"] for item in manifest["launched"]}
+        for slug, _, _ in polluted:
+            self.assertNotIn(slug, launched_slugs)
+        self.assertEqual(manifest["pages_blocked"], len(polluted))
+
+    def test_core_public_topic_examples_pass(self):
+        examples = [
+            ("agentbound", "AgentBound autonomous AI agents benchmark", "AgentBound evaluates autonomous AI agent capability and control."),
+            ("agrefactor", "AgRefactor agentic workflow developer tool", "AgRefactor improves agentic workflow reliability for code agents."),
+            ("ropoll", "RoPoLL LLM judges benchmark", "RoPoLL is a model evaluation benchmark for LLM judges."),
+            ("openlife", "OpenLife autonomous LLM agents", "OpenLife studies autonomous LLM agents and agent coordination."),
+            ("ai-governance", "AI regulation for frontier model governance", "AI governance and AI regulation for frontier model safety."),
+            ("vla-robotics", "VLA robotics foundation model framework", "A vision-language-action robotics foundation model for embodied AI agent capability."),
+        ]
+        records = [
+            eligible_record(
+                **{
+                    "Signal ID": f"sig_{slug}",
+                    "Signal Title": title,
+                    "Slug": slug,
+                    "Summary": summary,
+                    "Source Priority": "High",
+                    "AGI Relevance": "Medium",
+                    "Quality Hint": 80,
+                    "Published": False,
+                    "Ready for Pipeline": False,
+                }
+            )
+            for slug, title, summary in examples
+        ]
+        manifest = sync.sync_records(records, self.root)
+
+        launched_slugs = {item["slug"] for item in manifest["launched"]}
+        for slug, _, _ in examples:
+            self.assertIn(slug, launched_slugs)
+        self.assertEqual(manifest["pages_blocked"], 0)
+
+    def test_generic_indoor_robotics_without_agent_framing_is_blocked(self):
+        manifest = sync.sync_records(
+            [
+                eligible_record(
+                    **{
+                        "Signal ID": "sig_indoor_robotics",
+                        "Signal Title": "Generic indoor robotics navigation update",
+                        "Slug": "generic-indoor-robotics",
+                        "Summary": "A summary-only Signal about indoor robotics navigation hardware.",
+                        "Category": "Robotics",
+                        "Source Priority": "High",
+                        "AGI Relevance": "Medium",
+                        "Quality Hint": 90,
+                    }
+                )
+            ],
+            self.root,
+        )
+
+        launched_slugs = {item["slug"] for item in manifest["launched"]}
+        self.assertNotIn("generic-indoor-robotics", launched_slugs)
+        self.assertEqual(manifest["pages_blocked"], 1)
+
+    def test_missing_core_public_topic_is_reported(self):
+        report_path = self.root / "tmp" / "dysonx_public_signals_sync_report.json"
+        sync.sync_records(
+            [
+                eligible_record(
+                    **{
+                        "Signal Title": "Distributed systems scheduling update",
+                        "Slug": "distributed-systems-scheduling",
+                        "Summary": "A summary-only Signal about distributed systems scheduling.",
+                        "Category": "Infrastructure",
+                        "Source Priority": "High",
+                        "AGI Relevance": "Medium",
+                        "Quality Hint": 90,
+                    }
+                )
+            ],
+            self.root,
+            output_report=report_path,
+        )
+        report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        self.assertIn("missing_core_public_topic", report["blocked_reasons_by_title"]["Distributed systems scheduling update"])
+
     def test_missing_attribution_fails(self):
         manifest = sync.sync_records([eligible_record(**{"Attribution Status": "Missing"})], self.root)
 

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -28,7 +28,7 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
             encoding="utf-8",
         )
         (self.signals / self.slug / "index.html").write_text(
-            '<h1>Critical Agent Signal</h1><p>Summary-only public Signal.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a>',
+            '<h1>Critical AI Agent Evaluation Signal</h1><p>Summary-only public Signal about AI agent evaluation.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a>',
             encoding="utf-8",
         )
         self.manifest_path = self.signals / "public_launch_manifest.json"
@@ -43,8 +43,8 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
         entry = {
             "signal_id": "sig_critical_agent",
             "slug": self.slug,
-            "title": "Critical Agent Signal",
-            "summary": "Summary-only public Signal.",
+            "title": "Critical AI Agent Evaluation Signal",
+            "summary": "Summary-only public Signal about AI agent evaluation.",
             "public_path": f"signals/{self.slug}/index.html",
             "public_url_path": f"/signals/{self.slug}/",
             "source_name": "Example Source",
@@ -149,6 +149,11 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
     def test_fails_when_off_topic_terms_appear(self):
         polluted = [
             "biology medicine signal",
+            "child online safety policy update",
+            "medical object segmentation benchmark",
+            "drug-drug interaction prediction model",
+            "prostate cancer ultrasound detection model",
+            "generic law deliberation with multi-agent debate",
             "oceanography update",
             "poetry politics roundup",
             "robot vacuum product update",
@@ -158,6 +163,35 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
                 self.write_manifest(title=title)
                 self.assertNotEqual(self.run_gate(), 0)
                 self.write_manifest()
+
+    def test_fails_when_missing_core_public_topic(self):
+        self.write_manifest(title="Distributed systems scheduling update", summary="Summary-only public Signal about scheduling.")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_core_public_topic_examples_pass(self):
+        examples = [
+            ("AgentBound autonomous AI agents benchmark", "AgentBound evaluates autonomous AI agent capability and control."),
+            ("AgRefactor agentic workflow developer tool", "AgRefactor improves agentic workflow reliability for code agents."),
+            ("RoPoLL LLM judges benchmark", "RoPoLL is a model evaluation benchmark for LLM judges."),
+            ("OpenLife autonomous LLM agents", "OpenLife studies autonomous LLM agents and agent coordination."),
+            ("AI regulation for frontier model governance", "AI governance and AI regulation for frontier model safety."),
+            ("VLA robotics foundation model framework", "A vision-language-action robotics foundation model for embodied AI agent capability."),
+        ]
+        for title, summary in examples:
+            with self.subTest(title=title):
+                self.write_manifest(title=title, summary=summary, source_priority="High", agi_relevance="Medium", quality_hint=80, published=False, ready_for_pipeline=False)
+                self.assertEqual(self.run_gate(), 0)
+                self.write_manifest()
+
+    def test_generic_indoor_robotics_without_agent_framing_fails(self):
+        self.write_manifest(
+            title="Generic indoor robotics navigation update",
+            summary="Summary-only public Signal about indoor robotics navigation hardware.",
+            source_priority="High",
+            agi_relevance="Medium",
+            quality_hint=90,
+        )
+        self.assertNotEqual(self.run_gate(), 0)
 
     def test_fails_when_unknown_changed_file_path_exists(self):
         self.write_changed_files([f"signals/{self.slug}/index.html", "index.html"])


### PR DESCRIPTION
## Summary
- Strengthens DysonX public Signals topic filtering in the Notion sync and auto-merge gate.
- Adds a positive core public topic requirement for AI agents, AGI capability, model evaluation, AI safety, AI governance, AI infrastructure, developer tools, autonomous systems, and frontier model operations.
- Blocks child online safety, medical, biomedical, cancer, generic legal, oceanography, poetry, politics, agriculture, and consumer-appliance robotics rows unless explicitly tied to frontier AI safety/evaluation/governance.

## Confirmations
- Fully automatic publishing remains enabled.
- Published=true is not required.
- Ready for Pipeline=true is not required.
- Source Priority remains High or Critical.
- AGI Relevance remains Medium, High, or Critical.
- Quality Hint remains >= 80.
- Attribution Complete and Copyright Safe Summary Only remain required.
- Valid http(s) Source URL remains required.
- Max public Signals cap remains 30.
- Auto-merge gate topic policy is aligned with public sync.
- No OpenAI call.
- No scraping.
- No raw article body copying.
- No generated public content files.
- No CNAME change.
- No legacy aggregators re-enabled.
- No workflow dispatch.
- No deployment.

## Validation
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check