### PR TITLE
fix: derive Public Signals SEO domain from CNAME

### DIFF
--- a/scripts/dysonx_notion_public_signals_sync.py
+++ b/scripts/dysonx_notion_public_signals_sync.py
@@ -22,10 +22,10 @@ from dysonx_public_signals_contract import (
     ALLOWED_ARTIFACT_CLASSES,
     ALLOWED_SAFE_EMBEDS,
     FORBIDDEN_CONTENT_CLASSES,
-    PUBLIC_SEO_BASE_URL,
     PUBLIC_SIGNAL_CONTRACT_VERSION,
     PUBLIC_SIGNAL_POLICY_VERSION,
     build_artifact_entry,
+    public_seo_base_url,
 )
 from dysonx_public_signals_topic_policy import (
     has_core_public_topic as topic_has_core_public_topic,
@@ -512,8 +512,8 @@ def public_signal_sort_key(record: dict[str, Any]) -> tuple[int, int, float, int
     return (priority, relevance, -quality, published_rank, ready_rank, -timestamp_rank(record.get("timestamp")), str(record.get("title") or "").lower())
 
 
-def public_absolute_url(path: str) -> str:
-    return urljoin(f"{PUBLIC_SEO_BASE_URL}/", path.lstrip("/"))
+def public_absolute_url(path: str, seo_base_url: str) -> str:
+    return urljoin(f"{seo_base_url}/", path.lstrip("/"))
 
 
 def seo_description(record: dict[str, Any]) -> str:
@@ -558,10 +558,10 @@ def render_layout(title: str, body: str, head_extra: str = "") -> str:
 """
 
 
-def signal_seo_head(record: dict[str, Any], refreshed_at: str) -> str:
+def signal_seo_head(record: dict[str, Any], refreshed_at: str, seo_base_url: str) -> str:
     title = f"{normalize_text(record['title'])} | DysonX Public Signal"
     description = seo_description(record)
-    canonical = public_absolute_url(f"/signals/{record['slug']}/")
+    canonical = public_absolute_url(f"/signals/{record['slug']}/", seo_base_url)
     json_ld = {
         "@context": "https://schema.org",
         "@type": "TechArticle",
@@ -573,7 +573,7 @@ def signal_seo_head(record: dict[str, Any], refreshed_at: str) -> str:
         "publisher": {
             "@type": "Organization",
             "name": "EnergizeOS Media",
-            "url": PUBLIC_SEO_BASE_URL,
+            "url": seo_base_url,
         },
         "mainEntityOfPage": canonical,
     }
@@ -592,7 +592,7 @@ def signal_seo_head(record: dict[str, Any], refreshed_at: str) -> str:
   {json_ld_script(json_ld)}"""
 
 
-def render_signal_page(record: dict[str, Any], refreshed_at: str) -> str:
+def render_signal_page(record: dict[str, Any], refreshed_at: str, seo_base_url: str) -> str:
     source_html = PUBLIC_SAFE_SOURCE_NOTE
     if record.get("source_url") and is_safe_source_url(str(record["source_url"])):
         source_html = f'<a href="{escape(record["source_url"], quote=True)}" rel="nofollow noopener">{escape(record["source_label"])}</a>'
@@ -621,22 +621,22 @@ def render_signal_page(record: dict[str, Any], refreshed_at: str) -> str:
 <p><a href="/">Home</a> · <a href="/signals/">Back to Public Signals</a></p>
 <p class="muted">Content refreshed at {escape(refreshed_at)}. OpenAI was not called. Source pages were not scraped.</p>
 """
-    return render_layout(record["title"], body, signal_seo_head(record, refreshed_at))
+    return render_layout(record["title"], body, signal_seo_head(record, refreshed_at, seo_base_url))
 
 
-def organization_json_ld() -> str:
+def organization_json_ld(seo_base_url: str) -> str:
     return json_ld_script(
         {
             "@context": "https://schema.org",
             "@type": "Organization",
             "name": "EnergizeOS Media",
-            "url": PUBLIC_SEO_BASE_URL,
-            "publishingPrinciples": public_absolute_url("/signals/"),
+            "url": seo_base_url,
+            "publishingPrinciples": public_absolute_url("/signals/", seo_base_url),
         }
     )
 
 
-def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at: str) -> str:
+def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at: str, seo_base_url: str) -> str:
     items = []
     for record in records:
         tag_html = "".join(f'<span class="tag">{escape(tag)}</span>' for tag in record.get("tags", []))
@@ -658,17 +658,17 @@ def render_index(records: list[dict[str, Any]], blocked_count: int, refreshed_at
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>DysonX Public Signals</title>
   <meta name="description" content="DysonX Public Signals track source-attributed AI and AGI intelligence from the Notion-managed content layer.">
-  <link rel="canonical" href="{escape(public_absolute_url('/signals/'), quote=True)}">
-  <link rel="alternate" type="application/rss+xml" title="DysonX Public Signals RSS" href="{escape(public_absolute_url('/rss.xml'), quote=True)}">
-  <link rel="alternate" type="application/feed+json" title="DysonX Public Signals JSON Feed" href="{escape(public_absolute_url('/feed.json'), quote=True)}">
+  <link rel="canonical" href="{escape(public_absolute_url('/signals/', seo_base_url), quote=True)}">
+  <link rel="alternate" type="application/rss+xml" title="DysonX Public Signals RSS" href="{escape(public_absolute_url('/rss.xml', seo_base_url), quote=True)}">
+  <link rel="alternate" type="application/feed+json" title="DysonX Public Signals JSON Feed" href="{escape(public_absolute_url('/feed.json', seo_base_url), quote=True)}">
   <meta property="og:title" content="DysonX Public Signals">
   <meta property="og:description" content="Source-attributed public Signals tracking AI and AGI intelligence.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="{escape(public_absolute_url('/signals/'), quote=True)}">
+  <meta property="og:url" content="{escape(public_absolute_url('/signals/', seo_base_url), quote=True)}">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="DysonX Public Signals">
   <meta name="twitter:description" content="Source-attributed public Signals tracking AI and AGI intelligence.">
-  {organization_json_ld()}
+  {organization_json_ld(seo_base_url)}
   <style>
     body {{ margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #17202a; line-height: 1.55; }}
     main {{ max-width: 1040px; margin: 0 auto; padding: 28px 20px 56px; }}
@@ -815,19 +815,19 @@ def stable_lastmod(refreshed_at: str) -> str:
     return text[:10] if len(text) >= 10 else text
 
 
-def render_robots() -> str:
+def render_robots(seo_base_url: str) -> str:
     return f"""User-agent: *
 Allow: /
-Sitemap: {PUBLIC_SEO_BASE_URL}/sitemap.xml
+Sitemap: {seo_base_url}/sitemap.xml
 """
 
 
-def render_sitemap(records: list[dict[str, Any]], refreshed_at: str) -> str:
+def render_sitemap(records: list[dict[str, Any]], refreshed_at: str, seo_base_url: str) -> str:
     lastmod = stable_lastmod(refreshed_at)
     urls = ["/", "/signals/", *[f"/signals/{record['slug']}/" for record in records]]
     items = "\n".join(
         f"""  <url>
-    <loc>{escape(public_absolute_url(path))}</loc>
+    <loc>{escape(public_absolute_url(path, seo_base_url))}</loc>
     <lastmod>{escape(lastmod)}</lastmod>
   </url>"""
         for path in urls
@@ -839,10 +839,10 @@ def render_sitemap(records: list[dict[str, Any]], refreshed_at: str) -> str:
 """
 
 
-def render_rss(records: list[dict[str, Any]], refreshed_at: str) -> str:
+def render_rss(records: list[dict[str, Any]], refreshed_at: str, seo_base_url: str) -> str:
     items = []
     for record in records[:DEFAULT_MAX_PUBLIC_SIGNALS]:
-        public_url = public_absolute_url(f"/signals/{record['slug']}/")
+        public_url = public_absolute_url(f"/signals/{record['slug']}/", seo_base_url)
         source = record.get("source_url") or public_url
         items.append(
             f"""    <item>
@@ -858,7 +858,7 @@ def render_rss(records: list[dict[str, Any]], refreshed_at: str) -> str:
 <rss version="2.0">
   <channel>
     <title>DysonX Public Signals</title>
-    <link>{PUBLIC_SEO_BASE_URL}/signals/</link>
+    <link>{seo_base_url}/signals/</link>
     <description>Source-attributed public Signals tracking AI and AGI intelligence.</description>
 {chr(10).join(items)}
   </channel>
@@ -866,17 +866,17 @@ def render_rss(records: list[dict[str, Any]], refreshed_at: str) -> str:
 """
 
 
-def render_json_feed(records: list[dict[str, Any]], refreshed_at: str) -> str:
+def render_json_feed(records: list[dict[str, Any]], refreshed_at: str, seo_base_url: str) -> str:
     feed = {
         "version": "https://jsonfeed.org/version/1.1",
         "title": "DysonX Public Signals",
-        "home_page_url": public_absolute_url("/signals/"),
-        "feed_url": public_absolute_url("/feed.json"),
+        "home_page_url": public_absolute_url("/signals/", seo_base_url),
+        "feed_url": public_absolute_url("/feed.json", seo_base_url),
         "description": "Source-attributed public Signals tracking AI and AGI intelligence.",
         "items": [
             {
-                "id": public_absolute_url(f"/signals/{record['slug']}/"),
-                "url": public_absolute_url(f"/signals/{record['slug']}/"),
+                "id": public_absolute_url(f"/signals/{record['slug']}/", seo_base_url),
+                "url": public_absolute_url(f"/signals/{record['slug']}/", seo_base_url),
                 "title": normalize_text(record["title"]),
                 "summary": normalize_text(record.get("summary", "")),
                 "content_text": normalize_text(record.get("summary", "")),
@@ -926,6 +926,7 @@ def sync_records(
 ) -> dict[str, Any]:
     refreshed_at = refreshed_at or utc_now()
     output_root = output_root.resolve()
+    seo_base_url = public_seo_base_url(output_root)
     signals_root = output_root / "signals"
     signals_root.mkdir(parents=True, exist_ok=True)
 
@@ -954,13 +955,13 @@ def sync_records(
     for record in merged:
         if record.get("existing") and not any(item["slug"] == record["slug"] for item in eligible):
             continue
-        page_html = render_signal_page(record, refreshed_at)
+        page_html = render_signal_page(record, refreshed_at, seo_base_url)
         assert_public_safe(page_html, f"Signal page {record['slug']}")
         page_dir = signals_root / record["slug"]
         page_dir.mkdir(parents=True, exist_ok=True)
         (page_dir / "index.html").write_text(page_html, encoding="utf-8")
 
-    index_html = render_index(merged, blocked_count, refreshed_at)
+    index_html = render_index(merged, blocked_count, refreshed_at, seo_base_url)
     assert_public_safe(index_html, "Signals index")
     (signals_root / "index.html").write_text(index_html, encoding="utf-8")
 
@@ -973,10 +974,10 @@ def sync_records(
     assert_public_safe(artifact_manifest_text, "public artifact manifest")
     (signals_root / "public_artifact_manifest.json").write_text(artifact_manifest_text, encoding="utf-8")
     seo_outputs = {
-        "robots.txt": render_robots(),
-        "sitemap.xml": render_sitemap(merged, refreshed_at),
-        "rss.xml": render_rss(merged, refreshed_at),
-        "feed.json": render_json_feed(merged, refreshed_at),
+        "robots.txt": render_robots(seo_base_url),
+        "sitemap.xml": render_sitemap(merged, refreshed_at, seo_base_url),
+        "rss.xml": render_rss(merged, refreshed_at, seo_base_url),
+        "feed.json": render_json_feed(merged, refreshed_at, seo_base_url),
     }
     for relative_path, text in seo_outputs.items():
         assert_public_safe(text, relative_path)

--- a/scripts/dysonx_public_signals_auto_merge_gate.py
+++ b/scripts/dysonx_public_signals_auto_merge_gate.py
@@ -24,12 +24,12 @@ from dysonx_public_signals_contract import (
     ARTIFACT_SIGNAL_HTML,
     ARTIFACT_SIGNALS_INDEX_HTML,
     ARTIFACT_SITEMAP_XML,
-    PUBLIC_SEO_BASE_URL,
     PUBLIC_SIGNAL_CONTRACT_VERSION,
     artifact_class_for_path,
     allowed_embeds_for_artifact_class,
     is_allowed_public_artifact_path,
     normalize_public_path,
+    public_seo_base_url,
     signal_slug_from_public_path,
 )
 from dysonx_public_signals_topic_policy import (
@@ -179,7 +179,7 @@ def public_path_exists(root: pathlib.Path, href: str) -> bool:
     return (root / relative).exists()
 
 
-def validate_json_ld_script(script: dict[str, Any], artifact_class: str, label: str) -> None:
+def validate_json_ld_script(script: dict[str, Any], artifact_class: str, label: str, seo_base_url: str) -> None:
     attrs = script["attrs"]
     if attrs.get("src"):
         raise AutoMergeGateError(f"{label} contains external script src")
@@ -210,14 +210,14 @@ def validate_json_ld_script(script: dict[str, Any], artifact_class: str, label: 
         payload = json.dumps(node, sort_keys=True)
         if "javascript:" in payload.lower() or INLINE_EVENT_PATTERN.search(payload):
             raise AutoMergeGateError(f"{label} JSON-LD contains unsafe script-like text")
-        if PUBLIC_SEO_BASE_URL in payload:
+        if seo_base_url in payload:
             continue
         if any(str(value).startswith("http") for value in node.values() if isinstance(value, str)):
             # External source citations are allowed, but public page URLs must remain canonical.
             continue
 
 
-def check_html_file(path: pathlib.Path, root: pathlib.Path, artifact_class: str) -> None:
+def check_html_file(path: pathlib.Path, root: pathlib.Path, artifact_class: str, seo_base_url: str) -> None:
     if not path.exists():
         raise AutoMergeGateError(f"changed public HTML file is missing: {path}")
     text = path.read_text(encoding="utf-8", errors="ignore")
@@ -231,7 +231,7 @@ def check_html_file(path: pathlib.Path, root: pathlib.Path, artifact_class: str)
     if parser.inline_event_handlers:
         raise AutoMergeGateError(f"{path} contains inline event handler attribute")
     for script in parser.scripts:
-        validate_json_ld_script(script, artifact_class, str(path))
+        validate_json_ld_script(script, artifact_class, str(path), seo_base_url)
     for href in parser.hrefs:
         lowered = href.lower()
         if not href or href == "#":
@@ -254,21 +254,21 @@ def check_html_file(path: pathlib.Path, root: pathlib.Path, artifact_class: str)
         raise AutoMergeGateError(f"{path} contains non-relative unsupported href: {href}")
 
 
-def validate_robots(path: pathlib.Path) -> None:
+def validate_robots(path: pathlib.Path, seo_base_url: str) -> None:
     text = path.read_text(encoding="utf-8")
-    expected = f"User-agent: *\nAllow: /\nSitemap: {PUBLIC_SEO_BASE_URL}/sitemap.xml\n"
+    expected = f"User-agent: *\nAllow: /\nSitemap: {seo_base_url}/sitemap.xml\n"
     fail_if_forbidden_text(text, str(path))
     if text != expected:
         raise AutoMergeGateError("robots.txt must only allow crawling and point to the production sitemap")
 
 
-def validate_sitemap(path: pathlib.Path, launched_slugs: set[str]) -> None:
+def validate_sitemap(path: pathlib.Path, launched_slugs: set[str], seo_base_url: str) -> None:
     text = path.read_text(encoding="utf-8")
     fail_if_forbidden_text(text, str(path))
     root = ET.fromstring(text)
     namespace = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
-    allowed_urls = {f"{PUBLIC_SEO_BASE_URL}/", f"{PUBLIC_SEO_BASE_URL}/signals/"}
-    allowed_urls.update(f"{PUBLIC_SEO_BASE_URL}/signals/{slug}/" for slug in launched_slugs)
+    allowed_urls = {f"{seo_base_url}/", f"{seo_base_url}/signals/"}
+    allowed_urls.update(f"{seo_base_url}/signals/{slug}/" for slug in launched_slugs)
     found_urls: set[str] = set()
     for url_node in root.findall("sm:url", namespace):
         loc = (url_node.findtext("sm:loc", default="", namespaces=namespace) or "").strip()
@@ -278,12 +278,12 @@ def validate_sitemap(path: pathlib.Path, launched_slugs: set[str]) -> None:
         if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", lastmod):
             raise AutoMergeGateError(f"sitemap lastmod must be stable YYYY-MM-DD: {lastmod}")
         found_urls.add(loc)
-    required = {f"{PUBLIC_SEO_BASE_URL}/", f"{PUBLIC_SEO_BASE_URL}/signals/"}
+    required = {f"{seo_base_url}/", f"{seo_base_url}/signals/"}
     if not required.issubset(found_urls):
         raise AutoMergeGateError("sitemap must include homepage and /signals/")
 
 
-def validate_rss(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -> None:
+def validate_rss(path: pathlib.Path, entries: dict[str, dict[str, Any]], seo_base_url: str) -> None:
     text = path.read_text(encoding="utf-8")
     fail_if_forbidden_text(text, str(path))
     root = ET.fromstring(text)
@@ -295,7 +295,7 @@ def validate_rss(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -> None
         link = (item.findtext("link") or "").strip()
         description = (item.findtext("description") or "").strip()
         source = item.find("source")
-        if not link.startswith(f"{PUBLIC_SEO_BASE_URL}/signals/"):
+        if not link.startswith(f"{seo_base_url}/signals/"):
             raise AutoMergeGateError(f"rss.xml item link must be canonical public URL: {link}")
         if description not in summaries:
             raise AutoMergeGateError("rss.xml item description must match summary-only manifest content")
@@ -303,7 +303,7 @@ def validate_rss(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -> None
             raise AutoMergeGateError("rss.xml item source attribution URL is missing")
 
 
-def validate_json_feed(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -> None:
+def validate_json_feed(path: pathlib.Path, entries: dict[str, dict[str, Any]], seo_base_url: str) -> None:
     data = load_json_object(path, "feed.json")
     items = data.get("items")
     if not isinstance(items, list):
@@ -316,7 +316,7 @@ def validate_json_feed(path: pathlib.Path, entries: dict[str, dict[str, Any]]) -
             raise AutoMergeGateError("feed.json items must be objects")
         url = str(item.get("url") or "")
         content_text = str(item.get("content_text") or "")
-        if not url.startswith(f"{PUBLIC_SEO_BASE_URL}/signals/"):
+        if not url.startswith(f"{seo_base_url}/signals/"):
             raise AutoMergeGateError(f"feed.json item URL must be canonical public URL: {url}")
         if content_text not in summaries:
             raise AutoMergeGateError("feed.json content_text must match summary-only manifest content")
@@ -466,20 +466,20 @@ def validate_changed_files_declared(changed_files: list[str], artifact_entries: 
             raise AutoMergeGateError(f"changed public artifact is not declared: {changed_file}")
 
 
-def validate_public_artifact(path: str, root: pathlib.Path, artifact_class: str, entries: dict[str, dict[str, Any]]) -> None:
+def validate_public_artifact(path: str, root: pathlib.Path, artifact_class: str, entries: dict[str, dict[str, Any]], seo_base_url: str) -> None:
     full_path = root / path
     if not full_path.exists():
         raise AutoMergeGateError(f"changed public artifact is missing: {path}")
     if artifact_class in {ARTIFACT_SIGNAL_HTML, ARTIFACT_SIGNALS_INDEX_HTML}:
-        check_html_file(full_path, root, artifact_class)
+        check_html_file(full_path, root, artifact_class, seo_base_url)
     elif artifact_class == ARTIFACT_ROBOTS_TXT:
-        validate_robots(full_path)
+        validate_robots(full_path, seo_base_url)
     elif artifact_class == ARTIFACT_SITEMAP_XML:
-        validate_sitemap(full_path, set(entries))
+        validate_sitemap(full_path, set(entries), seo_base_url)
     elif artifact_class == ARTIFACT_RSS_XML:
-        validate_rss(full_path, entries)
+        validate_rss(full_path, entries, seo_base_url)
     elif artifact_class == ARTIFACT_JSON_FEED:
-        validate_json_feed(full_path, entries)
+        validate_json_feed(full_path, entries, seo_base_url)
     elif artifact_class == ARTIFACT_PUBLIC_LAUNCH_MANIFEST:
         manifest = load_json_object(full_path, path, scan_raw_body=False)
         validate_public_launch_manifest_raw_body_fields(manifest)
@@ -493,6 +493,7 @@ def validate_public_artifact(path: str, root: pathlib.Path, artifact_class: str,
 def run_gate(args: argparse.Namespace) -> None:
     manifest_path = pathlib.Path(args.manifest)
     root = manifest_path.parent.parent
+    seo_base_url = public_seo_base_url(root)
     manifest = load_json_object(manifest_path, str(manifest_path), scan_raw_body=False)
     validate_public_launch_manifest_raw_body_fields(manifest)
     check_manifest_flags(manifest)
@@ -536,7 +537,7 @@ def run_gate(args: argparse.Namespace) -> None:
         artifact = artifact_entries.get(relative_path)
         if not artifact:
             raise AutoMergeGateError(f"public artifact is not declared: {relative_path}")
-        validate_public_artifact(relative_path, root, str(artifact["artifact_class"]), entries)
+        validate_public_artifact(relative_path, root, str(artifact["artifact_class"]), entries, seo_base_url)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/scripts/dysonx_public_signals_contract.py
+++ b/scripts/dysonx_public_signals_contract.py
@@ -9,7 +9,7 @@ from typing import Any
 
 PUBLIC_SIGNAL_CONTRACT_VERSION = "dysonx_public_signal_contract_v1"
 PUBLIC_SIGNAL_POLICY_VERSION = "dysonx_public_signal_policy_v2"
-PUBLIC_SEO_BASE_URL = "https://media.energizeos.com"
+CNAME_FILE = "CNAME"
 
 ARTIFACT_SIGNAL_HTML = "signal_html"
 ARTIFACT_SIGNALS_INDEX_HTML = "signals_index_html"
@@ -63,6 +63,21 @@ SIGNALS_ARTIFACT_CLASSES = {
 
 def normalize_public_path(value: str | pathlib.PurePath) -> str:
     return str(value).strip().replace("\\", "/").lstrip("./")
+
+
+def public_domain_from_cname(root: pathlib.Path | str = ".") -> str:
+    cname_path = pathlib.Path(root) / CNAME_FILE
+    try:
+        domain = cname_path.read_text(encoding="utf-8").strip().splitlines()[0].strip()
+    except (OSError, IndexError):
+        domain = ""
+    if not domain or "://" in domain or "/" in domain or any(char.isspace() for char in domain):
+        raise ValueError(f"{CNAME_FILE} must contain a single public domain")
+    return domain
+
+
+def public_seo_base_url(root: pathlib.Path | str = ".") -> str:
+    return f"https://{public_domain_from_cname(root)}"
 
 
 def signal_slug_from_public_path(path: str | pathlib.PurePath) -> str | None:

--- a/scripts/dysonx_static_preview_check.py
+++ b/scripts/dysonx_static_preview_check.py
@@ -14,6 +14,7 @@ from urllib.parse import urlsplit
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 INDEX = ROOT / "index.html"
 ROBOTS = ROOT / "robots.txt"
+CNAME = ROOT / "CNAME"
 WORKFLOWS = ROOT / ".github" / "workflows"
 RAW_FIXTURE = ROOT / "tests" / "fixtures" / "raw_items_v1.json"
 PIPELINE_OUTPUT_DIR = ROOT / "tmp" / "dysonx_static_preview_check" / "v1_pipeline"
@@ -112,6 +113,16 @@ def fail(message: str) -> None:
 
 def read(path: pathlib.Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def public_seo_base_url() -> str:
+    try:
+        domain = CNAME.read_text(encoding="utf-8").strip().splitlines()[0].strip()
+    except (OSError, IndexError):
+        fail("CNAME must contain the public SEO domain")
+    if not domain or "://" in domain or "/" in domain or any(char.isspace() for char in domain):
+        fail("CNAME must contain a single public SEO domain")
+    return f"https://{domain}"
 
 
 def parse_index() -> tuple[str, IndexMetadataParser]:
@@ -232,7 +243,8 @@ def check_deleted_artifact_references(html: str) -> None:
     for artifact in REMOVED_PUBLIC_ARTIFACTS:
         if artifact.lower() in lower_html:
             fail(f"index.html references deleted artifact: {artifact}")
-    if "sitemap.xml" in lower_robots and "https://media.energizeos.com/sitemap.xml" not in lower_robots:
+    expected_sitemap = f"{public_seo_base_url()}/sitemap.xml".lower()
+    if "sitemap.xml" in lower_robots and expected_sitemap not in lower_robots:
         fail("robots.txt references an unexpected sitemap.xml")
 
 

--- a/tests/test_dysonx_identity_landing.py
+++ b/tests/test_dysonx_identity_landing.py
@@ -6,10 +6,15 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 README = ROOT / "README.md"
 INDEX = ROOT / "index.html"
 ROBOTS = ROOT / "robots.txt"
+CNAME = ROOT / "CNAME"
 
 
 def read_lower(path: pathlib.Path) -> str:
     return path.read_text(encoding="utf-8").lower()
+
+
+def public_seo_base_url() -> str:
+    return f"https://{CNAME.read_text(encoding='utf-8').strip().splitlines()[0].strip()}"
 
 
 class DysonXIdentityLandingTests(unittest.TestCase):
@@ -96,7 +101,7 @@ class DysonXIdentityLandingTests(unittest.TestCase):
     def test_robots_points_to_public_signals_sitemap(self):
         text = read_lower(ROBOTS)
 
-        self.assertIn("sitemap: https://media.energizeos.com/sitemap.xml", text)
+        self.assertIn(f"sitemap: {public_seo_base_url()}/sitemap.xml", text)
         self.assertNotIn("posts/", text)
 
 

--- a/tests/test_dysonx_legacy_independence.py
+++ b/tests/test_dysonx_legacy_independence.py
@@ -18,7 +18,6 @@ REMOVED_GENERATED_CONTENT_PATHS = (
     ROOT / "posts" / "page2.html",
     ROOT / "posts" / "page3.html",
     ROOT / "posts" / "page4.html",
-    ROOT / "sitemap.xml",
 )
 
 

--- a/tests/test_dysonx_notion_public_signals_sync.py
+++ b/tests/test_dysonx_notion_public_signals_sync.py
@@ -12,6 +12,10 @@ sys.path.insert(0, str(ROOT / "scripts"))
 import dysonx_notion_public_signals_sync as sync  # noqa: E402
 
 
+FIXTURE_DOMAIN = "example.com"
+FIXTURE_BASE_URL = f"https://{FIXTURE_DOMAIN}"
+
+
 def eligible_record(**overrides):
     record = {
         "Signal ID": "sig_notion_agent_eval",
@@ -41,6 +45,7 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.root = pathlib.Path(self.temp_dir.name)
         shutil.copytree(ROOT / "signals", self.root / "signals")
+        (self.root / "CNAME").write_text(f"{FIXTURE_DOMAIN}\n", encoding="utf-8")
 
     def tearDown(self):
         self.temp_dir.cleanup()
@@ -190,17 +195,17 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         rss = (self.root / "rss.xml").read_text(encoding="utf-8")
         feed = json.loads((self.root / "feed.json").read_text(encoding="utf-8"))
         launched_urls = {
-            f"https://media.energizeos.com{entry['public_url_path']}"
+            f"{FIXTURE_BASE_URL}{entry['public_url_path']}"
             for entry in manifest["launched"]
         }
 
-        self.assertEqual(robots, "User-agent: *\nAllow: /\nSitemap: https://media.energizeos.com/sitemap.xml\n")
-        self.assertIn("https://media.energizeos.com/", sitemap)
-        self.assertIn("https://media.energizeos.com/signals/", sitemap)
+        self.assertEqual(robots, f"User-agent: *\nAllow: /\nSitemap: {FIXTURE_BASE_URL}/sitemap.xml\n")
+        self.assertIn(f"{FIXTURE_BASE_URL}/", sitemap)
+        self.assertIn(f"{FIXTURE_BASE_URL}/signals/", sitemap)
         for url in launched_urls:
             self.assertIn(url, sitemap)
             self.assertIn(url, rss)
-        self.assertEqual(feed["feed_url"], "https://media.energizeos.com/feed.json")
+        self.assertEqual(feed["feed_url"], f"{FIXTURE_BASE_URL}/feed.json")
         self.assertLessEqual(len(feed["items"]), 30)
 
     def test_generates_public_artifact_manifest_for_every_public_artifact(self):
@@ -236,7 +241,7 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
         )
 
         sitemap = (self.root / "sitemap.xml").read_text(encoding="utf-8")
-        self.assertIn("https://media.energizeos.com/signals/notion-agent-reliability/", sitemap)
+        self.assertIn(f"{FIXTURE_BASE_URL}/signals/notion-agent-reliability/", sitemap)
         self.assertNotIn("blocked-biology-medicine", sitemap)
 
     def test_rss_and_json_feed_do_not_contain_raw_body_markers(self):
@@ -252,11 +257,11 @@ class DysonXNotionPublicSignalsSyncTests(unittest.TestCase):
 
         html = (self.root / "signals" / "notion-agent-reliability" / "index.html").read_text(encoding="utf-8")
         self.assertIn('<meta name="description"', html)
-        self.assertIn('<link rel="canonical" href="https://media.energizeos.com/signals/notion-agent-reliability/">', html)
+        self.assertIn(f'<link rel="canonical" href="{FIXTURE_BASE_URL}/signals/notion-agent-reliability/">', html)
         self.assertIn('property="og:title"', html)
         self.assertIn('property="og:description"', html)
         self.assertIn('property="og:type" content="article"', html)
-        self.assertIn('property="og:url" content="https://media.energizeos.com/signals/notion-agent-reliability/"', html)
+        self.assertIn(f'property="og:url" content="{FIXTURE_BASE_URL}/signals/notion-agent-reliability/"', html)
         self.assertIn('name="twitter:card"', html)
         self.assertIn('type="application/ld+json"', html)
         self.assertIn('"@type": "TechArticle"', html)

--- a/tests/test_dysonx_public_signals_auto_merge_gate.py
+++ b/tests/test_dysonx_public_signals_auto_merge_gate.py
@@ -16,6 +16,11 @@ from dysonx_public_signals_contract import (  # noqa: E402
 )
 
 
+FIXTURE_DOMAIN = "example.com"
+FIXTURE_BASE_URL = f"https://{FIXTURE_DOMAIN}"
+OLD_DOMAIN_BASE_URL = "https://old.example"
+
+
 def forbidden_domain() -> str:
     return "https://dysonx." + "ai"
 
@@ -26,23 +31,24 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
         self.root = pathlib.Path(self.temp_dir.name)
         self.signals = self.root / "signals"
         self.slug = "critical-agent-signal"
+        (self.root / "CNAME").write_text(f"{FIXTURE_DOMAIN}\n", encoding="utf-8")
         (self.signals / self.slug).mkdir(parents=True)
         (self.root / "index.html").write_text('<a href="/signals/">Signals</a>', encoding="utf-8")
         (self.signals / "index.html").write_text(
-            f'<h1>Signals</h1><a href="/signals/{self.slug}/">Signal</a><script type="application/ld+json">{{"@context":"https://schema.org","@type":"Organization","name":"EnergizeOS Media","url":"https://media.energizeos.com"}}</script>',
+            f'<h1>Signals</h1><a href="/signals/{self.slug}/">Signal</a><script type="application/ld+json">{{"@context":"https://schema.org","@type":"Organization","name":"EnergizeOS Media","url":"{FIXTURE_BASE_URL}"}}</script>',
             encoding="utf-8",
         )
         (self.signals / self.slug / "index.html").write_text(
-            '<h1>Critical AI Agent Evaluation Signal</h1><p>Summary-only public Signal about AI agent evaluation.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a><script type="application/ld+json">{"@context":"https://schema.org","@type":"TechArticle","headline":"Critical AI Agent Evaluation Signal","description":"Summary-only public Signal about AI agent evaluation.","url":"https://media.energizeos.com/signals/critical-agent-signal/"}</script>',
+            f'<h1>Critical AI Agent Evaluation Signal</h1><p>Summary-only public Signal about AI agent evaluation.</p><a href="/">Home</a> <a href="/signals/">Signals</a> <a href="https://example.org/source">Source</a><script type="application/ld+json">{{"@context":"https://schema.org","@type":"TechArticle","headline":"Critical AI Agent Evaluation Signal","description":"Summary-only public Signal about AI agent evaluation.","url":"{FIXTURE_BASE_URL}/signals/critical-agent-signal/"}}</script>',
             encoding="utf-8",
         )
-        (self.root / "robots.txt").write_text("User-agent: *\nAllow: /\nSitemap: https://media.energizeos.com/sitemap.xml\n", encoding="utf-8")
+        (self.root / "robots.txt").write_text(f"User-agent: *\nAllow: /\nSitemap: {FIXTURE_BASE_URL}/sitemap.xml\n", encoding="utf-8")
         (self.root / "sitemap.xml").write_text(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url>\n    <loc>https://media.energizeos.com/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n  <url>\n    <loc>https://media.energizeos.com/signals/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n  <url>\n    <loc>https://media.energizeos.com/signals/critical-agent-signal/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n</urlset>\n',
+            f'<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url>\n    <loc>{FIXTURE_BASE_URL}/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n  <url>\n    <loc>{FIXTURE_BASE_URL}/signals/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n  <url>\n    <loc>{FIXTURE_BASE_URL}/signals/critical-agent-signal/</loc>\n    <lastmod>2026-06-27</lastmod>\n  </url>\n</urlset>\n',
             encoding="utf-8",
         )
         (self.root / "rss.xml").write_text(
-            '<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"><channel><title>DysonX Public Signals</title><link>https://media.energizeos.com/signals/</link><description>Source-attributed public Signals tracking AI and AGI intelligence.</description><item><title>Critical AI Agent Evaluation Signal</title><link>https://media.energizeos.com/signals/critical-agent-signal/</link><guid>https://media.energizeos.com/signals/critical-agent-signal/</guid><description>Summary-only public Signal about AI agent evaluation.</description><source url="https://example.org/source">Example Source</source><pubDate>2026-06-27T00:00:00Z</pubDate></item></channel></rss>\n',
+            f'<?xml version="1.0" encoding="UTF-8"?>\n<rss version="2.0"><channel><title>DysonX Public Signals</title><link>{FIXTURE_BASE_URL}/signals/</link><description>Source-attributed public Signals tracking AI and AGI intelligence.</description><item><title>Critical AI Agent Evaluation Signal</title><link>{FIXTURE_BASE_URL}/signals/critical-agent-signal/</link><guid>{FIXTURE_BASE_URL}/signals/critical-agent-signal/</guid><description>Summary-only public Signal about AI agent evaluation.</description><source url="https://example.org/source">Example Source</source><pubDate>2026-06-27T00:00:00Z</pubDate></item></channel></rss>\n',
             encoding="utf-8",
         )
         (self.root / "feed.json").write_text(
@@ -50,12 +56,12 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
                 {
                     "version": "https://jsonfeed.org/version/1.1",
                     "title": "DysonX Public Signals",
-                    "home_page_url": "https://media.energizeos.com/signals/",
-                    "feed_url": "https://media.energizeos.com/feed.json",
+                    "home_page_url": f"{FIXTURE_BASE_URL}/signals/",
+                    "feed_url": f"{FIXTURE_BASE_URL}/feed.json",
                     "items": [
                         {
-                            "id": "https://media.energizeos.com/signals/critical-agent-signal/",
-                            "url": "https://media.energizeos.com/signals/critical-agent-signal/",
+                            "id": f"{FIXTURE_BASE_URL}/signals/critical-agent-signal/",
+                            "url": f"{FIXTURE_BASE_URL}/signals/critical-agent-signal/",
                             "title": "Critical AI Agent Evaluation Signal",
                             "content_text": "Summary-only public Signal about AI agent evaluation.",
                             "summary": "Summary-only public Signal about AI agent evaluation.",
@@ -438,7 +444,15 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
     def test_sitemap_with_blocked_signal_url_fails(self):
         self.write_changed_files(["sitemap.xml"])
         (self.root / "sitemap.xml").write_text(
-            '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://media.energizeos.com/signals/blocked-medical-signal/</loc><lastmod>2026-06-27</lastmod></url></urlset>',
+            f'<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>{FIXTURE_BASE_URL}/signals/blocked-medical-signal/</loc><lastmod>2026-06-27</lastmod></url></urlset>',
+            encoding="utf-8",
+        )
+        self.assertNotEqual(self.run_gate(), 0)
+
+    def test_gate_rejects_old_absolute_domain_when_cname_is_different(self):
+        self.write_changed_files(["sitemap.xml"])
+        (self.root / "sitemap.xml").write_text(
+            f'<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>{OLD_DOMAIN_BASE_URL}/</loc><lastmod>2026-06-27</lastmod></url><url><loc>{OLD_DOMAIN_BASE_URL}/signals/</loc><lastmod>2026-06-27</lastmod></url><url><loc>{OLD_DOMAIN_BASE_URL}/signals/critical-agent-signal/</loc><lastmod>2026-06-27</lastmod></url></urlset>',
             encoding="utf-8",
         )
         self.assertNotEqual(self.run_gate(), 0)
@@ -450,7 +464,7 @@ class DysonXPublicSignalsAutoMergeGateTests(unittest.TestCase):
 
     def test_json_feed_raw_body_leakage_fails(self):
         self.write_changed_files(["feed.json"])
-        (self.root / "feed.json").write_text(json.dumps({"items": [{"url": "https://media.energizeos.com/signals/critical-agent-signal/", "content_text": "raw source body"}]}), encoding="utf-8")
+        (self.root / "feed.json").write_text(json.dumps({"items": [{"url": f"{FIXTURE_BASE_URL}/signals/critical-agent-signal/", "content_text": "raw source body"}]}), encoding="utf-8")
         self.assertNotEqual(self.run_gate(), 0)
 
 


### PR DESCRIPTION
## Summary
- Moves Public Signals SEO base URL derivation to the repository CNAME file.
- Updates generated robots, sitemap, RSS, JSON feed, canonical URLs, Open Graph URLs, and JSON-LD public URLs to use https://<CNAME>.
- Updates the contract-aware auto-merge gate to validate canonical public URLs against the checked-out CNAME domain.
- Updates the static preview check to validate robots.txt against the CNAME-derived sitemap URL.
- Removes hardcoded production SEO domain usage from scripts and tests; tests use temporary fixture CNAME values.

## Safety
- Auto-publish eligibility unchanged.
- Topic policy unchanged.
- Copyright, raw-body, script, JSON-LD, artifact contract, and SEO output gates remain in place.
- No SEO outputs removed and no timestamp-only churn introduced.
- No deployment performed.

## Validation
- python3 scripts/constitution_guard.py
- python3 scripts/architecture_guard.py
- python3 scripts/release_guard.py
- python3 -m py_compile scripts/*.py
- python3 -m unittest discover -s tests (501 tests)
- python3 scripts/dysonx_static_preview_check.py --root .
- git diff --check