### PR TITLE
fix: seal DysonX public Signals publishing contract

### DIFF
--- a/.github/workflows/dysonx-notion-public-signals-sync.yml
+++ b/.github/workflows/dysonx-notion-public-signals-sync.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Print public Signals diff stat
         if: always()
-        run: git diff --stat -- signals
+        run: git diff --stat -- signals robots.txt sitemap.xml rss.xml feed.json
 
       - name: Upload public Signals diagnostics
         if: always()
@@ -61,6 +61,11 @@ jobs:
           name: dysonx-public-signals-diagnostics
           path: |
             signals/public_launch_manifest.json
+            signals/public_artifact_manifest.json
+            robots.txt
+            sitemap.xml
+            rss.xml
+            feed.json
             tmp/dysonx_public_signals_sync_report.json
           if-no-files-found: warn
 
@@ -78,7 +83,7 @@ jobs:
       - name: Detect public Signals changes
         id: signals_changes
         run: |
-          if git diff --quiet -- signals; then
+          if git diff --quiet -- signals robots.txt sitemap.xml rss.xml feed.json; then
             echo "[notion-public-signals-sync] no signals changes"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -89,7 +94,7 @@ jobs:
         if: steps.signals_changes.outputs.changed == 'true'
         run: |
           mkdir -p tmp
-          git diff --name-only -- signals > tmp/dysonx_public_signals_changed_files.txt
+          git diff --name-only -- signals robots.txt sitemap.xml rss.xml feed.json > tmp/dysonx_public_signals_changed_files.txt
           python3 -c 'import json; from pathlib import Path; files = Path("tmp/dysonx_public_signals_changed_files.txt").read_text(encoding="utf-8").splitlines(); Path("tmp/dysonx_public_signals_changed_files.json").write_text(json.dumps(files, indent=2) + "\n", encoding="utf-8"); print("changed_files=" + str(len(files)))'
 
       - name: Run trusted public Signals auto-merge gate
@@ -113,6 +118,11 @@ jobs:
           name: dysonx-public-signals-trusted-auto-merge
           path: |
             signals/public_launch_manifest.json
+            signals/public_artifact_manifest.json
+            robots.txt
+            sitemap.xml
+            rss.xml
+            feed.json
             tmp/dysonx_public_signals_sync_report.json
             tmp/dysonx_public_signals_changed_files.json
             tmp/dysonx_public_signals_changed_files.txt
@@ -127,6 +137,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git switch -c "$BRANCH"
           git add signals/
+          git add robots.txt sitemap.xml rss.xml feed.json
           git commit -m "content: sync DysonX public Signals from Notion"
           git push --set-upstream origin "$BRANCH"
           PR_BODY="$(printf 'Automated Notion public Signals sync. Opens PR for audit trail. The trusted DysonX Notion Public Signals Sync workflow merges this PR only if the strict public Signals auto-merge gate passes. No OpenAI call, no scraping, no raw article body copying, no hardcoded deployment domain.\n\n')"

--- a/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
+++ b/.github/workflows/dysonx-public-signals-auto-merge-v1.yml
@@ -78,7 +78,7 @@ jobs:
           import re
           from pathlib import Path
 
-          allowed = re.compile(r"^(signals/index\.html|signals/public_launch_manifest\.json|signals/[^/]+/index\.html)$")
+          allowed = re.compile(r"^(robots\.txt|sitemap\.xml|rss\.xml|feed\.json|signals/index\.html|signals/public_launch_manifest\.json|signals/public_artifact_manifest\.json|signals/[^/]+/index\.html)$")
           files = json.loads(Path("changed_files.json").read_text(encoding="utf-8"))
           bad = [path for path in files if not allowed.match(path)]
           if bad:

--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -18,13 +18,27 @@ from html.parser import HTMLParser
 from typing import Any, Callable
 from urllib.parse import urljoin, urlsplit
 
+from dysonx_public_signals_contract import (
+    ALLOWED_ARTIFACT_CLASSES,
+    ALLOWED_SAFE_EMBEDS,
+    FORBIDDEN_CONTENT_CLASSES,
+    PUBLIC_SEO_BASE_URL,
+    PUBLIC_SIGNAL_CONTRACT_VERSION,
+    PUBLIC_SIGNAL_POLICY_VERSION,
+    build_artifact_entry,
+)
+from dysonx_public_signals_topic_policy import (
+    has_core_public_topic as topic_has_core_public_topic,
+    off_topic_public_signal as topic_off_topic_public_signal,
+    public_topic_decision,
+)
+
 
 SYNC_VERSION = "notion_public_signals_sync_v1"
 TOKEN_ENV = "NOTION_TOKEN"
 DATABASE_ID_ENV = "NOTION_SIGNAL_INTAKE_DATABASE_ID"
 NOTION_VERSION = "2022-06-28"
 DEFAULT_OUTPUT_ROOT = pathlib.Path(".")
-PUBLIC_SEO_BASE_URL = "https://media.energizeos.com"
 PUBLIC_SAFE_SOURCE_NOTE = "Source attribution retained in Notion launch metadata; external source URL omitted for this V1 public sample."
 DEFAULT_MAX_PUBLIC_SIGNALS = 30
 PUBLIC_OUTPUT_MIN_QUALITY = 80
@@ -32,107 +46,6 @@ PUBLIC_OUTPUT_ALLOWED_PRIORITIES = {"High", "Critical"}
 PUBLIC_OUTPUT_ALLOWED_AGI_RELEVANCE = {"Medium", "High", "Critical"}
 SOURCE_PRIORITY_RANK = {"Critical": 0, "High": 1}
 AGI_RELEVANCE_RANK = {"Critical": 0, "High": 1, "Medium": 2}
-OFF_TOPIC_PUBLIC_TERMS = (
-    "agriculture",
-    "biology",
-    "biomedical",
-    "cattle",
-    "cancer",
-    "child online safety",
-    "clinical",
-    "dairy",
-    "drug drug interaction",
-    "drug-drug interaction",
-    "eclipse",
-    "eclipses",
-    "electoral politics",
-    "general news",
-    "general science",
-    "generic policy news",
-    "healthcare diagnosis",
-    "indoor robotics",
-    "lab agent",
-    "lab agents",
-    "laboratory agent",
-    "laboratory agents",
-    "law",
-    "legal deliberation",
-    "legal domain",
-    "legal-domain",
-    "medical",
-    "medical imaging",
-    "methane",
-    "medicine",
-    "oceanography",
-    "online safety",
-    "poetry",
-    "politics",
-    "prostate",
-    "robot vacuum",
-    "social media ban",
-    "social media bans",
-    "ultrasound",
-    "vacuum cleaner",
-)
-OFF_TOPIC_PUBLIC_OVERRIDE_TERMS = (
-    "agi governance",
-    "agi safety",
-    "ai act",
-    "ai governance",
-    "ai regulation",
-    "ai safety",
-    "ai safety evaluation",
-    "frontier ai safety",
-    "frontier model evaluation",
-    "frontier model governance",
-    "frontier model safety",
-    "model evaluation",
-)
-CORE_PUBLIC_TOPIC_TERMS = (
-    "agentic workflow",
-    "agentic workflows",
-    "agi governance",
-    "agi safety",
-    "ai agent",
-    "ai agents",
-    "ai governance",
-    "ai infrastructure",
-    "ai regulation",
-    "ai safety",
-    "autonomous ai agent",
-    "autonomous ai agents",
-    "benchmark",
-    "benchmarks",
-    "code agent",
-    "code agents",
-    "coding agent",
-    "coding agents",
-    "developer tool",
-    "developer tools",
-    "frontier model",
-    "frontier models",
-    "frontier model operations",
-    "llm agent",
-    "llm agents",
-    "llm judge",
-    "llm judges",
-    "model evaluation",
-    "model evaluations",
-)
-MULTI_AGENT_TERMS = ("multi-agent", "multi agent")
-MULTI_AGENT_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "governance", "coordination")
-AGENT_CONTEXT_TERMS = ("capability", "control", "evaluation", "governance", "reliability", "safety", "workflow")
-AUTONOMY_TERMS = ("autonomy", "autonomous systems")
-AUTONOMY_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "control")
-VLA_TERMS = ("vla", "vision-language-action", "vision language action")
-VLA_CONTEXT_TERMS = (
-    "agent capability",
-    "embodied agent",
-    "embodied ai",
-    "foundation model",
-    "robotics agent",
-    "robotics foundation model",
-)
 FORBIDDEN_PUBLIC_TERMS = (
     "." "invalid",
     "." "test/",
@@ -359,44 +272,16 @@ def is_safe_source_url(url: str) -> bool:
 
 
 def off_topic_public_signal(record: dict[str, Any]) -> bool:
-    haystack = " ".join(
-        [
-            signal_title(record),
-            signal_summary(record),
-            normalize_text(field(record, "Category", "Categories", "Tag", "Tags")),
-            source_label(record),
-        ]
-    ).lower()
-    if not any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS):
-        return False
-    return not any(term in haystack for term in OFF_TOPIC_PUBLIC_OVERRIDE_TERMS)
+    return topic_off_topic_public_signal(record)
 
 
 def has_core_public_topic(record: dict[str, Any]) -> bool:
-    haystack = " ".join(
-        [
-            signal_title(record),
-            signal_summary(record),
-            normalize_text(field(record, "Category", "Categories", "Tag", "Tags")),
-            source_label(record),
-            agi_relevance(record),
-        ]
-    ).lower()
-    if any(term in haystack for term in CORE_PUBLIC_TOPIC_TERMS):
-        return True
-    if "agent" in haystack and any(term in haystack for term in AGENT_CONTEXT_TERMS):
-        return True
-    if any(term in haystack for term in MULTI_AGENT_TERMS) and any(term in haystack for term in MULTI_AGENT_CONTEXT_TERMS):
-        return True
-    if any(term in haystack for term in AUTONOMY_TERMS) and any(term in haystack for term in AUTONOMY_CONTEXT_TERMS):
-        return True
-    if any(term in haystack for term in VLA_TERMS) and any(term in haystack for term in VLA_CONTEXT_TERMS):
-        return True
-    return False
+    return topic_has_core_public_topic(record)
 
 
 def eligibility_blockers(record: dict[str, Any]) -> list[str]:
     blockers: list[str] = []
+    topic_decision = public_topic_decision(record)
     if source_priority(record) not in PUBLIC_OUTPUT_ALLOWED_PRIORITIES:
         blockers.append("source_priority_below_high")
     if attribution_status(record) != "Complete":
@@ -407,9 +292,9 @@ def eligibility_blockers(record: dict[str, Any]) -> list[str]:
         blockers.append("quality_hint_below_80")
     if agi_relevance(record) not in PUBLIC_OUTPUT_ALLOWED_AGI_RELEVANCE:
         blockers.append("agi_relevance_below_medium")
-    if off_topic_public_signal(record):
+    if topic_decision["off_topic_public_signal"]:
         blockers.append("off_topic_public_signal")
-    if not has_core_public_topic(record):
+    if not topic_decision["has_core_public_topic"]:
         blockers.append("missing_core_public_topic")
     if not signal_title(record):
         blockers.append("missing_signal_title")
@@ -575,6 +460,7 @@ def existing_public_signals(output_root: pathlib.Path) -> list[dict[str, Any]]:
 
 
 def record_from_notion(record: dict[str, Any]) -> dict[str, Any]:
+    decision = public_topic_decision(record)
     return {
         "signal_id": normalize_text(field(record, "Signal ID", "signal_id", "_notion_page_id")) or f"notion_{signal_slug(record)}",
         "slug": signal_slug(record),
@@ -594,6 +480,7 @@ def record_from_notion(record: dict[str, Any]) -> dict[str, Any]:
         "risk_notes": text_field(record, "Risk Notes", "Safety Notes", "risk_notes", default="Summary-only; source text not reproduced."),
         "watch_next": text_field(record, "Watch Next", "watch_next", default="Watch for follow-up Signals in the Notion-managed intake."),
         "tags": tags(record),
+        "topic_decision": decision,
         "existing": False,
     }
 
@@ -871,6 +758,7 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
             "copyright_status": record.get("copyright_status", ""),
             "quality_hint": record.get("quality_hint", ""),
             "ready_for_pipeline": bool(record.get("ready_for_pipeline")),
+            "topic_decision": record.get("topic_decision") or public_topic_decision(record),
             "production_publish_performed": True,
         }
         for record in records
@@ -893,6 +781,32 @@ def build_manifest(records: list[dict[str, Any]], blocked_count: int, refreshed_
         "newsletter_distribution_performed": False,
         "source_pack_manifest": "notion_signal_intake_public_safe_reference",
         "source_release_guard_report": "static_preview_link_integrity_check",
+    }
+
+
+def build_artifact_manifest(records: list[dict[str, Any]], public_manifest: dict[str, Any]) -> dict[str, Any]:
+    material = normalize_text(public_manifest.get("material_signature"))
+    artifact_paths = [
+        "signals/index.html",
+        "signals/public_launch_manifest.json",
+        "signals/public_artifact_manifest.json",
+        "robots.txt",
+        "sitemap.xml",
+        "rss.xml",
+        "feed.json",
+        *[f"signals/{record['slug']}/index.html" for record in records],
+    ]
+    artifacts = [build_artifact_entry(path, material) for path in sorted(set(artifact_paths))]
+    return {
+        "contract_version": PUBLIC_SIGNAL_CONTRACT_VERSION,
+        "policy_version": PUBLIC_SIGNAL_POLICY_VERSION,
+        "generated_from_public_signal_manifest": True,
+        "public_launch_manifest_path": "signals/public_launch_manifest.json",
+        "public_launch_manifest_material_signature": material,
+        "allowed_artifact_classes": sorted(ALLOWED_ARTIFACT_CLASSES),
+        "allowed_safe_embeds": sorted(ALLOWED_SAFE_EMBEDS),
+        "forbidden_content_classes": sorted(FORBIDDEN_CONTENT_CLASSES),
+        "artifacts": artifacts,
     }
 
 
@@ -1054,6 +968,10 @@ def sync_records(
     manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
     assert_public_safe(manifest_text, "public launch manifest")
     (signals_root / "public_launch_manifest.json").write_text(manifest_text, encoding="utf-8")
+    artifact_manifest = build_artifact_manifest(merged, manifest)
+    artifact_manifest_text = json.dumps(artifact_manifest, indent=2, sort_keys=True) + "\n"
+    assert_public_safe(artifact_manifest_text, "public artifact manifest")
+    (signals_root / "public_artifact_manifest.json").write_text(artifact_manifest_text, encoding="utf-8")
     seo_outputs = {
         "robots.txt": render_robots(),
         "sitemap.xml": render_sitemap(merged, refreshed_at),

--- a/scripts/dysonx_public_signals_auto_merge_gate.py
+++ b/scripts/dysonx_public_signals_auto_merge_gate.py
@@ -4,128 +4,43 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import pathlib
 import re
 import sys
+import xml.etree.ElementTree as ET
 from html.parser import HTMLParser
 from typing import Any
 from urllib.parse import urlsplit
 
+from dysonx_public_signals_contract import (
+    ALLOWED_ARTIFACT_CLASSES,
+    ARTIFACT_JSON_FEED,
+    ARTIFACT_PUBLIC_ARTIFACT_MANIFEST,
+    ARTIFACT_PUBLIC_LAUNCH_MANIFEST,
+    ARTIFACT_ROBOTS_TXT,
+    ARTIFACT_RSS_XML,
+    ARTIFACT_SIGNAL_HTML,
+    ARTIFACT_SIGNALS_INDEX_HTML,
+    ARTIFACT_SITEMAP_XML,
+    PUBLIC_SEO_BASE_URL,
+    PUBLIC_SIGNAL_CONTRACT_VERSION,
+    artifact_class_for_path,
+    allowed_embeds_for_artifact_class,
+    is_allowed_public_artifact_path,
+    normalize_public_path,
+    signal_slug_from_public_path,
+)
+from dysonx_public_signals_topic_policy import (
+    has_core_public_topic as topic_has_core_public_topic,
+    off_topic_public_signal as topic_off_topic_public_signal,
+)
 
 GATE_VERSION = "dysonx_public_signals_auto_merge_gate_v1"
-ALLOWED_STATIC_FILES = {
-    "feed.json",
-    "robots.txt",
-    "rss.xml",
-    "sitemap.xml",
-    "signals/index.html",
-    "signals/public_launch_manifest.json",
-}
 MIN_PUBLIC_QUALITY = 80
 ALLOWED_SOURCE_PRIORITIES = {"High", "Critical"}
 ALLOWED_AGI_RELEVANCE = {"Medium", "High", "Critical"}
-OFF_TOPIC_PUBLIC_TERMS = (
-    "agriculture",
-    "biology",
-    "biomedical",
-    "cattle",
-    "cancer",
-    "child online safety",
-    "clinical",
-    "dairy",
-    "drug drug interaction",
-    "drug-drug interaction",
-    "eclipse",
-    "eclipses",
-    "electoral politics",
-    "general news",
-    "general science",
-    "generic policy news",
-    "healthcare diagnosis",
-    "indoor robotics",
-    "lab agent",
-    "lab agents",
-    "laboratory agent",
-    "laboratory agents",
-    "law",
-    "legal deliberation",
-    "legal domain",
-    "legal-domain",
-    "medical",
-    "medical imaging",
-    "methane",
-    "medicine",
-    "oceanography",
-    "online safety",
-    "poetry",
-    "politics",
-    "prostate",
-    "robot vacuum",
-    "social media ban",
-    "social media bans",
-    "ultrasound",
-    "vacuum cleaner",
-)
-OFF_TOPIC_PUBLIC_OVERRIDE_TERMS = (
-    "agi governance",
-    "agi safety",
-    "ai act",
-    "ai governance",
-    "ai regulation",
-    "ai safety",
-    "ai safety evaluation",
-    "frontier ai safety",
-    "frontier model evaluation",
-    "frontier model governance",
-    "frontier model safety",
-    "model evaluation",
-)
-CORE_PUBLIC_TOPIC_TERMS = (
-    "agentic workflow",
-    "agentic workflows",
-    "agi governance",
-    "agi safety",
-    "ai agent",
-    "ai agents",
-    "ai governance",
-    "ai infrastructure",
-    "ai regulation",
-    "ai safety",
-    "autonomous ai agent",
-    "autonomous ai agents",
-    "benchmark",
-    "benchmarks",
-    "code agent",
-    "code agents",
-    "coding agent",
-    "coding agents",
-    "developer tool",
-    "developer tools",
-    "frontier model",
-    "frontier models",
-    "frontier model operations",
-    "llm agent",
-    "llm agents",
-    "llm judge",
-    "llm judges",
-    "model evaluation",
-    "model evaluations",
-)
-MULTI_AGENT_TERMS = ("multi-agent", "multi agent")
-MULTI_AGENT_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "governance", "coordination")
-AGENT_CONTEXT_TERMS = ("capability", "control", "evaluation", "governance", "reliability", "safety", "workflow")
-AUTONOMY_TERMS = ("autonomy", "autonomous systems")
-AUTONOMY_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "control")
-VLA_TERMS = ("vla", "vision-language-action", "vision language action")
-VLA_CONTEXT_TERMS = (
-    "agent capability",
-    "embodied agent",
-    "embodied ai",
-    "foundation model",
-    "robotics agent",
-    "robotics foundation model",
-)
 FORBIDDEN_TERMS = (
     "https://dysonx." "ai",
     "source.dysonx." "invalid",
@@ -151,19 +66,23 @@ class AutoMergeGateError(RuntimeError):
     """Raised when the public Signals auto-merge gate must block."""
 
 
-class HrefParser(HTMLParser):
+class PublicHtmlParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.hrefs: list[str] = []
         self.ids: set[str] = set()
-        self.script_tags = 0
+        self.scripts: list[dict[str, Any]] = []
+        self._script_stack: list[dict[str, Any]] = []
         self.iframe_tags = 0
         self.inline_event_handlers: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        tag = tag.lower()
         attr_map = {key.lower(): value or "" for key, value in attrs}
         if tag == "script":
-            self.script_tags += 1
+            script = {"attrs": attr_map, "content": ""}
+            self.scripts.append(script)
+            self._script_stack.append(script)
         if tag == "iframe":
             self.iframe_tags += 1
         if "id" in attr_map and attr_map["id"]:
@@ -172,23 +91,21 @@ class HrefParser(HTMLParser):
             self.hrefs.append(attr_map["href"])
         self.inline_event_handlers.extend(key for key in attr_map if key.startswith("on"))
 
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() == "script" and self._script_stack:
+            self._script_stack.pop()
 
-def normalize_path(value: str) -> str:
-    return value.strip().lstrip("./")
+    def handle_data(self, data: str) -> None:
+        if self._script_stack:
+            self._script_stack[-1]["content"] += data
 
 
 def signal_slug_from_path(path: str) -> str | None:
-    parts = pathlib.PurePosixPath(normalize_path(path)).parts
-    if len(parts) == 3 and parts[0] == "signals" and parts[2] == "index.html":
-        return parts[1]
-    return None
+    return signal_slug_from_public_path(path)
 
 
 def is_allowed_changed_file(path: str) -> bool:
-    normalized = normalize_path(path)
-    if normalized in ALLOWED_STATIC_FILES:
-        return True
-    return signal_slug_from_path(normalized) is not None
+    return is_allowed_public_artifact_path(path)
 
 
 def load_changed_files(path: str | None) -> list[str]:
@@ -197,7 +114,7 @@ def load_changed_files(path: str | None) -> list[str]:
     data = json.loads(pathlib.Path(path).read_text(encoding="utf-8"))
     if not isinstance(data, list) or not all(isinstance(item, str) for item in data):
         raise AutoMergeGateError("changed files JSON must be a list of strings")
-    return [normalize_path(item) for item in data]
+    return [normalize_public_path(item) for item in data]
 
 
 def fail_if_forbidden_text(text: str, label: str) -> None:
@@ -210,6 +127,15 @@ def fail_if_forbidden_text(text: str, label: str) -> None:
             raise AutoMergeGateError(f"{label} contains raw/source body marker: {marker}")
 
 
+def load_json_object(path: pathlib.Path, label: str) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    fail_if_forbidden_text(text, label)
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise AutoMergeGateError(f"{label} must be a JSON object")
+    return data
+
+
 def public_path_exists(root: pathlib.Path, href: str) -> bool:
     path = urlsplit(href).path
     if path == "/":
@@ -220,21 +146,59 @@ def public_path_exists(root: pathlib.Path, href: str) -> bool:
     return (root / relative).exists()
 
 
-def check_html_file(path: pathlib.Path, root: pathlib.Path) -> None:
+def validate_json_ld_script(script: dict[str, Any], artifact_class: str, label: str) -> None:
+    attrs = script["attrs"]
+    if attrs.get("src"):
+        raise AutoMergeGateError(f"{label} contains external script src")
+    if attrs.get("type") != "application/ld+json":
+        raise AutoMergeGateError(f"{label} contains non-JSON-LD script tag")
+    content = html.unescape(str(script.get("content") or "")).strip()
+    fail_if_forbidden_text(content, f"{label} JSON-LD")
+    if INLINE_EVENT_PATTERN.search(content) or "javascript:" in content.lower():
+        raise AutoMergeGateError(f"{label} JSON-LD contains unsafe script-like text")
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise AutoMergeGateError(f"{label} contains malformed JSON-LD") from exc
+    nodes = data if isinstance(data, list) else [data]
+    allowed_types = {
+        ARTIFACT_SIGNAL_HTML: {"TechArticle", "Article"},
+        ARTIFACT_SIGNALS_INDEX_HTML: {"Organization"},
+    }.get(artifact_class, set())
+    if not allowed_types:
+        raise AutoMergeGateError(f"{label} is not allowed to contain JSON-LD")
+    for node in nodes:
+        if not isinstance(node, dict):
+            raise AutoMergeGateError(f"{label} JSON-LD nodes must be objects")
+        raw_type = node.get("@type")
+        node_types = set(raw_type if isinstance(raw_type, list) else [raw_type])
+        if not node_types.intersection(allowed_types):
+            raise AutoMergeGateError(f"{label} JSON-LD type must be one of {sorted(allowed_types)}")
+        payload = json.dumps(node, sort_keys=True)
+        if "javascript:" in payload.lower() or INLINE_EVENT_PATTERN.search(payload):
+            raise AutoMergeGateError(f"{label} JSON-LD contains unsafe script-like text")
+        if PUBLIC_SEO_BASE_URL in payload:
+            continue
+        if any(str(value).startswith("http") for value in node.values() if isinstance(value, str)):
+            # External source citations are allowed, but public page URLs must remain canonical.
+            continue
+
+
+def check_html_file(path: pathlib.Path, root: pathlib.Path, artifact_class: str) -> None:
     if not path.exists():
         raise AutoMergeGateError(f"changed public HTML file is missing: {path}")
     text = path.read_text(encoding="utf-8", errors="ignore")
     fail_if_forbidden_text(text, str(path))
     if INLINE_EVENT_PATTERN.search(text):
         raise AutoMergeGateError(f"{path} contains inline event handler")
-    parser = HrefParser()
+    parser = PublicHtmlParser()
     parser.feed(text)
-    if parser.script_tags:
-        raise AutoMergeGateError(f"{path} contains script tag")
     if parser.iframe_tags:
         raise AutoMergeGateError(f"{path} contains iframe tag")
     if parser.inline_event_handlers:
         raise AutoMergeGateError(f"{path} contains inline event handler attribute")
+    for script in parser.scripts:
+        validate_json_ld_script(script, artifact_class, str(path))
     for href in parser.hrefs:
         lowered = href.lower()
         if not href or href == "#":
@@ -255,6 +219,77 @@ def check_html_file(path: pathlib.Path, root: pathlib.Path) -> None:
                 raise AutoMergeGateError(f"{path} contains invalid external source link: {href}")
             continue
         raise AutoMergeGateError(f"{path} contains non-relative unsupported href: {href}")
+
+
+def validate_robots(path: pathlib.Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    expected = f"User-agent: *\nAllow: /\nSitemap: {PUBLIC_SEO_BASE_URL}/sitemap.xml\n"
+    fail_if_forbidden_text(text, str(path))
+    if text != expected:
+        raise AutoMergeGateError("robots.txt must only allow crawling and point to the production sitemap")
+
+
+def validate_sitemap(path: pathlib.Path, launched_slugs: set[str]) -> None:
+    text = path.read_text(encoding="utf-8")
+    fail_if_forbidden_text(text, str(path))
+    root = ET.fromstring(text)
+    namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+    allowed_urls = {f"{PUBLIC_SEO_BASE_URL}/", f"{PUBLIC_SEO_BASE_URL}/signals/"}
+    allowed_urls.update(f"{PUBLIC_SEO_BASE_URL}/signals/{slug}/" for slug in launched_slugs)
+    found_urls: set[str] = set()
+    for url_node in root.findall("sm:url", namespace):
+        loc = (url_node.findtext("sm:loc", default="", namespaces=namespace) or "").strip()
+        lastmod = (url_node.findtext("sm:lastmod", default="", namespaces=namespace) or "").strip()
+        if loc not in allowed_urls:
+            raise AutoMergeGateError(f"sitemap contains non-canonical or blocked URL: {loc}")
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", lastmod):
+            raise AutoMergeGateError(f"sitemap lastmod must be stable YYYY-MM-DD: {lastmod}")
+        found_urls.add(loc)
+    required = {f"{PUBLIC_SEO_BASE_URL}/", f"{PUBLIC_SEO_BASE_URL}/signals/"}
+    if not required.issubset(found_urls):
+        raise AutoMergeGateError("sitemap must include homepage and /signals/")
+
+
+def validate_rss(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -> None:
+    text = path.read_text(encoding="utf-8")
+    fail_if_forbidden_text(text, str(path))
+    root = ET.fromstring(text)
+    items = root.findall("./channel/item")
+    if len(items) > 30:
+        raise AutoMergeGateError("rss.xml must not include more than 30 items")
+    summaries = {entry.get("summary", "") for entry in entries.values()}
+    for item in items:
+        link = (item.findtext("link") or "").strip()
+        description = (item.findtext("description") or "").strip()
+        source = item.find("source")
+        if not link.startswith(f"{PUBLIC_SEO_BASE_URL}/signals/"):
+            raise AutoMergeGateError(f"rss.xml item link must be canonical public URL: {link}")
+        if description not in summaries:
+            raise AutoMergeGateError("rss.xml item description must match summary-only manifest content")
+        if source is None or not (source.attrib.get("url") or "").startswith(("http://", "https://")):
+            raise AutoMergeGateError("rss.xml item source attribution URL is missing")
+
+
+def validate_json_feed(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -> None:
+    data = load_json_object(path, "feed.json")
+    items = data.get("items")
+    if not isinstance(items, list):
+        raise AutoMergeGateError("feed.json items must be a list")
+    if len(items) > 30:
+        raise AutoMergeGateError("feed.json must not include more than 30 items")
+    summaries = {entry.get("summary", "") for entry in entries.values()}
+    for item in items:
+        if not isinstance(item, dict):
+            raise AutoMergeGateError("feed.json items must be objects")
+        url = str(item.get("url") or "")
+        content_text = str(item.get("content_text") or "")
+        if not url.startswith(f"{PUBLIC_SEO_BASE_URL}/signals/"):
+            raise AutoMergeGateError(f"feed.json item URL must be canonical public URL: {url}")
+        if content_text not in summaries:
+            raise AutoMergeGateError("feed.json content_text must match summary-only manifest content")
+        external_url = str(item.get("external_url") or "")
+        if external_url and not external_url.startswith(("http://", "https://")):
+            raise AutoMergeGateError("feed.json external_url must be absolute http/https when present")
 
 
 def launched_by_slug(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -291,31 +326,11 @@ def check_manifest_flags(manifest: dict[str, Any]) -> None:
 
 
 def off_topic_public_signal(entry: dict[str, Any]) -> bool:
-    haystack = " ".join(
-        str(entry.get(key) or "")
-        for key in ("title", "summary", "source_name", "source_priority", "agi_relevance")
-    ).lower()
-    if not any(term in haystack for term in OFF_TOPIC_PUBLIC_TERMS):
-        return False
-    return not any(term in haystack for term in OFF_TOPIC_PUBLIC_OVERRIDE_TERMS)
+    return topic_off_topic_public_signal(entry)
 
 
 def has_core_public_topic(entry: dict[str, Any]) -> bool:
-    haystack = " ".join(
-        str(entry.get(key) or "")
-        for key in ("title", "summary", "source_name", "source_priority", "agi_relevance")
-    ).lower()
-    if any(term in haystack for term in CORE_PUBLIC_TOPIC_TERMS):
-        return True
-    if "agent" in haystack and any(term in haystack for term in AGENT_CONTEXT_TERMS):
-        return True
-    if any(term in haystack for term in MULTI_AGENT_TERMS) and any(term in haystack for term in MULTI_AGENT_CONTEXT_TERMS):
-        return True
-    if any(term in haystack for term in AUTONOMY_TERMS) and any(term in haystack for term in AUTONOMY_CONTEXT_TERMS):
-        return True
-    if any(term in haystack for term in VLA_TERMS) and any(term in haystack for term in VLA_CONTEXT_TERMS):
-        return True
-    return False
+    return topic_has_core_public_topic(entry)
 
 
 def check_entry(entry: dict[str, Any], *, min_quality: float, allowed_priorities: set[str], allowed_agi_relevance: set[str], require_attribution_complete: bool, require_safe_summary_only: bool) -> None:
@@ -348,20 +363,82 @@ def check_entry(entry: dict[str, Any], *, min_quality: float, allowed_priorities
         raise AutoMergeGateError(f"{slug} is missing a core DysonX public topic")
 
 
-def run_gate(args: argparse.Namespace) -> None:
-    manifest_path = pathlib.Path(args.manifest)
-    root = manifest_path.parent.parent
-    manifest_text = manifest_path.read_text(encoding="utf-8")
-    fail_if_forbidden_text(manifest_text, str(manifest_path))
-    manifest = json.loads(manifest_text)
-    if not isinstance(manifest, dict):
-        raise AutoMergeGateError("manifest must be a JSON object")
-    check_manifest_flags(manifest)
+def load_artifact_manifest(root: pathlib.Path) -> dict[str, Any]:
+    path = root / "signals" / "public_artifact_manifest.json"
+    if not path.exists():
+        raise AutoMergeGateError("signals/public_artifact_manifest.json is missing")
+    data = load_json_object(path, "public artifact manifest")
+    if data.get("contract_version") != PUBLIC_SIGNAL_CONTRACT_VERSION:
+        raise AutoMergeGateError("public artifact manifest has unsupported contract_version")
+    artifacts = data.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise AutoMergeGateError("public artifact manifest artifacts must be a list")
+    return data
 
-    changed_files = load_changed_files(args.changed_files_json)
+
+def artifact_entries_by_path(artifact_manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    entries: dict[str, dict[str, Any]] = {}
+    for item in artifact_manifest.get("artifacts", []):
+        if not isinstance(item, dict):
+            raise AutoMergeGateError("artifact manifest entries must be objects")
+        path = normalize_public_path(str(item.get("path") or ""))
+        artifact_class = str(item.get("artifact_class") or "")
+        if not path:
+            raise AutoMergeGateError("artifact manifest entry missing path")
+        if path in entries:
+            raise AutoMergeGateError(f"artifact manifest declares duplicate path: {path}")
+        if artifact_class not in ALLOWED_ARTIFACT_CLASSES:
+            raise AutoMergeGateError(f"artifact manifest declares unknown artifact_class: {artifact_class}")
+        expected_class = artifact_class_for_path(path)
+        if expected_class != artifact_class:
+            raise AutoMergeGateError(f"artifact manifest class/path mismatch for {path}: {artifact_class}")
+        if item.get("contract_version") != PUBLIC_SIGNAL_CONTRACT_VERSION:
+            raise AutoMergeGateError(f"artifact manifest entry has unsupported contract_version: {path}")
+        declared_embeds = item.get("allowed_embeds")
+        if declared_embeds != allowed_embeds_for_artifact_class(artifact_class):
+            raise AutoMergeGateError(f"artifact manifest entry has wrong allowed_embeds: {path}")
+        entries[path] = item
+    return entries
+
+
+def validate_changed_files_declared(changed_files: list[str], artifact_entries: dict[str, dict[str, Any]]) -> None:
     for changed_file in changed_files:
         if not is_allowed_changed_file(changed_file):
             raise AutoMergeGateError(f"changed file is outside allowed public Signals paths: {changed_file}")
+        if changed_file not in artifact_entries:
+            raise AutoMergeGateError(f"changed public artifact is not declared: {changed_file}")
+
+
+def validate_public_artifact(path: str, root: pathlib.Path, artifact_class: str, entries: dict[str, dict[str, Any]]) -> None:
+    full_path = root / path
+    if not full_path.exists():
+        raise AutoMergeGateError(f"changed public artifact is missing: {path}")
+    if artifact_class in {ARTIFACT_SIGNAL_HTML, ARTIFACT_SIGNALS_INDEX_HTML}:
+        check_html_file(full_path, root, artifact_class)
+    elif artifact_class == ARTIFACT_ROBOTS_TXT:
+        validate_robots(full_path)
+    elif artifact_class == ARTIFACT_SITEMAP_XML:
+        validate_sitemap(full_path, set(entries))
+    elif artifact_class == ARTIFACT_RSS_XML:
+        validate_rss(full_path, entries)
+    elif artifact_class == ARTIFACT_JSON_FEED:
+        validate_json_feed(full_path, entries)
+    elif artifact_class in {ARTIFACT_PUBLIC_LAUNCH_MANIFEST, ARTIFACT_PUBLIC_ARTIFACT_MANIFEST}:
+        fail_if_forbidden_text(full_path.read_text(encoding="utf-8"), path)
+    else:
+        raise AutoMergeGateError(f"unsupported artifact class: {artifact_class}")
+
+
+def run_gate(args: argparse.Namespace) -> None:
+    manifest_path = pathlib.Path(args.manifest)
+    root = manifest_path.parent.parent
+    manifest = load_json_object(manifest_path, str(manifest_path))
+    check_manifest_flags(manifest)
+    artifact_manifest = load_artifact_manifest(root)
+    artifact_entries = artifact_entries_by_path(artifact_manifest)
+
+    changed_files = load_changed_files(args.changed_files_json)
+    validate_changed_files_declared(changed_files, artifact_entries)
 
     entries = launched_by_slug(manifest)
     slugs_to_check = changed_signal_slugs(changed_files, manifest)
@@ -381,11 +458,23 @@ def run_gate(args: argparse.Namespace) -> None:
             require_safe_summary_only=args.require_safe_summary_only,
         )
 
-    paths_to_check = {path for path in changed_files if path.endswith(".html")}
+    paths_to_check = set(changed_files)
     if not changed_files:
-        paths_to_check = {"signals/index.html", *[f"signals/{slug}/index.html" for slug in slugs_to_check]}
+        paths_to_check = {
+            "signals/index.html",
+            "signals/public_launch_manifest.json",
+            "signals/public_artifact_manifest.json",
+            "robots.txt",
+            "sitemap.xml",
+            "rss.xml",
+            "feed.json",
+            *[f"signals/{slug}/index.html" for slug in slugs_to_check],
+        }
     for relative_path in sorted(paths_to_check):
-        check_html_file(root / relative_path, root)
+        artifact = artifact_entries.get(relative_path)
+        if not artifact:
+            raise AutoMergeGateError(f"public artifact is not declared: {relative_path}")
+        validate_public_artifact(relative_path, root, str(artifact["artifact_class"]), entries)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/dysonx_public_signals_contract.py
+++ b/scripts/dysonx_public_signals_contract.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Contract metadata for DysonX Public Signals artifacts."""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+
+PUBLIC_SIGNAL_CONTRACT_VERSION = "dysonx_public_signal_contract_v1"
+PUBLIC_SIGNAL_POLICY_VERSION = "dysonx_public_signal_policy_v2"
+PUBLIC_SEO_BASE_URL = "https://media.energizeos.com"
+
+ARTIFACT_SIGNAL_HTML = "signal_html"
+ARTIFACT_SIGNALS_INDEX_HTML = "signals_index_html"
+ARTIFACT_PUBLIC_LAUNCH_MANIFEST = "public_launch_manifest"
+ARTIFACT_PUBLIC_ARTIFACT_MANIFEST = "public_artifact_manifest"
+ARTIFACT_ROBOTS_TXT = "robots_txt"
+ARTIFACT_SITEMAP_XML = "sitemap_xml"
+ARTIFACT_RSS_XML = "rss_xml"
+ARTIFACT_JSON_FEED = "json_feed"
+
+ALLOWED_ARTIFACT_CLASSES = {
+    ARTIFACT_SIGNAL_HTML,
+    ARTIFACT_SIGNALS_INDEX_HTML,
+    ARTIFACT_PUBLIC_LAUNCH_MANIFEST,
+    ARTIFACT_PUBLIC_ARTIFACT_MANIFEST,
+    ARTIFACT_ROBOTS_TXT,
+    ARTIFACT_SITEMAP_XML,
+    ARTIFACT_RSS_XML,
+    ARTIFACT_JSON_FEED,
+}
+
+SAFE_EMBED_JSON_LD_ARTICLE = "json_ld_article"
+SAFE_EMBED_JSON_LD_ORGANIZATION = "json_ld_organization"
+ALLOWED_SAFE_EMBEDS = {
+    SAFE_EMBED_JSON_LD_ARTICLE,
+    SAFE_EMBED_JSON_LD_ORGANIZATION,
+}
+
+FORBIDDEN_CONTENT_CLASSES = {
+    "raw_body",
+    "source_body",
+    "verbatim_article",
+    "unsafe_script",
+    "unsafe_external_resource",
+    "off_topic",
+}
+
+ROOT_ARTIFACT_CLASSES = {
+    "robots.txt": ARTIFACT_ROBOTS_TXT,
+    "sitemap.xml": ARTIFACT_SITEMAP_XML,
+    "rss.xml": ARTIFACT_RSS_XML,
+    "feed.json": ARTIFACT_JSON_FEED,
+}
+
+SIGNALS_ARTIFACT_CLASSES = {
+    "signals/index.html": ARTIFACT_SIGNALS_INDEX_HTML,
+    "signals/public_launch_manifest.json": ARTIFACT_PUBLIC_LAUNCH_MANIFEST,
+    "signals/public_artifact_manifest.json": ARTIFACT_PUBLIC_ARTIFACT_MANIFEST,
+}
+
+
+def normalize_public_path(value: str | pathlib.PurePath) -> str:
+    return str(value).strip().replace("\\", "/").lstrip("./")
+
+
+def signal_slug_from_public_path(path: str | pathlib.PurePath) -> str | None:
+    parts = pathlib.PurePosixPath(normalize_public_path(path)).parts
+    if len(parts) == 3 and parts[0] == "signals" and parts[2] == "index.html" and parts[1] != "index":
+        return parts[1]
+    return None
+
+
+def artifact_class_for_path(path: str | pathlib.PurePath) -> str | None:
+    normalized = normalize_public_path(path)
+    if normalized in ROOT_ARTIFACT_CLASSES:
+        return ROOT_ARTIFACT_CLASSES[normalized]
+    if normalized in SIGNALS_ARTIFACT_CLASSES:
+        return SIGNALS_ARTIFACT_CLASSES[normalized]
+    if signal_slug_from_public_path(normalized):
+        return ARTIFACT_SIGNAL_HTML
+    return None
+
+
+def allowed_embeds_for_artifact_class(artifact_class: str) -> list[str]:
+    if artifact_class == ARTIFACT_SIGNAL_HTML:
+        return [SAFE_EMBED_JSON_LD_ARTICLE]
+    if artifact_class == ARTIFACT_SIGNALS_INDEX_HTML:
+        return [SAFE_EMBED_JSON_LD_ORGANIZATION]
+    return []
+
+
+def is_allowed_public_artifact_path(path: str | pathlib.PurePath) -> bool:
+    return artifact_class_for_path(path) in ALLOWED_ARTIFACT_CLASSES
+
+
+def artifact_slug(path: str | pathlib.PurePath, artifact_class: str) -> str | None:
+    if artifact_class == ARTIFACT_SIGNAL_HTML:
+        return signal_slug_from_public_path(path)
+    return None
+
+
+def build_artifact_entry(path: str, material_signature: str, *, generated: bool = True) -> dict[str, Any]:
+    artifact_class = artifact_class_for_path(path)
+    if artifact_class not in ALLOWED_ARTIFACT_CLASSES:
+        raise ValueError(f"unsupported public artifact path: {path}")
+    entry: dict[str, Any] = {
+        "path": normalize_public_path(path),
+        "artifact_class": artifact_class,
+        "contract_version": PUBLIC_SIGNAL_CONTRACT_VERSION,
+        "policy_version": PUBLIC_SIGNAL_POLICY_VERSION,
+        "allowed_embeds": allowed_embeds_for_artifact_class(artifact_class),
+        "material_signature": material_signature,
+        "generated_from_public_signal_manifest": generated,
+    }
+    slug = artifact_slug(path, artifact_class)
+    if slug:
+        entry["slug"] = slug
+    return entry

--- a/scripts/dysonx_public_signals_topic_policy.py
+++ b/scripts/dysonx_public_signals_topic_policy.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Reusable topic policy for DysonX Public Signals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+CORE_PUBLIC_TOPIC_TERMS = (
+    "agentic workflow",
+    "agentic workflows",
+    "agi governance",
+    "agi safety",
+    "ai agent",
+    "ai agents",
+    "ai governance",
+    "ai infrastructure",
+    "ai regulation",
+    "ai safety",
+    "autonomous ai agent",
+    "autonomous ai agents",
+    "benchmark",
+    "benchmarks",
+    "code agent",
+    "code agents",
+    "coding agent",
+    "coding agents",
+    "developer tool",
+    "developer tools",
+    "formal verification",
+    "frontier model",
+    "frontier models",
+    "frontier model operations",
+    "llm agent",
+    "llm agents",
+    "llm judge",
+    "llm judges",
+    "model evaluation",
+    "model evaluations",
+)
+
+DOMAIN_RISK_GROUPS = {
+    "child_online_safety": ("child online safety", "online safety", "social media ban", "social media bans"),
+    "medical": (
+        "biomedical",
+        "cancer",
+        "clinical",
+        "drug",
+        "drug drug interaction",
+        "drug-drug interaction",
+        "healthcare diagnosis",
+        "laparoscopic",
+        "medical",
+        "medical imaging",
+        "medicine",
+        "prostate",
+        "surgical",
+        "ultrasound",
+    ),
+    "biological_lab": ("biology", "lab agent", "lab agents", "laboratory agent", "laboratory agents"),
+    "legal": ("law", "legal deliberation", "legal domain", "legal-domain"),
+    "agriculture": ("agriculture", "agricultural", "cattle", "dairy", "methane"),
+    "oceanography": ("oceanography",),
+    "poetry": ("eclipse", "eclipses", "poetry"),
+    "generic_news": ("electoral politics", "general news", "general science", "generic policy news", "politics"),
+    "household_robotics": ("robot vacuum", "vacuum cleaner"),
+    "generic_robotics": ("generic indoor robotics", "household robotics", "indoor robotics"),
+}
+
+DOMAIN_RISK_CLEAR_FRAMING_TERMS = (
+    "agent audit",
+    "agent transparency",
+    "agi governance",
+    "agi safety",
+    "ai agent governance",
+    "ai governance",
+    "ai regulation",
+    "ai safety",
+    "ai safety evaluation",
+    "autonomous capability tracking",
+    "embodied ai",
+    "formal verification of ai behavior",
+    "foundation model",
+    "frontier ai safety",
+    "frontier model evaluation",
+    "frontier model governance",
+    "frontier model safety",
+    "model evaluation",
+    "multi-agent planning",
+    "vla capability evaluation",
+)
+
+MULTI_AGENT_TERMS = ("multi-agent", "multi agent")
+MULTI_AGENT_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "governance", "coordination", "planning")
+AGENT_CONTEXT_TERMS = ("audit", "capability", "control", "evaluation", "governance", "reliability", "safety", "transparency", "workflow")
+AUTONOMY_TERMS = ("autonomy", "autonomous systems")
+AUTONOMY_CONTEXT_TERMS = ("ai", "agent", "capability", "safety", "evaluation", "control")
+VLA_TERMS = ("vla", "vision-language-action", "vision language action")
+VLA_CONTEXT_TERMS = (
+    "agent capability",
+    "embodied agent",
+    "embodied ai",
+    "foundation model",
+    "robotics agent",
+    "robotics foundation model",
+)
+
+
+def normalize_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def field(record: dict[str, Any], *names: str) -> Any:
+    lowered = {key.lower(): value for key, value in record.items()}
+    for name in names:
+        if name in record:
+            return record[name]
+        value = lowered.get(name.lower())
+        if value is not None:
+            return value
+    return None
+
+
+def topic_haystack(record: dict[str, Any]) -> str:
+    values = [
+        field(record, "Signal Title", "Title", "Name", "signal_title", "title"),
+        field(record, "Summary", "Public Summary", "summary"),
+        field(record, "Why This Matters", "why_this_matters"),
+        field(record, "Risk Notes", "Safety Notes", "risk_notes"),
+        field(record, "Watch Next", "watch_next"),
+        field(record, "Category", "Categories", "Tag", "Tags", "tags"),
+        field(record, "Source Label", "Source Name", "Source", "source_label", "source_name"),
+        field(record, "AGI Relevance", "agi_relevance"),
+    ]
+    flattened: list[str] = []
+    for value in values:
+        if isinstance(value, list):
+            flattened.extend(normalize_text(item) for item in value)
+        else:
+            flattened.append(normalize_text(value))
+    return " ".join(flattened).lower()
+
+
+def matched_terms(haystack: str, terms: tuple[str, ...]) -> list[str]:
+    return [term for term in terms if term in haystack]
+
+
+def core_topic_matches(haystack: str) -> list[str]:
+    matches = matched_terms(haystack, CORE_PUBLIC_TOPIC_TERMS)
+    if "agent" in haystack and any(term in haystack for term in AGENT_CONTEXT_TERMS):
+        matches.append("agent_context")
+    if any(term in haystack for term in MULTI_AGENT_TERMS) and any(term in haystack for term in MULTI_AGENT_CONTEXT_TERMS):
+        matches.append("multi_agent_context")
+    if any(term in haystack for term in AUTONOMY_TERMS) and any(term in haystack for term in AUTONOMY_CONTEXT_TERMS):
+        matches.append("autonomy_context")
+    if any(term in haystack for term in VLA_TERMS) and any(term in haystack for term in VLA_CONTEXT_TERMS):
+        matches.append("vla_context")
+    return sorted(set(matches))
+
+
+def domain_risk_matches(haystack: str) -> dict[str, list[str]]:
+    return {
+        group: matched
+        for group, terms in DOMAIN_RISK_GROUPS.items()
+        if (matched := matched_terms(haystack, terms))
+    }
+
+
+def public_topic_decision(record: dict[str, Any]) -> dict[str, Any]:
+    haystack = topic_haystack(record)
+    core_matches = core_topic_matches(haystack)
+    risk_matches = domain_risk_matches(haystack)
+    clear_framing = matched_terms(haystack, DOMAIN_RISK_CLEAR_FRAMING_TERMS)
+    has_core = bool(core_matches)
+    has_domain_risk = bool(risk_matches)
+    allowed_domain_risk = has_domain_risk and has_core and bool(clear_framing)
+    off_topic = has_domain_risk and not allowed_domain_risk
+    reasons: list[str] = []
+    if off_topic:
+        reasons.append("off_topic_public_signal")
+    if not has_core:
+        reasons.append("missing_core_public_topic")
+    return {
+        "has_core_public_topic": has_core,
+        "domain_risk_detected": has_domain_risk,
+        "allowed_domain_risk": allowed_domain_risk,
+        "off_topic_public_signal": off_topic,
+        "matched_core_topics": core_matches,
+        "matched_domain_risks": risk_matches,
+        "matched_domain_risk_framing": sorted(set(clear_framing)),
+        "reasons": reasons,
+    }
+
+
+def off_topic_public_signal(record: dict[str, Any]) -> bool:
+    return bool(public_topic_decision(record)["off_topic_public_signal"])
+
+
+def has_core_public_topic(record: dict[str, Any]) -> bool:
+    return bool(public_topic_decision(record)["has_core_public_topic"])

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -203,6 +203,22 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertEqual(feed["feed_url"], "https://media.energizeos.com/feed.json")
         self.assertLessEqual(len(feed["items"]), 30)
 
+    def test_generates_public_artifact_manifest_for_every_public_artifact(self):
+        sync.sync_records([eligible_record()], self.root, refreshed_at="2026-06-27T00:00:00Z")
+
+        artifact_manifest = json.loads((self.root / "signals" / "public_artifact_manifest.json").read_text(encoding="utf-8"))
+        artifact_paths = {item["path"] for item in artifact_manifest["artifacts"]}
+
+        self.assertEqual(artifact_manifest["contract_version"], "dysonx_public_signal_contract_v1")
+        self.assertIn("signals/public_artifact_manifest.json", artifact_paths)
+        self.assertIn("robots.txt", artifact_paths)
+        self.assertIn("sitemap.xml", artifact_paths)
+        self.assertIn("rss.xml", artifact_paths)
+        self.assertIn("feed.json", artifact_paths)
+        signal_artifact = next(item for item in artifact_manifest["artifacts"] if item["path"] == "signals/notion-agent-reliability/index.html")
+        self.assertEqual(signal_artifact["artifact_class"], "signal_html")
+        self.assertEqual(signal_artifact["allowed_embeds"], ["json_ld_article"])
+
     def test_sitemap_excludes_blocked_signals(self):
         sync.sync_records(
             [
@@ -429,9 +445,11 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         polluted = [
             ("child-online-safety", "Child online safety policy update", "Policy"),
             ("medical-object-segmentation", "Medical object segmentation benchmark", "Medical Imaging"),
+            ("surgical-laparoscopic", "Surgical laparoscopic clinical model", "Clinical"),
             ("drug-drug-interaction", "Drug-drug interaction prediction model", "Biomedical"),
             ("prostate-cancer-ultrasound", "Prostate cancer ultrasound detection model", "Clinical"),
             ("legal-deliberation", "Generic law deliberation with multi-agent debate", "Law"),
+            ("agricultural-dairy", "Agricultural dairy methane forecasting model", "Agriculture"),
         ]
         records = [
             eligible_record(
@@ -463,6 +481,7 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
             ("openlife", "OpenLife autonomous LLM agents", "OpenLife studies autonomous LLM agents and agent coordination."),
             ("ai-governance", "AI regulation for frontier model governance", "AI governance and AI regulation for frontier model safety."),
             ("vla-robotics", "VLA robotics foundation model framework", "A vision-language-action robotics foundation model for embodied AI agent capability."),
+            ("uav-agents", "UAV multi-agent planning benchmark", "A multi-agent planning benchmark for autonomous AI agent capability evaluation."),
         ]
         records = [
             eligible_record(
@@ -510,6 +529,28 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.assertNotIn("generic-indoor-robotics", launched_slugs)
         self.assertEqual(manifest["pages_blocked"], 1)
 
+    def test_domain_risk_can_pass_with_explicit_ai_safety_evaluation_framing(self):
+        manifest = sync.sync_records(
+            [
+                eligible_record(
+                    **{
+                        "Signal ID": "sig_medical_eval",
+                        "Signal Title": "Medical AI agent safety evaluation benchmark",
+                        "Slug": "medical-ai-agent-safety-evaluation",
+                        "Summary": "A summary-only Signal about AI safety evaluation for agent behavior in a domain-risk setting.",
+                        "Category": "AI Safety",
+                        "Source Priority": "High",
+                        "AGI Relevance": "Medium",
+                        "Quality Hint": 84,
+                    }
+                )
+            ],
+            self.root,
+        )
+
+        launched_slugs = {item["slug"] for item in manifest["launched"]}
+        self.assertIn("medical-ai-agent-safety-evaluation", launched_slugs)
+
     def test_missing_core_public_topic_is_reported(self):
         report_path = self.root / "tmp" / "dysonx_public_signals_sync_report.json"
         sync.sync_records(
@@ -519,6 +560,8 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
                         "Signal Title": "Distributed systems scheduling update",
                         "Slug": "distributed-systems-scheduling",
                         "Summary": "A summary-only Signal about distributed systems scheduling.",
+                        "Why This Matters": "Scheduling metrics affect distributed infrastructure operations.",
+                        "Watch Next": "Watch whether scheduling behavior changes in future releases.",
                         "Category": "Infrastructure",
                         "Source Priority": "High",
                         "AGI Relevance": "Medium",

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -9,6 +9,11 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 import dysonx_public_signals_auto_merge_gate as gate  # noqa: E402
+from dysonx_public_signals_contract import (  # noqa: E402
+    PUBLIC_SIGNAL_CONTRACT_VERSION,
+    PUBLIC_SIGNAL_POLICY_VERSION,
+    build_artifact_entry,
+)
 
 
 def forbidden_domain() -> str:
@@ -24,16 +29,50 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
         (self.signals / self.slug).mkdir(parents=True)
         (self.root / "index.html").write_text('<a href="/signals/">Signals</a>', encoding="utf-8")
         (self.signals / "index.html").write_text(
-            f'<h1>Signals</h1><a href="/signals/{self.slug}/">Signal</a>',
+            f'<h1>Signals</h1><a href="/signals/{self.slug}/">Signal</a><script type="application/ld+json">{{"@context":"https://schema.org","@type":"Organization","name":"EnergizeOS Media","url":"https://media.energizeos.com"}}</script>',
             encoding="utf-8",
         )
         (self.signals / self.slug / "index.html").write_text(
-            '<h1>Critical AI Agent Evaluation Signal</h1><p>Summary-only public Signal about AI agent evaluation.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a>',
+            '<h1>Critical AI Agent Evaluation Signal</h1><p>Summary-only public Signal about AI agent evaluation.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a><script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Critical AI Agent Evaluation Signal","description":"Summary-only public Signal about AI agent evaluation.","url":"https://media.energizeos.com/signals/critical-agent-signal/"}</script>',
+            encoding="utf-8",
+        )
+        (self.root / "robots.txt").write_text("User-agent: *\nAllow: /\nSitemap: https://media.energizeos.com/sitemap.xml\n", encoding="utf-8")
+        (self.root / "sitemap.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url>\n    <loc>https://media.energizeos.com/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n  <url>\n    <loc>https://media.energizeos.com/signals/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n  <url>\n    <loc>https://media.energizeos.com/signals/critical-agent-signal/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n</urlset>\n',
+            encoding="utf-8",
+        )
+        (self.root / "rss.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"><channel><title>DysonX Public Signals</title><link>https://media.energizeos.com/signals/</link><description>Source-attributed public Signals tracking AI and AGI intelligence.</description><item><title>Critical AI Agent Evaluation Signal</title><link>https://media.energizeos.com/signals/critical-agent-signal/</link><guid>https://media.energizeos.com/signals/critical-agent-signal/</guid><description>Summary-only public Signal about AI agent evaluation.</description><source url="https://example.org/source">Example Source</source><pubDate>2026-06-27T00:00:00Z</pubDate></item></channel></rss>\n',
+            encoding="utf-8",
+        )
+        (self.root / "feed.json").write_text(
+            json.dumps(
+                {
+                    "version": "https://jsonfeed.org/version/1.1",
+                    "title": "DysonX Public Signals",
+                    "home_page_url": "https://media.energizeos.com/signals/",
+                    "feed_url": "https://media.energizeos.com/feed.json",
+                    "items": [
+                        {
+                            "id": "https://media.energizeos.com/signals/critical-agent-signal/",
+                            "url": "https://media.energizeos.com/signals/critical-agent-signal/",
+                            "title": "Critical AI Agent Evaluation Signal",
+                            "content_text": "Summary-only public Signal about AI agent evaluation.",
+                            "summary": "Summary-only public Signal about AI agent evaluation.",
+                            "external_url": "https://example.org/source",
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
             encoding="utf-8",
         )
         self.manifest_path = self.signals / "public_launch_manifest.json"
+        self.artifact_manifest_path = self.signals / "public_artifact_manifest.json"
         self.changed_files_path = self.root / "changed_files.json"
         self.write_manifest()
+        self.write_artifact_manifest()
         self.write_changed_files([f"signals/{self.slug}/index.html", "signals/index.html", "signals/public_launch_manifest.json"])
 
     def tearDown(self):
@@ -71,6 +110,30 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
 
     def write_manifest(self, **entry_overrides):
         self.manifest_path.write_text(json.dumps(self.manifest(**entry_overrides), indent=2), encoding="utf-8")
+        self.write_artifact_manifest()
+
+    def artifact_manifest(self, paths=None):
+        paths = paths or [
+            "feed.json",
+            "robots.txt",
+            "rss.xml",
+            "sitemap.xml",
+            "signals/index.html",
+            "signals/public_launch_manifest.json",
+            "signals/public_artifact_manifest.json",
+            f"signals/{self.slug}/index.html",
+        ]
+        return {
+            "contract_version": PUBLIC_SIGNAL_CONTRACT_VERSION,
+            "policy_version": PUBLIC_SIGNAL_POLICY_VERSION,
+            "generated_from_public_signal_manifest": True,
+            "public_launch_manifest_path": "signals/public_launch_manifest.json",
+            "public_launch_manifest_material_signature": "test-material",
+            "artifacts": [build_artifact_entry(path, "test-material") for path in paths],
+        }
+
+    def write_artifact_manifest(self, paths=None, data=None):
+        self.artifact_manifest_path.write_text(json.dumps(data or self.artifact_manifest(paths), indent=2), encoding="utf-8")
 
     def write_changed_files(self, files):
         self.changed_files_path.write_text(json.dumps(files), encoding="utf-8")
@@ -224,8 +287,34 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
         )
         self.assertEqual(self.run_gate(), 0)
 
-    def test_fails_when_script_tag_appears(self):
+    def test_techarticle_json_ld_passes_on_signal_page(self):
+        self.assertEqual(self.run_gate(), 0)
+
+    def test_organization_json_ld_passes_on_signals_index(self):
+        self.write_changed_files(["signals/index.html"])
+        self.assertEqual(self.run_gate(), 0)
+
+    def test_fails_when_normal_inline_script_tag_appears(self):
         (self.signals / self.slug / "index.html").write_text("<script>alert(1)</script>", encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_external_script_src_appears(self):
+        (self.signals / self.slug / "index.html").write_text('<script src="https://example.org/app.js"></script>', encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_malformed_json_ld_appears(self):
+        (self.signals / self.slug / "index.html").write_text('<script type="application/ld+json">{"@type":</script>', encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_json_ld_contains_raw_body_marker(self):
+        (self.signals / self.slug / "index.html").write_text(
+            '<script type="application/ld+json">{"@type":"TechArticle","description":"full article text"}</script>',
+            encoding="utf-8",
+        )
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_fails_when_event_handler_attribute_appears(self):
+        (self.signals / self.slug / "index.html").write_text('<a href="/" onclick="alert(1)">Home</a>', encoding="utf-8")
         self.assertNotEqual(self.run_gate(), 0)
 
     def test_fails_when_forbidden_terms_appear(self):
@@ -267,12 +356,49 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
             "sitemap.xml",
             "signals/index.html",
             "signals/public_launch_manifest.json",
+            "signals/public_artifact_manifest.json",
             f"signals/{self.slug}/index.html",
         ]
         for path in allowed:
             with self.subTest(path=path):
                 self.write_changed_files([path])
                 self.assertEqual(self.run_gate(), 0)
+
+    def test_artifact_manifest_must_declare_every_changed_file(self):
+        self.write_artifact_manifest(paths=["signals/index.html", "signals/public_launch_manifest.json", "signals/public_artifact_manifest.json"])
+        self.write_changed_files([f"signals/{self.slug}/index.html"])
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_artifact_manifest_unknown_class_fails(self):
+        data = self.artifact_manifest()
+        data["artifacts"][0]["artifact_class"] = "unknown_public_artifact"
+        self.write_artifact_manifest(data=data)
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_artifact_manifest_class_path_mismatch_fails(self):
+        data = self.artifact_manifest()
+        data["artifacts"][0]["path"] = "signals/index.html"
+        data["artifacts"][0]["artifact_class"] = "rss_xml"
+        self.write_artifact_manifest(data=data)
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_sitemap_with_blocked_signal_url_fails(self):
+        self.write_changed_files(["sitemap.xml"])
+        (self.root / "sitemap.xml").write_text(
+            '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://media.energizeos.com/signals/blocked-medical-signal/</loc><lastmod>2026-06-27</lastmod></url></urlset>',
+            encoding="utf-8",
+        )
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_rss_raw_body_leakage_fails(self):
+        self.write_changed_files(["rss.xml"])
+        (self.root / "rss.xml").write_text("full article text", encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_json_feed_raw_body_leakage_fails(self):
+        self.write_changed_files(["feed.json"])
+        (self.root / "feed.json").write_text(json.dumps({"items": [{"url": "https://media.energizeos.com/signals/critical-agent-signal/", "content_text": "raw source body"}]}), encoding="utf-8")
+        self.assertNotEqual(self.run_gate(), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds a formal DysonX Public Signal contract with allowed artifact classes, safe JSON-LD embeds, forbidden content classes, and path/class rules.
- Emits signals/public_artifact_manifest.json so every generated public artifact is declared, including Signal pages, signals/index.html, public_launch_manifest, robots.txt, sitemap.xml, rss.xml, and feed.json.
- Refactors the trusted auto-merge gate into layered validation: path gate, artifact manifest gate, artifact-specific structure checks, JSON-LD validation, content safety checks, and shared topic-policy validation.
- Shares explicit domain-risk/topic decision helpers between the generator and gate so medical/legal/agriculture/generic robotics risks are blocked unless clearly framed as DysonX AI/agent/safety/evaluation/governance topics.
- Updates the trusted sync workflow and legacy fallback workflow so root SEO artifacts participate in diff detection, diagnostics, gate input, and commits.

## Automation contract
- Fully automatic clean path is preserved: Notion Signal Intake -> eligibility/topic filter -> public static output -> SEO outputs -> trusted gate -> audit PR -> same-run squash merge.
- Clean content can auto-merge from the trusted DysonX Notion Public Signals Sync workflow without depending on bot-created pull_request checks.
- Unsafe, undeclared, off-topic, copyright-risk, raw-body, or script-injected output fails the trusted gate and remains open for audit.

## Safety and SEO
- Public output still requires High/Critical source priority, Medium/High/Critical AGI relevance, Quality Hint >= 80, complete attribution, Safe Summary Only copyright status, valid http(s) source URL, title, summary, and topic safety.
- Published and Ready for Pipeline remain ranking signals, not hard gates.
- SEO outputs remain enabled: robots.txt, sitemap.xml, rss.xml, feed.json, canonical URLs, Open Graph/Twitter metadata, TechArticle/Article JSON-LD, and Organization JSON-LD.
- Safe JSON-LD is allowed only as application/ld+json with valid JSON and allowed schema types; normal inline scripts, external scripts, event-handler attributes, malformed JSON-LD, raw-body markers, and temporary/deployment domains fail.
- No-op reruns remain idempotent because material signatures and stable timestamps continue to drive manifest, page, sitemap, RSS, and JSON feed output. Content can still update automatically when material summary/metadata, ranking, counts, or eligible slugs change.

## Validation
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests (493 tests)
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check

## Notes
- PR #108 was already closed before this PR was opened; this PR supersedes that pre-contract generated content path.
- No OpenAI call.
- No scraping.
- No raw/source body copying.
- No production deployment.
- No manual approval added for clean content.
- No Published/Ready hard gate reintroduced.
- No Critical-only rollback.
- No temporary domains introduced.