### PR TITLE
fix: auto-merge DysonX public Signals in trusted sync workflow

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -76,11 +76,6 @@ jobs:
           ! grep -R "\.test/" -n signals scripts tests docs
           ! grep -R "tmp/production_publish_pack" -n signals scripts tests docs
 
-      - name: Check auto-merge marker eligibility
-        id: auto_merge_marker
-        run: |
-          python3 -c 'import json, subprocess, sys; from pathlib import Path; sys.path.insert(0, "scripts"); import dysonx_notion_public_signals_sync as sync; marker = Path("auto_merge_marker.txt"); manifest_path = Path("signals/public_launch_manifest.json"); eligible = False; data = json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else None; changed_files = subprocess.check_output(["git", "diff", "--name-only", "--", "signals"], text=True).splitlines() if data is not None else []; eligible = sync.auto_merge_marker_eligible(data, changed_files) if data is not None else False; marker.write_text("AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1\n" if eligible else "", encoding="utf-8"); print(f"eligible={str(eligible).lower()}")'
-
       - name: Detect public Signals changes
         id: signals_changes
         run: |
@@ -91,7 +86,41 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Write public Signals changed files report
+        if: steps.signals_changes.outputs.changed == 'true'
+        run: |
+          mkdir -p tmp
+          git diff --name-only -- signals > tmp/dysonx_public_signals_changed_files.txt
+          python3 -c 'import json; from pathlib import Path; files = Path("tmp/dysonx_public_signals_changed_files.txt").read_text(encoding="utf-8").splitlines(); Path("tmp/dysonx_public_signals_changed_files.json").write_text(json.dumps(files, indent=2) + "\n", encoding="utf-8"); print("changed_files=" + str(len(files)))'
+
+      - name: Run trusted public Signals auto-merge gate
+        id: trusted_auto_merge_gate
+        if: steps.signals_changes.outputs.changed == 'true'
+        continue-on-error: true
+        run: |
+          python3 scripts/dysonx_public_signals_auto_merge_gate.py \
+            --manifest signals/public_launch_manifest.json \
+            --changed-files-json tmp/dysonx_public_signals_changed_files.json \
+            --min-quality 80 \
+            --allowed-priorities High,Critical \
+            --allowed-agi-relevance Medium,High,Critical \
+            --require-attribution-complete \
+            --require-safe-summary-only
+
+      - name: Upload trusted auto-merge diagnostics
+        if: always() && steps.signals_changes.outputs.changed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dysonx-public-signals-trusted-auto-merge
+          path: |
+            signals/public_launch_manifest.json
+            tmp/dysonx_public_signals_sync_report.json
+            tmp/dysonx_public_signals_changed_files.json
+            tmp/dysonx_public_signals_changed_files.txt
+          if-no-files-found: warn
+
       - name: Open content sync PR
+        id: content_pr
         if: steps.signals_changes.outputs.changed == 'true'
         run: |
           BRANCH="automation/dysonx-notion-signals-${GITHUB_RUN_ID}"
@@ -101,8 +130,29 @@ jobs:
           git add signals/
           git commit -m "content: sync DysonX public Signals from Notion"
           git push --set-upstream origin "$BRANCH"
-          gh pr create \
-            --title "content: sync DysonX public Signals from Notion" \
-            --body "$(printf 'Automated Notion public Signals sync. Opens PR only unless the strict DysonX public Signals auto-merge gate passes. No OpenAI call, no scraping, no raw article body copying, no hardcoded deployment domain.\n\n'; cat auto_merge_marker.txt)" \
-            --base main \
-            --head "$BRANCH"
+          PR_BODY="$(printf 'Automated Notion public Signals sync. Opens PR for audit trail. The trusted DysonX Notion Public Signals Sync workflow merges this PR only if the strict public Signals auto-merge gate passes. No OpenAI call, no scraping, no raw article body copying, no hardcoded deployment domain.\n\n')"
+          if [ "${{ steps.trusted_auto_merge_gate.outcome }}" = "success" ]; then
+            PR_BODY="${PR_BODY}AUTO_MERGE_CANDIDATE: dysonx-public-signals-v1"$'\n'
+          else
+            PR_BODY="${PR_BODY}Trusted same-run auto-merge gate did not pass. Manual review required."$'\n'
+          fi
+          PR_URL="$(gh pr list --base main --head "$BRANCH" --json url --jq '.[0].url')"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$(gh pr create \
+              --title "content: sync DysonX public Signals from Notion" \
+              --body "$PR_BODY" \
+              --base main \
+              --head "$BRANCH")"
+          else
+            gh pr edit "$PR_URL" --body "$PR_BODY"
+          fi
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Squash merge trusted public Signals PR
+        if: steps.signals_changes.outputs.changed == 'true' && steps.trusted_auto_merge_gate.outcome == 'success'
+        run: |
+          gh pr merge "${{ steps.content_pr.outputs.url }}" \
+            --squash \
+            --delete-branch \
+            --subject "content: sync DysonX public Signals from Notion" \
+            --body "Auto-merged by the trusted DysonX Notion Public Signals Sync workflow after the strict public Signals auto-merge gate passed."

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -259,8 +259,9 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         ]
         manifest = sync.sync_records([], self.root)
 
-        self.assertEqual(manifest["pages_launched"], 5)
-        self.assertEqual(len(manifest["launched"]), 5)
+        self.assertEqual(manifest["pages_launched"], len(manifest["launched"]))
+        self.assertLessEqual(manifest["pages_launched"], sync.DEFAULT_MAX_PUBLIC_SIGNALS)
+        self.assertGreaterEqual(manifest["pages_launched"], 1)
         manifest = sync.sync_records(records, self.root)
         launched_slugs = {item["slug"] for item in manifest["launched"]}
         for slug, _, _ in polluted:
@@ -389,11 +390,12 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertNotIn("notion-agent-reliability", launched_slugs)
         self.assertEqual(manifest["pages_blocked"], 1)
 
-    def test_existing_5_seed_signals_still_pass_as_safe_existing_public_signals(self):
+    def test_existing_public_signals_still_pass_as_safe_existing_public_signals(self):
         manifest = sync.sync_records([], self.root)
 
-        self.assertEqual(manifest["pages_launched"], 5)
-        self.assertEqual(len(manifest["launched"]), 5)
+        self.assertEqual(manifest["pages_launched"], len(manifest["launched"]))
+        self.assertLessEqual(manifest["pages_launched"], sync.DEFAULT_MAX_PUBLIC_SIGNALS)
+        self.assertGreaterEqual(manifest["pages_launched"], 1)
 
     def test_source_name_is_used_when_source_label_is_missing(self):
         record = eligible_record(**{"Source Name": "arXiv cs.CV RSS", "Quality Hint": 94})

--- a/tests/test_dysonx_public_launch_correctness.py
+++ b/tests/test_dysonx_public_launch_correctness.py
@@ -64,7 +64,9 @@ class DysonXPublicLaunchCorrectnessTests(unittest.TestCase):
         text = LAUNCH_MANIFEST.read_text(encoding="utf-8")
         data = json.loads(text)
 
-        self.assertEqual(data["pages_launched"], 5)
+        self.assertEqual(data["pages_launched"], len(data["launched"]))
+        self.assertLessEqual(data["pages_launched"], 30)
+        self.assertGreaterEqual(data["pages_launched"], 1)
         self.assertGreaterEqual(data["pages_blocked"], 0)
         self.assertNotIn("blocked", data)
         self.assertNotIn("source.dysonx." + "test", text)


### PR DESCRIPTION
## Purpose
Make DysonX Public Signals content PRs fully automatic by validating and merging eligible generated content PRs inside the trusted Notion Public Signals Sync workflow run.

## Scope
- Updates .github/workflows/dysonx-notion-public-signals-sync.yml to run the public auto-merge gate against the generated signals diff.
- Creates/updates the content PR for audit trail.
- Squash merges and deletes the automation branch only when the gate passes in the same trusted workflow run.
- Leaves failed-gate content PRs open and uploads diagnostics.
- Updates brittle public Signal count tests to assert the current capped feed contract instead of the old 5-seed count.

## Constitution Compliance
- Preserves Signal-first public output.
- Does not turn DysonX into a generic news site.
- Does not hardcode monitored sources.
- Does not weaken eligibility, topic filtering, attribution, copyright, source URL, raw-body, or path restrictions.
- Keeps max public Signals cap at 30.

## Safety Confirmations
- Existing public auto-merge gate script remains the validation authority.
- Pull-request auto-merge workflow is kept but is no longer required for generated content PRs to merge.
- AUTO_MERGE_CANDIDATE marker is included only after the trusted gate passes.
- No OpenAI call.
- No scraping.
- No raw article body copying.
- No generated public content files.
- No CNAME change.
- No legacy aggregators re-enabled.
- No workflow dispatch.
- No deployment.

## Validation
- ruby YAML parse check
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check

## Rollback
Revert this PR to return public content PR merging to the existing pull_request-based auto-merge workflow.