### PR TITLE
fix: prevent raw-body false positives and timestamp-only public Signal PRs

### DIFF
--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import html
 import json
 import os
@@ -590,7 +591,7 @@ def record_from_notion(record: dict[str, Any]) -> dict[str, Any]:
         "published": field(record, "Published", "published") is True,
         "quality_hint": int(quality_hint(record)),
         "timestamp": timestamp_value(record),
-        "risk_notes": text_field(record, "Risk Notes", "Safety Notes", "risk_notes", default="Summary-only public treatment. No raw article body is reproduced."),
+        "risk_notes": text_field(record, "Risk Notes", "Safety Notes", "risk_notes", default="Summary-only; source text not reproduced."),
         "watch_next": text_field(record, "Watch Next", "watch_next", default="Watch for follow-up Signals in the Notion-managed intake."),
         "tags": tags(record),
         "existing": False,
@@ -676,7 +677,7 @@ def render_signal_page(record: dict[str, Any], refreshed_at: str) -> str:
 <h2>Source Attribution</h2>
 <p>{source_html}</p>
 <h2>Risk And Safety Notes</h2>
-<p>{escape(record.get("risk_notes") or "Summary-only public treatment. No raw article body is reproduced.")}</p>
+<p>{escape(record.get("risk_notes") or "Summary-only; source text not reproduced.")}</p>
 <h2>Watch Next</h2>
 <p>{escape(record.get("watch_next") or "Watch for follow-up Signals in the Notion-managed intake.")}</p>
 <p><a href="/">Home</a> · <a href="/signals/">Back to Public Signals</a></p>
@@ -730,7 +731,7 @@ def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at
 <div class="grid">
 {''.join(items)}
 </div>
-<p class="meta">Content refreshed at {escape(refreshed_at)}. No raw article bodies are reproduced. OpenAI was not called. Source pages were not scraped.</p>
+<p class="meta">Content refreshed at {escape(refreshed_at)}. Source text is not reproduced. OpenAI was not called. Source pages were not scraped.</p>
 <p><a href="/">Home</a></p>
 </main>
 </body>
@@ -743,6 +744,38 @@ def assert_public_safe(text: str, label: str) -> None:
     matches = [term for term in FORBIDDEN_PUBLIC_TERMS if term in lowered]
     if matches:
         raise NotionPublicSignalsSyncError(f"{label} contains forbidden public terms: {', '.join(matches)}")
+
+
+def material_signature(records: list[dict[str, Any]], blocked_count: int) -> str:
+    material_records = [
+        {
+            "signal_id": record.get("signal_id", ""),
+            "slug": record.get("slug", ""),
+            "title": record.get("title", ""),
+            "summary": record.get("summary", ""),
+            "why_this_matters": record.get("why_this_matters", ""),
+            "agi_relevance": record.get("agi_relevance", ""),
+            "source_label": record.get("source_label", ""),
+            "source_url": record.get("source_url", ""),
+            "source_priority": record.get("source_priority", ""),
+            "attribution_status": record.get("attribution_status", ""),
+            "copyright_status": record.get("copyright_status", ""),
+            "ready_for_pipeline": bool(record.get("ready_for_pipeline")),
+            "published": bool(record.get("published")),
+            "quality_hint": record.get("quality_hint", ""),
+            "risk_notes": record.get("risk_notes", ""),
+            "watch_next": record.get("watch_next", ""),
+            "tags": record.get("tags", []),
+        }
+        for record in records
+    ]
+    material = {
+        "pages_launched": len(records),
+        "pages_blocked": blocked_count,
+        "records": material_records,
+    }
+    payload = json.dumps(material, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_at: str) -> dict[str, Any]:
@@ -773,6 +806,7 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
         "pages_launched": len(records),
         "pages_blocked": blocked_count,
         "public_output_root": ".",
+        "material_signature": material_signature(records, blocked_count),
         "launched": launched,
         "openai_call_performed": False,
         "source_scraping_performed": False,
@@ -785,6 +819,33 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
         "source_pack_manifest": "notion_signal_intake_public_safe_reference",
         "source_release_guard_report": "static_preview_link_integrity_check",
     }
+
+
+def manifest_material_view(manifest: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in manifest.items() if key != "content_refreshed_at"}
+
+
+def existing_manifest(signals_root: pathlib.Path) -> dict[str, Any] | None:
+    manifest_path = signals_root / "public_launch_manifest.json"
+    if not manifest_path.exists():
+        return None
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def stable_refreshed_at(signals_root: pathlib.Path, candidate_manifest: dict[str, Any], fallback_refreshed_at: str) -> str:
+    previous_manifest = existing_manifest(signals_root)
+    if not previous_manifest:
+        return fallback_refreshed_at
+    previous_refreshed_at = normalize_text(previous_manifest.get("content_refreshed_at"))
+    if not previous_refreshed_at:
+        return fallback_refreshed_at
+    if manifest_material_view(previous_manifest) == manifest_material_view(candidate_manifest):
+        return previous_refreshed_at
+    return fallback_refreshed_at
 
 
 def sync_records(
@@ -818,6 +879,8 @@ def sync_records(
     for record in selected:
         by_slug[record["slug"]] = record
     merged = sorted(by_slug.values(), key=public_signal_sort_key)
+    candidate_manifest = build_manifest(merged, blocked_count, refreshed_at)
+    refreshed_at = stable_refreshed_at(signals_root, candidate_manifest, refreshed_at)
 
     for record in merged:
         if record.get("existing") and not any(item["slug"] == record["slug"] for item in eligible):

--- a/scripts/dysonx_public_signals_auto_merge_gate.py
+++ b/scripts/dysonx_public_signals_auto_merge_gate.py
@@ -128,10 +128,15 @@ FORBIDDEN_TERMS = (
     "tmp/" "production_publish_pack",
 )
 RAW_BODY_MARKERS = (
-    "raw article body",
-    "source-page body copied",
+    "article body:",
     "full article text",
-    "verbatim article body",
+    "raw source body",
+    "raw body",
+    "raw_body",
+    "scraped body",
+    "source body:",
+    "source-page body copied",
+    "verbatim source",
 )
 INLINE_EVENT_PATTERN = re.compile(r"\son[a-z]+\s*=", re.IGNORECASE)
 

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -48,6 +48,13 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
     def read_output(self) -> str:
         return "\n".join(path.read_text(encoding="utf-8") for path in sorted((self.root / "signals").rglob("*")) if path.is_file())
 
+    def output_snapshot(self) -> dict[str, str]:
+        return {
+            str(path.relative_to(self.root)): path.read_text(encoding="utf-8")
+            for path in sorted((self.root / "signals").rglob("*"))
+            if path.is_file()
+        }
+
     def test_eligible_row_generates_page(self):
         manifest = sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
 
@@ -58,6 +65,78 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertIn("https://example.org/agent-reliability", html)
         self.assertEqual(manifest["openai_call_performed"], False)
         self.assertEqual(manifest["source_scraping_performed"], False)
+
+    def test_generated_page_uses_safe_source_text_disclaimer(self):
+        sync.sync_records([eligible_record(**{"Risk Notes": ""})], self.root, refreshed_at="2026-06-27T00:00:00Z")
+
+        html = (self.root / "signals" / "notion-agent-reliability" / "index.html").read_text(encoding="utf-8")
+        self.assertIn("Summary-only; source text not reproduced.", html)
+        self.assertNotIn("raw article body", html.lower())
+
+    def test_rerunning_identical_records_does_not_churn_timestamps_or_files(self):
+        shutil.rmtree(self.root / "signals")
+        records = [eligible_record()]
+
+        first_manifest = sync.sync_records(records, self.root, refreshed_at="2026-06-27T00:00:00Z")
+        first_snapshot = self.output_snapshot()
+        second_manifest = sync.sync_records(records, self.root, refreshed_at="2026-06-28T00:00:00Z")
+        second_snapshot = self.output_snapshot()
+
+        self.assertEqual(first_manifest["content_refreshed_at"], "2026-06-27T00:00:00Z")
+        self.assertEqual(second_manifest["content_refreshed_at"], "2026-06-27T00:00:00Z")
+        self.assertEqual(second_snapshot, first_snapshot)
+
+    def test_material_content_change_updates_outputs(self):
+        shutil.rmtree(self.root / "signals")
+        records = [eligible_record()]
+        sync.sync_records(records, self.root, refreshed_at="2026-06-27T00:00:00Z")
+        first_snapshot = self.output_snapshot()
+
+        changed = [eligible_record(**{"Summary": "Updated summary-only Signal about AI agent evaluation."})]
+        manifest = sync.sync_records(changed, self.root, refreshed_at="2026-06-28T00:00:00Z")
+        second_snapshot = self.output_snapshot()
+
+        self.assertEqual(manifest["content_refreshed_at"], "2026-06-28T00:00:00Z")
+        self.assertNotEqual(second_snapshot, first_snapshot)
+        self.assertIn("Updated summary-only Signal about AI agent evaluation.", second_snapshot["signals/notion-agent-reliability/index.html"])
+
+    def test_risk_note_change_updates_outputs(self):
+        shutil.rmtree(self.root / "signals")
+        records = [eligible_record()]
+        sync.sync_records(records, self.root, refreshed_at="2026-06-27T00:00:00Z")
+        first_snapshot = self.output_snapshot()
+
+        changed = [eligible_record(**{"Risk Notes": "Summary-only; updated source text safety note."})]
+        manifest = sync.sync_records(changed, self.root, refreshed_at="2026-06-28T00:00:00Z")
+        second_snapshot = self.output_snapshot()
+
+        self.assertEqual(manifest["content_refreshed_at"], "2026-06-28T00:00:00Z")
+        self.assertNotEqual(second_snapshot, first_snapshot)
+        self.assertIn("updated source text safety note", second_snapshot["signals/notion-agent-reliability/index.html"])
+
+    def test_new_eligible_signal_creates_content_changes(self):
+        shutil.rmtree(self.root / "signals")
+        records = [eligible_record()]
+        sync.sync_records(records, self.root, refreshed_at="2026-06-27T00:00:00Z")
+        first_snapshot = self.output_snapshot()
+
+        records.append(
+            eligible_record(
+                **{
+                    "Signal ID": "sig_second_agent",
+                    "Signal Title": "Second AI agent evaluation Signal",
+                    "Slug": "second-ai-agent-evaluation",
+                    "Summary": "A second summary-only Signal about AI agent evaluation.",
+                    "Quality Hint": 93,
+                }
+            )
+        )
+        manifest = sync.sync_records(records, self.root, refreshed_at="2026-06-28T00:00:00Z")
+        second_snapshot = self.output_snapshot()
+
+        self.assertEqual(manifest["content_refreshed_at"], "2026-06-28T00:00:00Z")
+        self.assertNotEqual(second_snapshot, first_snapshot)
+        self.assertIn("signals/second-ai-agent-evaluation/index.html", second_snapshot)
 
     def test_row_with_missing_attribution_does_not_generate_page(self):
         manifest = sync.sync_records([eligible_record(**{"Attribution Status": "Incomplete"})], self.root)

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -198,8 +198,31 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
         self.assertNotEqual(self.run_gate(), 0)
 
     def test_fails_when_raw_body_marker_appears(self):
-        (self.signals / self.slug / "index.html").write_text("full article text", encoding="utf-8")
-        self.assertNotEqual(self.run_gate(), 0)
+        markers = [
+            "full article text",
+            "raw source body",
+            "article body:",
+            "raw_body",
+            "Raw Body",
+        ]
+        for marker in markers:
+            with self.subTest(marker=marker):
+                (self.signals / self.slug / "index.html").write_text(marker, encoding="utf-8")
+                self.assertNotEqual(self.run_gate(), 0)
+
+    def test_safe_source_text_disclaimer_passes(self):
+        (self.signals / self.slug / "index.html").write_text(
+            '<h1>Critical AI Agent Evaluation Signal</h1><p>Summary-only; source text not reproduced.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a>',
+            encoding="utf-8",
+        )
+        self.assertEqual(self.run_gate(), 0)
+
+    def test_negative_raw_article_body_disclaimer_does_not_false_positive(self):
+        (self.signals / self.slug / "index.html").write_text(
+            '<h1>Critical AI Agent Evaluation Signal</h1><p>No raw article body copied.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a>',
+            encoding="utf-8",
+        )
+        self.assertEqual(self.run_gate(), 0)
 
     def test_fails_when_script_tag_appears(self):
         (self.signals / self.slug / "index.html").write_text("<script>alert(1)</script>", encoding="utf-8")


### PR DESCRIPTION
## Purpose
Fix DysonX public Signals trusted auto-merge after #101 by removing a raw-body false positive and preventing timestamp-only public Signal churn.

## Scope
- Updates generated public Signal safety copy to use source-text wording instead of the ambiguous raw article body phrase.
- Keeps the public auto-merge gate strict for real source-body leakage markers.
- Adds a material signature to public sync output so unchanged records reuse the prior content_refreshed_at timestamp.
- Adds tests for safe disclaimers, real raw/source body markers, identical reruns, material content changes, risk-note changes, and new eligible Signals.

## Safety Confirmations
- Actual raw/source body protection remains active.
- Full article text remains blocked.
- Attribution and copyright safeguards are unchanged.
- Eligibility thresholds are unchanged.
- Manual approval was not restored.
- Same-run auto-merge workflow behavior from #101 is unchanged.
- No OpenAI call.
- No scraping.
- No generated public content files.
- No CNAME change.
- No legacy aggregators re-enabled.
- No workflow dispatch.
- No deployment.

## Validation
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check

## Rollback
Revert this PR to restore the previous raw-body marker list and timestamp behavior.