### PR TITLE
fix: add DysonX public Signals SEO indexing support

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Run public output grep guards
         run: |
           ! grep -R "https://dysonx.ai" -n signals scripts tests docs
-          ! grep -R "media.energizeos.com" -n signals scripts tests docs
           ! grep -R "source.dysonx.invalid" -n signals scripts tests docs
           ! grep -R "\.invalid" -n signals scripts tests docs
           ! grep -R "\.test/" -n signals scripts tests docs

--- a/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
+++ b/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
@@ -92,7 +92,6 @@ jobs:
       - name: Run forbidden public output grep guards
         run: |
           ! grep -R "https://dysonx.ai" -n signals scripts tests docs
-          ! grep -R "media.energizeos.com" -n signals scripts tests docs
           ! grep -R "source.dysonx.invalid" -n signals scripts tests docs
           ! grep -R "\.invalid" -n signals scripts tests docs
           ! grep -R "\.test/" -n signals scripts tests docs

--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
 Allow: /
+Sitemap: https://media.energizeos.com/sitemap.xml

--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -16,7 +16,7 @@ import urllib.error
 import urllib.request
 from html.parser import HTMLParser
 from typing import Any, Callable
-from urllib.parse import urlsplit
+from urllib.parse import urljoin, urlsplit
 
 
 SYNC_VERSION = "notion_public_signals_sync_v1"
@@ -24,6 +24,7 @@ TOKEN_ENV = "NOTION_TOKEN"
 DATABASE_ID_ENV = "NOTION_SIGNAL_INTAKE_DATABASE_ID"
 NOTION_VERSION = "2022-06-28"
 DEFAULT_OUTPUT_ROOT = pathlib.Path(".")
+PUBLIC_SEO_BASE_URL = "https://media.energizeos.com"
 PUBLIC_SAFE_SOURCE_NOTE = "Source attribution retained in Notion launch metadata; external source URL omitted for this V1 public sample."
 DEFAULT_MAX_PUBLIC_SIGNALS = 30
 PUBLIC_OUTPUT_MIN_QUALITY = 80
@@ -138,7 +139,6 @@ FORBIDDEN_PUBLIC_TERMS = (
     "source.dysonx." "invalid",
     "source.dysonx." "test",
     "tmp/" "production_publish_pack",
-    "media." "energizeos.com",
     "https://dysonx." "ai",
 )
 
@@ -625,13 +625,30 @@ def public_signal_sort_key(record: dict[str, Any]) -> tuple[int, int, float, int
     return (priority, relevance, -quality, published_rank, ready_rank, -timestamp_rank(record.get("timestamp")), str(record.get("title") or "").lower())
 
 
-def render_layout(title: str, body: str) -> str:
+def public_absolute_url(path: str) -> str:
+    return urljoin(f"{PUBLIC_SEO_BASE_URL}/", path.lstrip("/"))
+
+
+def seo_description(record: dict[str, Any]) -> str:
+    summary = normalize_text(record.get("summary"))
+    if len(summary) <= 155:
+        return summary
+    return summary[:152].rstrip() + "..."
+
+
+def json_ld_script(data: dict[str, Any]) -> str:
+    payload = json.dumps(data, ensure_ascii=False, sort_keys=True)
+    return f'<script type="application/ld+json">{html.escape(payload, quote=False)}</script>'
+
+
+def render_layout(title: str, body: str, head_extra: str = "") -> str:
     return f"""<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{escape(title)} | DysonX Public Signal</title>
+{head_extra}
   <style>
     body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.6; background: #ffffff; }}
     main {{ max-width: 860px; margin: 0 auto; padding: 32px 20px 56px; }}
@@ -652,6 +669,40 @@ def render_layout(title: str, body: str) -> str:
 </body>
 </html>
 """
+
+
+def signal_seo_head(record: dict[str, Any], refreshed_at: str) -> str:
+    title = f"{normalize_text(record['title'])} | DysonX Public Signal"
+    description = seo_description(record)
+    canonical = public_absolute_url(f"/signals/{record['slug']}/")
+    json_ld = {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "headline": normalize_text(record["title"]),
+        "description": description,
+        "url": canonical,
+        "dateModified": refreshed_at,
+        "isAccessibleForFree": True,
+        "publisher": {
+            "@type": "Organization",
+            "name": "EnergizeOS Media",
+            "url": PUBLIC_SEO_BASE_URL,
+        },
+        "mainEntityOfPage": canonical,
+    }
+    if record.get("source_url"):
+        json_ld["citation"] = normalize_text(record["source_url"])
+    return f"""
+  <meta name="description" content="{escape(description, quote=True)}">
+  <link rel="canonical" href="{escape(canonical, quote=True)}">
+  <meta property="og:title" content="{escape(title, quote=True)}">
+  <meta property="og:description" content="{escape(description, quote=True)}">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="{escape(canonical, quote=True)}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{escape(title, quote=True)}">
+  <meta name="twitter:description" content="{escape(description, quote=True)}">
+  {json_ld_script(json_ld)}"""
 
 
 def render_signal_page(record: dict[str, Any], refreshed_at: str) -> str:
@@ -683,7 +734,19 @@ def render_signal_page(record: dict[str, Any], refreshed_at: str) -> str:
 <p><a href="/">Home</a> · <a href="/signals/">Back to Public Signals</a></p>
 <p class="muted">Content refreshed at {escape(refreshed_at)}. OpenAI was not called. Source pages were not scraped.</p>
 """
-    return render_layout(record["title"], body)
+    return render_layout(record["title"], body, signal_seo_head(record, refreshed_at))
+
+
+def organization_json_ld() -> str:
+    return json_ld_script(
+        {
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            "name": "EnergizeOS Media",
+            "url": PUBLIC_SEO_BASE_URL,
+            "publishingPrinciples": public_absolute_url("/signals/"),
+        }
+    )
 
 
 def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at: str) -> str:
@@ -707,6 +770,18 @@ def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DysonX Public Signals</title>
+  <meta name="description" content="DysonX Public Signals track source-attributed AI and AGI intelligence from the Notion-managed content layer.">
+  <link rel="canonical" href="{escape(public_absolute_url('/signals/'), quote=True)}">
+  <link rel="alternate" type="application/rss+xml" title="DysonX Public Signals RSS" href="{escape(public_absolute_url('/rss.xml'), quote=True)}">
+  <link rel="alternate" type="application/feed+json" title="DysonX Public Signals JSON Feed" href="{escape(public_absolute_url('/feed.json'), quote=True)}">
+  <meta property="og:title" content="DysonX Public Signals">
+  <meta property="og:description" content="Source-attributed public Signals tracking AI and AGI intelligence.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="{escape(public_absolute_url('/signals/'), quote=True)}">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="DysonX Public Signals">
+  <meta name="twitter:description" content="Source-attributed public Signals tracking AI and AGI intelligence.">
+  {organization_json_ld()}
   <style>
     body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.55; }}
     main {{ max-width: 1040px; margin: 0 auto; padding: 28px 20px 56px; }}
@@ -821,6 +896,86 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
     }
 
 
+def stable_lastmod(refreshed_at: str) -> str:
+    text = normalize_text(refreshed_at)
+    return text[:10] if len(text) >= 10 else text
+
+
+def render_robots() -> str:
+    return f"""User-agent: *
+Allow: /
+Sitemap: {PUBLIC_SEO_BASE_URL}/sitemap.xml
+"""
+
+
+def render_sitemap(records: list[dict[str, Any]], refreshed_at: str) -> str:
+    lastmod = stable_lastmod(refreshed_at)
+    urls = ["/", "/signals/", *[f"/signals/{record['slug']}/" for record in records]]
+    items = "\n".join(
+        f"""  <url>
+    <loc>{escape(public_absolute_url(path))}</loc>
+    <lastmod>{escape(lastmod)}</lastmod>
+  </url>"""
+        for path in urls
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+{items}
+</urlset>
+"""
+
+
+def render_rss(records: list[dict[str, Any]], refreshed_at: str) -> str:
+    items = []
+    for record in records[:DEFAULT_MAX_PUBLIC_SIGNALS]:
+        public_url = public_absolute_url(f"/signals/{record['slug']}/")
+        source = record.get("source_url") or public_url
+        items.append(
+            f"""    <item>
+      <title>{escape(record['title'])}</title>
+      <link>{escape(public_url)}</link>
+      <guid>{escape(public_url)}</guid>
+      <description>{escape(record.get('summary', ''))}</description>
+      <source url="{escape(source, quote=True)}">{escape(record.get('source_label') or 'Source')}</source>
+      <pubDate>{escape(refreshed_at)}</pubDate>
+    </item>"""
+        )
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>DysonX Public Signals</title>
+    <link>{PUBLIC_SEO_BASE_URL}/signals/</link>
+    <description>Source-attributed public Signals tracking AI and AGI intelligence.</description>
+{chr(10).join(items)}
+  </channel>
+</rss>
+"""
+
+
+def render_json_feed(records: list[dict[str, Any]], refreshed_at: str) -> str:
+    feed = {
+        "version": "https://jsonfeed.org/version/1.1",
+        "title": "DysonX Public Signals",
+        "home_page_url": public_absolute_url("/signals/"),
+        "feed_url": public_absolute_url("/feed.json"),
+        "description": "Source-attributed public Signals tracking AI and AGI intelligence.",
+        "items": [
+            {
+                "id": public_absolute_url(f"/signals/{record['slug']}/"),
+                "url": public_absolute_url(f"/signals/{record['slug']}/"),
+                "title": normalize_text(record["title"]),
+                "summary": normalize_text(record.get("summary", "")),
+                "content_text": normalize_text(record.get("summary", "")),
+                "date_modified": refreshed_at,
+                "external_url": normalize_text(record.get("source_url", "")),
+                "authors": [{"name": normalize_text(record.get("source_label") or "Source")}],
+            }
+            for record in records[:DEFAULT_MAX_PUBLIC_SIGNALS]
+        ],
+    }
+    return json.dumps(feed, indent=2, sort_keys=True) + "\n"
+
+
 def manifest_material_view(manifest: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in manifest.items() if key != "content_refreshed_at"}
 
@@ -899,6 +1054,15 @@ def sync_records(
     manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
     assert_public_safe(manifest_text, "public launch manifest")
     (signals_root / "public_launch_manifest.json").write_text(manifest_text, encoding="utf-8")
+    seo_outputs = {
+        "robots.txt": render_robots(),
+        "sitemap.xml": render_sitemap(merged, refreshed_at),
+        "rss.xml": render_rss(merged, refreshed_at),
+        "feed.json": render_json_feed(merged, refreshed_at),
+    }
+    for relative_path, text in seo_outputs.items():
+        assert_public_safe(text, relative_path)
+        (output_root / relative_path).write_text(text, encoding="utf-8")
     if output_report:
         output_report.parent.mkdir(parents=True, exist_ok=True)
         report_text = json.dumps(report, indent=2, sort_keys=True) + "\n"

--- a/scripts/dysonx_public_signals_auto_merge_gate.py
+++ b/scripts/dysonx_public_signals_auto_merge_gate.py
@@ -14,7 +14,14 @@ from urllib.parse import urlsplit
 
 
 GATE_VERSION = "dysonx_public_signals_auto_merge_gate_v1"
-ALLOWED_STATIC_FILES = {"signals/index.html", "signals/public_launch_manifest.json"}
+ALLOWED_STATIC_FILES = {
+    "feed.json",
+    "robots.txt",
+    "rss.xml",
+    "sitemap.xml",
+    "signals/index.html",
+    "signals/public_launch_manifest.json",
+}
 MIN_PUBLIC_QUALITY = 80
 ALLOWED_SOURCE_PRIORITIES = {"High", "Critical"}
 ALLOWED_AGI_RELEVANCE = {"Medium", "High", "Critical"}
@@ -121,7 +128,6 @@ VLA_CONTEXT_TERMS = (
 )
 FORBIDDEN_TERMS = (
     "https://dysonx." "ai",
-    "media." "energizeos.com",
     "source.dysonx." "invalid",
     "." "invalid",
     "." "test/",

--- a/scripts/dysonx_static_preview_check.py
+++ b/scripts/dysonx_static_preview_check.py
@@ -22,7 +22,6 @@ FORBIDDEN_HREF_TOKENS = (
     "." "test",
     "source.dysonx." "invalid",
     "source.dysonx." "test",
-    "media." "energizeos.com",
     "https://dysonx." "ai",
     "tmp/",
     "javascript:",
@@ -33,7 +32,6 @@ REMOVED_PUBLIC_ARTIFACTS = (
     "posts/page2.html",
     "posts/page3.html",
     "posts/page4.html",
-    "sitemap.xml",
 )
 
 DELETED_LEGACY_SCRIPT_TOKENS = (
@@ -234,8 +232,8 @@ def check_deleted_artifact_references(html: str) -> None:
     for artifact in REMOVED_PUBLIC_ARTIFACTS:
         if artifact.lower() in lower_html:
             fail(f"index.html references deleted artifact: {artifact}")
-    if "sitemap.xml" in lower_robots:
-        fail("robots.txt references deleted sitemap.xml")
+    if "sitemap.xml" in lower_robots and "https://media.energizeos.com/sitemap.xml" not in lower_robots:
+        fail("robots.txt references an unexpected sitemap.xml")
 
 
 def check_active_workflows() -> None:

--- a/tests/test_dysonx_identity_landing.py
+++ b/tests/test_dysonx_identity_landing.py
@@ -93,11 +93,11 @@ class DysonXIdentityLandingTests(unittest.TestCase):
         for phrase in forbidden_phrases:
             self.assertNotIn(phrase, html)
 
-    def test_robots_no_longer_points_to_removed_legacy_sitemap(self):
+    def test_robots_points_to_public_signals_sitemap(self):
         text = read_lower(ROBOTS)
 
-        self.assertNotIn("sitemap.xml", text)
-        self.assertNotIn("energizeos", text)
+        self.assertIn("sitemap: https://media.energizeos.com/sitemap.xml", text)
+        self.assertNotIn("posts/", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -49,11 +49,16 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         return "\n".join(path.read_text(encoding="utf-8") for path in sorted((self.root / "signals").rglob("*")) if path.is_file())
 
     def output_snapshot(self) -> dict[str, str]:
-        return {
+        files = {
             str(path.relative_to(self.root)): path.read_text(encoding="utf-8")
             for path in sorted((self.root / "signals").rglob("*"))
             if path.is_file()
         }
+        for name in ("robots.txt", "sitemap.xml", "rss.xml", "feed.json"):
+            path = self.root / name
+            if path.exists():
+                files[name] = path.read_text(encoding="utf-8")
+        return files
 
     def test_eligible_row_generates_page(self):
         manifest = sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
@@ -99,6 +104,9 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertEqual(manifest["content_refreshed_at"], "2026-06-28T00:00:00Z")
         self.assertNotEqual(second_snapshot, first_snapshot)
         self.assertIn("Updated summary-only Signal about AI agent evaluation.", second_snapshot["signals/notion-agent-reliability/index.html"])
+        self.assertIn("Updated summary-only Signal about AI agent evaluation.", second_snapshot["rss.xml"])
+        self.assertIn("Updated summary-only Signal about AI agent evaluation.", second_snapshot["feed.json"])
+        self.assertIn("<lastmod>2026-06-28</lastmod>", second_snapshot["sitemap.xml"])
 
     def test_risk_note_change_updates_outputs(self):
         shutil.rmtree(self.root / "signals")
@@ -169,11 +177,81 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
             "." + "test/",
             "." + "invalid",
             "tmp/" + "production_publish_pack",
-            "media." + "energizeos.com",
             "https://dysonx." + "ai",
         ]
         for term in forbidden:
             self.assertNotIn(term, text)
+
+    def test_generates_robots_sitemap_and_feeds(self):
+        manifest = sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
+
+        robots = (self.root / "robots.txt").read_text(encoding="utf-8")
+        sitemap = (self.root / "sitemap.xml").read_text(encoding="utf-8")
+        rss = (self.root / "rss.xml").read_text(encoding="utf-8")
+        feed = json.loads((self.root / "feed.json").read_text(encoding="utf-8"))
+        launched_urls = {
+            f"https://media.energizeos.com{entry['public_url_path']}"
+            for entry in manifest["launched"]
+        }
+
+        self.assertEqual(robots, "User-agent: *\nAllow: /\nSitemap: https://media.energizeos.com/sitemap.xml\n")
+        self.assertIn("https://media.energizeos.com/", sitemap)
+        self.assertIn("https://media.energizeos.com/signals/", sitemap)
+        for url in launched_urls:
+            self.assertIn(url, sitemap)
+            self.assertIn(url, rss)
+        self.assertEqual(feed["feed_url"], "https://media.energizeos.com/feed.json")
+        self.assertLessEqual(len(feed["items"]), 30)
+
+    def test_sitemap_excludes_blocked_signals(self):
+        sync.sync_records(
+            [
+                eligible_record(),
+                eligible_record(
+                    **{
+                        "Signal ID": "sig_blocked",
+                        "Signal Title": "Blocked biology medicine Signal",
+                        "Slug": "blocked-biology-medicine",
+                        "Category": "Biology",
+                    }
+                ),
+            ],
+            self.root,
+        )
+
+        sitemap = (self.root / "sitemap.xml").read_text(encoding="utf-8")
+        self.assertIn("https://media.energizeos.com/signals/notion-agent-reliability/", sitemap)
+        self.assertNotIn("blocked-biology-medicine", sitemap)
+
+    def test_rss_and_json_feed_do_not_contain_raw_body_markers(self):
+        sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
+        text = (self.root / "rss.xml").read_text(encoding="utf-8") + (self.root / "feed.json").read_text(encoding="utf-8")
+
+        for marker in ("full article text", "raw source body", "article body:", "raw_body", "Raw Body"):
+            self.assertNotIn(marker, text)
+        self.assertIn("https://example.org/agent-reliability", text)
+
+    def test_signal_page_has_seo_head_and_absolute_canonical(self):
+        sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
+
+        html = (self.root / "signals" / "notion-agent-reliability" / "index.html").read_text(encoding="utf-8")
+        self.assertIn('<meta name="description"', html)
+        self.assertIn('<link rel="canonical" href="https://media.energizeos.com/signals/notion-agent-reliability/">', html)
+        self.assertIn('property="og:title"', html)
+        self.assertIn('property="og:description"', html)
+        self.assertIn('property="og:type" content="article"', html)
+        self.assertIn('property="og:url" content="https://media.energizeos.com/signals/notion-agent-reliability/"', html)
+        self.assertIn('name="twitter:card"', html)
+        self.assertIn('type="application/ld+json"', html)
+        self.assertIn('"@type": "TechArticle"', html)
+
+    def test_signals_index_has_organization_json_ld(self):
+        sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
+
+        html = (self.root / "signals" / "index.html").read_text(encoding="utf-8")
+        self.assertIn('"@type": "Organization"', html)
+        self.assertIn('"name": "EnergizeOS Media"', html)
+        self.assertIn('<link rel="alternate" type="application/rss+xml"', html)
 
     def test_unsafe_source_url_is_blocked(self):
         manifest = sync.sync_records([eligible_record(**{"Source URL": "https://source.dysonx." + "invalid/research"})], self.root)

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -232,7 +232,6 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
         forbidden = [
             "." + "invalid",
             "." + "test/",
-            "media." + "energizeos.com",
             forbidden_domain(),
             "tmp/" + "production_publish_pack",
         ]
@@ -262,6 +261,10 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
 
     def test_passes_only_for_allowed_signals_paths(self):
         allowed = [
+            "feed.json",
+            "robots.txt",
+            "rss.xml",
+            "sitemap.xml",
             "signals/index.html",
             "signals/public_launch_manifest.json",
             f"signals/{self.slug}/index.html",

--- a/tests/test_dysonx_static_preview_check.py
+++ b/tests/test_dysonx_static_preview_check.py
@@ -41,7 +41,7 @@ class DysonXStaticPreviewCheckTests(unittest.TestCase):
 
     def test_removed_artifact_tokens_are_explicit(self):
         self.assertIn("posts/page1.html", preview_check.REMOVED_PUBLIC_ARTIFACTS)
-        self.assertIn("sitemap.xml", preview_check.REMOVED_PUBLIC_ARTIFACTS)
+        self.assertNotIn("sitemap.xml", preview_check.REMOVED_PUBLIC_ARTIFACTS)
         self.assertIn("scripts/aggregator.py", preview_check.DELETED_LEGACY_SCRIPT_TOKENS)
         self.assertIn("scripts/generate_sitemap.py", preview_check.DELETED_LEGACY_SCRIPT_TOKENS)
 


### PR DESCRIPTION
## Purpose
Add SEO/indexing support for DysonX / EnergizeOS Media Public Signals while preserving the existing public Signals auto-publish and trusted auto-merge safety chain.

## Scope
- Generates robots.txt with the production sitemap URL.
- Generates sitemap.xml, rss.xml, and feed.json from launched public Signals.
- Adds absolute production canonical URLs, Open Graph, Twitter card metadata, and TechArticle JSON-LD to generated Signal pages.
- Adds Organization JSON-LD and feed discovery links to the public Signals index.
- Allows the approved production canonical host in public SEO output checks while keeping temporary/test domains blocked.
- Allows only the new root SEO artifacts in the public Signals auto-merge gate.

## Safety Confirmations
- Public Signals eligibility rules unchanged.
- Topic filter unchanged.
- Attribution/copyright gates unchanged.
- Raw-body gate unchanged.
- Trusted same-run auto-merge behavior unchanged.
- Material-signature timestamp stability preserved.
- Feed output is summary-only and limited to 30 entries.
- No OpenAI call.
- No scraping.
- No CNAME change.
- No legacy aggregators re-enabled.
- No deployment.

## Validation
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check

## Rollback
Revert this PR to remove generated SEO artifacts and restore prior public output guard assumptions.